### PR TITLE
Change npm to use https for gulp-gh-pages restore.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "gulp-less": "3.3.2",
     "gulp-rename": "1.2.2",
     "gulp-uglify": "3.0.0",
-    "gulp-gh-pages": "git@github.com:tekd/gulp-gh-pages.git#update-dependency",
+    "gulp-gh-pages": "git+https://github.com/tekd/gulp-gh-pages.git#update-dependency",
     "gulp-preprocess": "2.0.0",
     "gulp-ng-annotate": "2.0.0",
     "gulp-ng-config": "1.5.0",


### PR DESCRIPTION
When using VS 2017 node.js integration, npm fails because a host key cannot be validated. Switching to https, provides security and no additional configuration to restore the package.