### PR TITLE
Generate subresource-integrity attributes for scripts and styles.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11275,6 +11275,33 @@
         }
       }
     },
+    "webpack-core": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
+      "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
+      "dev": true,
+      "requires": {
+        "source-list-map": "~0.1.7",
+        "source-map": "~0.4.1"
+      },
+      "dependencies": {
+        "source-list-map": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
+          "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
     "webpack-dev-middleware": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.3.0.tgz",
@@ -11639,6 +11666,15 @@
       "requires": {
         "source-list-map": "^2.0.0",
         "source-map": "~0.6.1"
+      }
+    },
+    "webpack-subresource-integrity": {
+      "version": "1.1.0-rc.5",
+      "resolved": "https://registry.npmjs.org/webpack-subresource-integrity/-/webpack-subresource-integrity-1.1.0-rc.5.tgz",
+      "integrity": "sha512-pUlU358+futuHwICLLBmkIu1dnDqZqgNGOoeSO5Y8Uy4dvo54Rp4bBtUE323kFpS5MH61dVxBuP30n6jxlFoig==",
+      "dev": true,
+      "requires": {
+        "webpack-core": "^0.6.8"
       }
     },
     "whatwg-fetch": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "typescript": "^2.7.2",
     "webpack": "^4.18.0",
     "webpack-cli": "^3.1.0",
-    "webpack-serve": "^2.0.2"
+    "webpack-serve": "^2.0.2",
+    "webpack-subresource-integrity": "^1.1.0-rc.5"
   },
   "dependencies": {
     "@angular/animations": "6.1.7",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const AngularCompilerPlugin = require('@ngtools/webpack').AngularCompilerPlugin;
 const pjson = require('./package.json');
+const SubresourceIntegrityPlugin = require('webpack-subresource-integrity');
 
 if (process.env.NODE_ENV == null) {
     process.env.NODE_ENV = 'development';
@@ -110,6 +111,9 @@ const plugins = [
             'CACHE_TAG': JSON.stringify(Math.random().toString(36).substring(7)),
         }
     }),
+    new SubresourceIntegrityPlugin({
+        hashFuncNames: ['sha384']
+    })
 ];
 
 if (ENV === 'production') {
@@ -179,6 +183,7 @@ const config = {
     output: {
         filename: '[name].[hash].js',
         path: path.resolve(__dirname, 'build'),
+        crossOriginLoading: 'anonymous',
     },
     module: { rules: moduleRules },
     plugins: plugins,


### PR DESCRIPTION
Include `webpack-subresource-integrity` to generate `integrity` attributes for script and style inclusions.

Examples 

    <link href="app/main.d05626c7cc7c24d5dda4.css" rel="stylesheet" integrity="sha384-zJjhV2XVqs22s9nugPeyrfvORcjbSk8e54nbJQYPBrEXBGL01n4OyPLumXvDBHxN" crossorigin="anonymous">
    <script type="text/javascript" src="app/polyfills.5b1ce1f7f47c818b3ad3.js" integrity="sha384-jI43JMQZWJhozXgCwrpTsAX/V87OnwoddlN9jSBTDGRHe++HYBe7CzLhfdD2DJjk" crossorigin="anonymous"></script>
    <script type="text/javascript" src="app/vendor.7a0e6d1c31980954b2f3.js" integrity="sha384-gmZonBUHM1iBomMf56C4GetQYzDTT/LvoTd9pni/6267L2Tt0e0Z11mPTceBxXwd" crossorigin="anonymous"></script>
    <script type="text/javascript" src="app/main.d05626c7cc7c24d5dda4.js" integrity="sha384-O6X6VpeE1w6g2fmARoXYYXLy4fd7Qzfl/+giZZ4RJov7JozbqswlqnlLlc6nmvyd" crossorigin="anonymous"></script>

While I'm not sure I can argue that this change alone does much for security, it would allow a strict Content Security header to be set for styles:

    Content-Security-Policy: require-sri-for style;

Unfortunately the inclusion of Paypal javascript would prevent this same policy from being applied to scripts. But I believe its still a step in the right direction, basically for free. 