### PR TITLE
Enforce Password Generator Policy Options

### DIFF
--- a/src/app/organizations/manage/policy-edit.component.html
+++ b/src/app/organizations/manage/policy-edit.component.html
@@ -59,19 +59,19 @@
                         <div class="col-6 form-group">
                             <label for="passGenMinLength">{{'minLength' | i18n}}</label>
                             <input id="passGenMinLength" class="form-control" type="number" name="PassGenMinLength"
-                                [(ngModel)]="passGenMinLength">
+                                min="5" max="128" [(ngModel)]="passGenMinLength">
                         </div>
                     </div>
                     <div class="row">
                         <div class="col-6 form-group">
                             <label for="passGenMinNumbers">{{'minNumbers' | i18n}}</label>
                             <input id="passGenMinNumbers" class="form-control" type="number" name="PassGenMinNumbers"
-                                [(ngModel)]="passGenMinNumbers">
+                                min="0" max="9" [(ngModel)]="passGenMinNumbers">
                         </div>
                         <div class="col-6 form-group">
                             <label for="passGenMinSpecial">{{'minSpecial' | i18n}}</label>
                             <input id="passGenMinSpecial" class="form-control" type="number" name="PassGenMinSpecial"
-                                [(ngModel)]="passGenMinSpecial">
+                                min="0" max="9" [(ngModel)]="passGenMinSpecial">
                         </div>
                     </div>
                     <div class="form-check">

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -142,8 +142,8 @@ export function initFactory(): Function {
         }
         apiService.setUrls({
             base: isDev ? null : window.location.origin,
-            api: isDev ? 'http://localhost:5000' : null,
-            identity: isDev ? 'http://localhost:33657' : null,
+            api: isDev ? 'http://localhost:4000' : null,
+            identity: isDev ? 'http://localhost:33656' : null,
             events: isDev ? 'http://localhost:46273' : null,
 
             // Uncomment these (and comment out the above) if you want to target production

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -113,7 +113,7 @@ const lockService = new LockService(cipherService, folderService, collectionServ
 const syncService = new SyncService(userService, apiService, settingsService,
     folderService, cipherService, cryptoService, collectionService, storageService, messagingService, policyService,
     async (expired: boolean) => messagingService.send('logout', { expired: expired }));
-const passwordGenerationService = new PasswordGenerationService(cryptoService, storageService);
+const passwordGenerationService = new PasswordGenerationService(cryptoService, storageService, policyService);
 const totpService = new TotpService(storageService, cryptoFunctionService);
 const containerService = new ContainerService(cryptoService);
 const authService = new AuthService(cryptoService, apiService,
@@ -142,8 +142,8 @@ export function initFactory(): Function {
         }
         apiService.setUrls({
             base: isDev ? null : window.location.origin,
-            api: isDev ? 'http://localhost:4000' : null,
-            identity: isDev ? 'http://localhost:33656' : null,
+            api: isDev ? 'http://localhost:5000' : null,
+            identity: isDev ? 'http://localhost:33657' : null,
             events: isDev ? 'http://localhost:46273' : null,
 
             // Uncomment these (and comment out the above) if you want to target production

--- a/src/app/tools/password-generator.component.html
+++ b/src/app/tools/password-generator.component.html
@@ -53,34 +53,34 @@
         </div>
         <div class="form-group col-4">
             <label for="min-number">{{'minNumbers' | i18n}}</label>
-            <input id="min-number" class="form-control" type="number" min="0" max="9" (input)="saveOptions()"
-                [(ngModel)]="options.minNumber">
+            <input id="min-number" class="form-control" type="number" min="0" max="9" (blur)="saveOptions()"
+                [(ngModel)]="options.minNumber" (change)="minNumberChanged()">
         </div>
         <div class="form-group col-4">
             <label for="min-special">{{'minSpecial' | i18n}}</label>
-            <input id="min-special" class="form-control" type="number" min="0" max="9" (input)="saveOptions()"
-                [(ngModel)]="options.minSpecial">
+            <input id="min-special" class="form-control" type="number" min="0" max="9" (blur)="saveOptions()"
+                [(ngModel)]="options.minSpecial" (change)="minSpecialChanged()">
         </div>
     </div>
     <div class="form-group">
         <div class="form-check">
             <input id="uppercase" class="form-check-input" type="checkbox" (change)="saveOptions()"
-                [(ngModel)]="options.uppercase">
+                [(ngModel)]="options.uppercase" [disabled]="enforcedPolicyOptions?.useUppercase">
             <label for="uppercase" class="form-check-label">A-Z</label>
         </div>
         <div class="form-check">
             <input id="lowercase" class="form-check-input" type="checkbox" (change)="saveOptions()"
-                [(ngModel)]="options.lowercase">
+                [(ngModel)]="options.lowercase" [disabled]="enforcedPolicyOptions?.useLowercase">
             <label for="lowercase" class="form-check-label">a-z</label>
         </div>
         <div class="form-check">
             <input id="numbers" class="form-check-input" type="checkbox" (change)="saveOptions()"
-                [(ngModel)]="options.number">
+                [(ngModel)]="options.number" [disabled]="enforcedPolicyOptions?.useNumbers">
             <label for="numbers" class="form-check-label">0-9</label>
         </div>
         <div class="form-check">
             <input id="special" class="form-check-input" type="checkbox" (change)="saveOptions()"
-                [(ngModel)]="options.special">
+                [(ngModel)]="options.special" [disabled]="enforcedPolicyOptions?.useSpecial">
             <label for="special" class="form-check-label">!@#$%^&amp;*</label>
         </div>
         <div class="form-check">

--- a/src/app/tools/password-generator.component.ts
+++ b/src/app/tools/password-generator.component.ts
@@ -47,4 +47,12 @@ export class PasswordGeneratorComponent extends BasePasswordGeneratorComponent {
     lengthChanged() {
         document.getElementById('length').focus();
     }
+
+    minNumberChanged() {
+        document.getElementById('min-number').focus();
+    }
+
+    minSpecialChanged() {
+        document.getElementById('min-special').focus();
+    }
 }

--- a/src/app/vault/add-edit.component.ts
+++ b/src/app/vault/add-edit.component.ts
@@ -103,7 +103,7 @@ export class AddEditComponent extends BaseAddEditComponent {
     async generatePassword(): Promise<boolean> {
         const confirmed = await super.generatePassword();
         if (confirmed) {
-            const options = await this.passwordGenerationService.getOptions();
+            const options = (await this.passwordGenerationService.getOptions())[0];
             this.cipher.login.password = await this.passwordGenerationService.generatePassword(options);
         }
         return confirmed;


### PR DESCRIPTION
## Objective
>Make sure the Password Generator enforces the specific rules set by an Organization for password generation. In the case of multiple Organizational rules, apply the stricter option.

## Code Changes
- **policy-edit.component.ts**: Added basic min/max restrictions for the three input fields to deny saving negative numbers or numbers outside the allowed ranges within the Password Generator
- **services.module.ts**: Added the `policyServer` dependency into the `passwordGenerationService`
- **password-generator.component.html**: Adjusted the `min-number` and `min-special` field to mirror how the `length` field operates and adjust the `disabled` property for each checkbox based on the enforced policy options
- **password-generator.component.ts**: Added methods to focus the field(s) when a `change` event occurs
- **add-edit.component.ts**:  Made sure the call to `getOptions` used the correct values from the tuple

## Screenshots
<img width="754" alt="Screen Shot 2020-02-25 at 1 00 57 PM" src="https://user-images.githubusercontent.com/26154748/75397928-cecfa780-58bd-11ea-90d5-cd71e5d358a0.png">
