### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.sh eol=lf
+.dockerignore eol=lf
+dockerfile eol=lf


### PR DESCRIPTION
Added .gitattributes file to files requiring LF endings are properly checked out on Windows.