### PR TITLE
vaultAddCipherController.js: secureNote Type is int not string

### DIFF
--- a/src/app/vault/vaultAddCipherController.js
+++ b/src/app/vault/vaultAddCipherController.js
@@ -15,7 +15,7 @@
             identity: {},
             card: {},
             secureNote: {
-                type: '0'
+                type: 0
             }
         };
 


### PR DESCRIPTION
SecureNote Type is defined as int not as string, send int in JSON