### PR TITLE
Proposal: Add "Value 2" to custom fields

### DIFF
--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -309,7 +309,7 @@
                 <h3 class="mt-4">{{'customFields' | i18n}}</h3>
                 <ng-container *ngIf="cipher.hasFields">
                     <div class="row" appBoxRow *ngFor="let f of cipher.fields; let i = index">
-                        <div class="col-5 form-group">
+                        <div class="col-3 form-group">
                             <div class="d-flex">
                                 <label for="fieldName{{i}}">{{'name' | i18n}}</label>
                                 <a class="ml-auto" href="https://help.bitwarden.com/article/custom-fields/" target="_blank" rel="noopener" title="{{'learnMore' | i18n}}">
@@ -318,7 +318,7 @@
                             </div>
                             <input id="fieldName{{i}}" type="text" name="Field.Name{{i}}" [(ngModel)]="f.name" class="form-control" appInputVerbatim>
                         </div>
-                        <div class="col-7 form-group">
+                        <div class="col-4 form-group">
                             <label for="fieldValue{{i}}">{{'value' | i18n}}</label>
                             <div class="d-flex align-items-center">
                                 <div class="input-group" *ngIf="f.type === fieldType.Text">
@@ -348,11 +348,43 @@
                                     <input id="fieldValue{{i}}" name="Field.Value{{i}}" type="checkbox" [(ngModel)]="f.value" *ngIf="f.type === fieldType.Boolean"
                                         appTrueFalseValue trueValue="true" falseValue="false">
                                 </div>
-                                <button type="button" class="btn btn-link text-danger ml-2" (click)="removeField(f)" title="{{'remove' | i18n}}">
-                                    <i class="fa fa-minus-circle fa-lg"></i>
-                                </button>
                             </div>
                         </div>
+                        <div class="col-4 form-group">
+                            <label for="fieldValue2{{i}}">{{'value2' | i18n}}</label>
+                            <div class="d-flex align-items-center">
+                                <div class="input-group" *ngIf="f.type === fieldType.Text">
+                                    <input id="fieldValue2{{i}}" class="form-control" type="text" name="Field.Value2{{i}}" [(ngModel)]="f.value2" appInputVerbatim>
+                                    <div class="input-group-append">
+                                        <button type="button" class="btn btn-outline-secondary" title="{{'copyValue2' | i18n}}" (click)="copy(f.value2, 'value2', 'Field')"
+                                            tabindex="-1">
+                                            <i class="fa fa-lg fa-clipboard"></i>
+                                        </button>
+                                    </div>
+                                </div>
+                                <div class="input-group" *ngIf="f.type === fieldType.Hidden">
+                                    <input id="fieldValue2{{i}}" type="{{f.showValue ? 'text' : 'password'}}" name="Field.Value2{{i}}" [(ngModel)]="f.value2" class="form-control text-monospace"
+                                        appInputVerbatim autocomplete="new-password">
+                                    <div class="input-group-append">
+                                        <button type="button" class="btn btn-outline-secondary" title="{{'toggleVisibility' | i18n}}" (click)="toggleFieldValue(f)"
+                                            tabindex="-1">
+                                            <i class="fa fa-lg" [ngClass]="{'fa-eye': !f.showValue2, 'fa-eye-slash': f.showValue2}"></i>
+                                        </button>
+                                        <button type="button" class="btn btn-outline-secondary" title="{{'copyValue2' | i18n}}" (click)="copy(f.value2, 'value2', 'Field')"
+                                            tabindex="-1">
+                                            <i class="fa fa-lg fa-clipboard"></i>
+                                        </button>
+                                    </div>
+                                </div>
+                                <div class="flex-fill">
+                                    <input id="fieldValue2{{i}}" name="Field.Value2{{i}}" type="checkbox" [(ngModel)]="f.value2" *ngIf="f.type === fieldType.Boolean"
+                                        appTrueFalseValue trueValue="true" falseValue="false">
+                                </div>
+                            </div>
+                        </div>
+                        <button type="button" class="btn btn-link text-danger ml-2" (click)="removeField(f)" title="{{'remove' | i18n}}">
+                            <i class="fa fa-minus-circle fa-lg"></i>
+                        </button>
                     </div>
                 </ng-container>
                 <a href="#" appStopClick (click)="addField()" class="d-inline-block mb-2">

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -151,6 +151,9 @@
   "value": {
     "message": "Value"
   },
+  "value2": {
+    "message": "Value 2"
+  },
   "cfTypeText": {
     "message": "Text"
   },
@@ -357,9 +360,23 @@
       }
     }
   },
+  "valueCopied2": {
+    "message": "$VALUE$ copied",
+    "description": "Value 2 has been copied to the clipboard.",
+    "placeholders": {
+      "value": {
+        "content": "$1",
+        "example": "Password"
+      }
+    }
+  },
   "copyValue": {
     "message": "Copy Value",
     "description": "Copy value to clipboard"
+  },
+  "copyValue2": {
+    "message": "Copy Value 2",
+    "description": "Copy value 2 to clipboard"
   },
   "copyPassword": {
     "message": "Copy Password",
@@ -401,9 +418,6 @@
   },
   "unselectAll": {
     "message": "Unselect All"
-  },
-  "value": {
-    "message": "Value"
   },
   "launch": {
     "message": "Launch"


### PR DESCRIPTION
I'd like to propose adding a "Value 2" to the custom fields.  The easiest case for this is security questions, when trying to add those to logins to save them (and be able to use random ones...perhaps we could add a randomize button next to the two values, though that would use a lot of space) there isn't a way to do so that makes sense.  You can name it security question but you can't save the question/answer pair then, you can set the name as the question but that doesn't make sense either.  This would allow cases where you need to save a name/value pair as a custom field but still be able to give it a proper name.

I've done the work for the jslib, core, and web repos and can do the pull request for those if this would be accepted.  The only thing I wasn't sure on was the other language translations and what may need to get changed for the if statement in jslib cipher.service.ts on line 103 "if (existingCipher.hasFields)".