### PR TITLE
Changed MAC comparison to constant time comparison

### DIFF
--- a/src/app/services/cryptoService.js
+++ b/src/app/services/cryptoService.js
@@ -779,14 +779,14 @@ angular
 
                     var arr1 = new Uint8Array(mac1);
                     var arr2 = new Uint8Array(mac2);
-
+                    var macsEqualConstantTime = true
                     for (var i = 0; i < arr2.length; i++) {
                         if (arr1[i] !== arr2[i]) {
-                            return false;
+                            macsEqualConstantTime = false;
                         }
                     }
 
-                    return true;
+                    return macsEqualConstantTime;
                 });
         }
 

--- a/src/app/services/cryptoService.js
+++ b/src/app/services/cryptoService.js
@@ -779,7 +779,7 @@ angular
 
                     var arr1 = new Uint8Array(mac1);
                     var arr2 = new Uint8Array(mac2);
-                    var macsEqualConstantTime = true
+                    var macsEqualConstantTime = true;
                     for (var i = 0; i < arr2.length; i++) {
                         if (arr1[i] !== arr2[i]) {
                             macsEqualConstantTime = false;


### PR DESCRIPTION
I changed the algorithm for mac comparison to be in constant time. That means comparing every single byte of each mac with one another and not failing after one miss. 

If you exit after the first miss the algorithm takes longer if there are more matching bytes and this may be an issue for timing attacks. Checking every byte thus makes this constant time.