### PR TITLE
Fix spanish translation

### DIFF
--- a/src/locales/es/messages.json
+++ b/src/locales/es/messages.json
@@ -279,7 +279,7 @@
     "message": "Tipos"
   },
   "typeLogin": {
-    "message": "Entrada"
+    "message": "Inicio de sesión"
   },
   "typeCard": {
     "message": "Tarjeta"


### PR DESCRIPTION
In spanish `Login` is `Inicio de sesión`, not `Entrada`.

Thanks!