### PR TITLE
enable clear button in search input types

### DIFF
--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -254,6 +254,10 @@ label:not(.form-check-label):not(.btn), label.bold {
     font-weight: 600;
 }
 
+input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: searchfield-cancel-button;
+}
+
 .btn[class*="btn-outline-"] {
     &:not(:hover) {
         border-color: $secondary;


### PR DESCRIPTION
Screenshots attached. Should be pretty clear.

bootstrap disables this behaviour by default.

<img width="256" alt="screenshot 2018-12-08 at 05 25 46" src="https://user-images.githubusercontent.com/797608/49673611-fb758480-faa9-11e8-87e0-95afb9fba1a1.png">
<img width="240" alt="screenshot 2018-12-08 at 05 25 55" src="https://user-images.githubusercontent.com/797608/49673612-fc0e1b00-faa9-11e8-88cf-474377fd0a72.png">
