### PR TITLE
Adding permanent add site button to each folder

### DIFF
--- a/src/Web/wwwroot/app/vault/views/vault.html
+++ b/src/Web/wwwroot/app/vault/views/vault.html
@@ -12,7 +12,7 @@
         <div class="box-header with-border">
             <h3 class="box-title"><i class="fa fa-folder-open"></i> {{folder.name}}</h3>
             <div class="box-tools pull-right">
-                <button type="button" class="btn btn-default btn-flat" ng-click="addSite(folder)" uib-tooltip="Add Site">
+                <button type="button" class="btn btn-box-tool" ng-click="addSite(folder)" uib-tooltip="Add Site">
                     <i class="fa fa-plus"></i>
                 </button>
                 <button type="button" class="btn btn-box-tool" ng-click="deleteFolder(folder)" ng-show="canDeleteFolder(folder)" uib-tooltip="Delete">

--- a/src/Web/wwwroot/app/vault/views/vault.html
+++ b/src/Web/wwwroot/app/vault/views/vault.html
@@ -12,6 +12,9 @@
         <div class="box-header with-border">
             <h3 class="box-title"><i class="fa fa-folder-open"></i> {{folder.name}}</h3>
             <div class="box-tools pull-right">
+                <button type="button" class="btn btn-default btn-flat" ng-click="addSite(folder)" uib-tooltip="Add Site">
+                    <i class="fa fa-plus"></i>
+                </button>
                 <button type="button" class="btn btn-box-tool" ng-click="deleteFolder(folder)" ng-show="canDeleteFolder(folder)" uib-tooltip="Delete">
                     <i class="fa fa-trash"></i>
                 </button>


### PR DESCRIPTION
When a folder has no sites, there's a convenient 'add site' button. It would be nice if this was permanent. 

It's tedious to have to select a folder each time, causing at least in my case to forget about the folder selection since it wasn't used on the first site that was added (due to the convenient add site button).