### PR TITLE
Stop showing score 3 passwords as weak passwords

### DIFF
--- a/src/app/tools/weak-passwords-report.component.ts
+++ b/src/app/tools/weak-passwords-report.component.ts
@@ -63,7 +63,7 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
                 this.passwordStrengthCache.set(cacheKey, result.score);
             }
             const score = this.passwordStrengthCache.get(cacheKey);
-            if (score != null && score <= 3) {
+            if (score != null && score <= 2) {
                 this.passwordStrengthMap.set(c.id, this.scoreKey(score));
                 weakPasswordCiphers.push(c);
             }


### PR DESCRIPTION
* Summary
Stops showing score 3 passwords in Weak Passwords Report page.
https://vault.bitwarden.com/#/tools/weak-passwords-report

* Reason
In zxcvbn library that scores the password, score 3 is considered "safely unguessable" (c.f. https://github.com/dropbox/zxcvbn#usage )
Showing too many passwords in the list distracts users and prevents from focusing on really weak passwords.