### PR TITLE
Allow organizational admins to assign clone ownership

### DIFF
--- a/src/app/organizations/vault/add-edit.component.ts
+++ b/src/app/organizations/vault/add-edit.component.ts
@@ -42,6 +42,17 @@ export class AddEditComponent extends BaseAddEditComponent {
             eventService);
     }
 
+    protected allowOwnershipAssignment() {
+        if (this.ownershipOptions != null && this.ownershipOptions.length > 1) {
+            if (this.organization != null) {
+                return this.cloneMode && this.organization.isAdmin;
+            } else {
+                return !this.editMode || this.cloneMode;
+            }
+        }
+        return false;
+    }
+
     protected loadCollections() {
         if (!this.organization.isAdmin) {
             return super.loadCollections();
@@ -67,7 +78,7 @@ export class AddEditComponent extends BaseAddEditComponent {
     }
 
     protected async saveCipher(cipher: Cipher) {
-        if (!this.organization.isAdmin) {
+        if (!this.organization.isAdmin || cipher.organizationId == null) {
             return super.saveCipher(cipher);
         }
         if (this.editMode && !this.cloneMode) {

--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -439,8 +439,7 @@
                         </select>
                     </div>
                 </div>
-                <ng-container
-                    *ngIf="(!editMode || cloneMode) && !organization && ownershipOptions && ownershipOptions.length > 1">
+                <ng-container *ngIf="allowOwnershipAssignment()">
                     <h3 class="mt-4">{{'ownership' | i18n}}</h3>
                     <div class="row">
                         <div class="col-5">

--- a/src/app/vault/add-edit.component.ts
+++ b/src/app/vault/add-edit.component.ts
@@ -154,6 +154,10 @@ export class AddEditComponent extends BaseAddEditComponent {
         }
     }
 
+    protected allowOwnershipAssignment() {
+        return (!this.editMode || this.cloneMode) && this.ownershipOptions != null && this.ownershipOptions.length > 1;
+    }
+
     private async totpTick(intervalSeconds: number) {
         const epoch = Math.round(new Date().getTime() / 1000.0);
         const mod = epoch % intervalSeconds;


### PR DESCRIPTION
> Implement the ability for organizational admins to assign ownership during clone item flow. This can be used as a roundabout method for "unsharing" organizational items back to personal vaults.

- **organizations/add-edit.component.ts**:  added function for determining ownership visibility and adjusted save function override to call proper api for adding a cipher when cloning to personal vault (non-admins will NOT be able to assign ownership)
- **add-edit.component.html**: changed direct conditionals to call allowOwnershipAssignment function
- **add-edit.component.ts**: added function for determining ownership visibility 

<img width="801" alt="0-clone-org-item-ownership-admin" src="https://user-images.githubusercontent.com/26154748/74372486-54246980-4da0-11ea-8b41-a73ad81beb51.png">
<img width="801" alt="1-clone-org-item-to-personal-admin" src="https://user-images.githubusercontent.com/26154748/74372493-55ee2d00-4da0-11ea-9faa-9bc5aa7da6af.png">
<img width="513" alt="2-clone-org-item-ownership-success" src="https://user-images.githubusercontent.com/26154748/74372495-55ee2d00-4da0-11ea-842c-65b01eb2117c.png">
