### PR TITLE
fix logos in breach report page

### DIFF
--- a/src/app/tools/breach-report.component.html
+++ b/src/app/tools/breach-report.component.html
@@ -28,7 +28,7 @@
             <li *ngFor="let a of breachedAccounts" class="list-group-item min-height-fix">
                 <div class="row">
                     <div class="col-2 text-center">
-                        <img [src]="'https://haveibeenpwned.com/Content/Images/PwnedLogos/' + a.name + '.' + a.logoType" alt="" class="img-fluid">
+                        <img [src]="a.logoPath" alt="" class="img-fluid">
                     </div>
                     <div class="col-7">
                         <h3 class="text-lg">{{a.title}}</h3>


### PR DESCRIPTION
This PR provide a fix for brokens logos on breach report page :

![image](https://user-images.githubusercontent.com/8047492/49147210-5669e780-f304-11e8-9982-5c455d9b184b.png)

Depends on PR  [bitwarden/jslib#23](https://github.com/bitwarden/jslib/pull/23)