### PR TITLE
Show policy in effect banner for password generator

### DIFF
--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -142,8 +142,8 @@ export function initFactory(): Function {
         }
         apiService.setUrls({
             base: isDev ? null : window.location.origin,
-            api: isDev ? 'http://localhost:5000' : null,
-            identity: isDev ? 'http://localhost:33657' : null,
+            api: isDev ? 'http://localhost:4000' : null,
+            identity: isDev ? 'http://localhost:33656' : null,
             events: isDev ? 'http://localhost:46273' : null,
 
             // Uncomment these (and comment out the above) if you want to target production

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -142,8 +142,8 @@ export function initFactory(): Function {
         }
         apiService.setUrls({
             base: isDev ? null : window.location.origin,
-            api: isDev ? 'http://localhost:4000' : null,
-            identity: isDev ? 'http://localhost:33656' : null,
+            api: isDev ? 'http://localhost:5000' : null,
+            identity: isDev ? 'http://localhost:33657' : null,
             events: isDev ? 'http://localhost:46273' : null,
 
             // Uncomment these (and comment out the above) if you want to target production

--- a/src/app/tools/password-generator.component.html
+++ b/src/app/tools/password-generator.component.html
@@ -1,6 +1,9 @@
 <div class="page-header">
     <h1>{{'passwordGenerator' | i18n}}</h1>
 </div>
+<app-callout type="primary" *ngIf="hasPolicyInEffect()">
+    {{'passwordGeneratorPolicyInEffect' | i18n}}
+</app-callout>
 <div class="card card-password bg-light my-4">
     <div class="card-body">
         <div class="password-wrapper" [innerHTML]="password | colorPassword" appSelectCopy></div>
@@ -14,7 +17,7 @@
     </div>
     <div class="form-check form-check-inline">
         <input id="generate-passphrase" name="type" value="passphrase" class="form-check-input" type="radio"
-            (change)="saveOptions()" [(ngModel)]="options.type">
+            (change)="saveOptions()" [(ngModel)]="options.type">`
         <label for="generate-passphrase" class="form-check-label">{{'passphrase' | i18n}}</label>
     </div>
 </div>

--- a/src/app/tools/password-generator.component.html
+++ b/src/app/tools/password-generator.component.html
@@ -1,7 +1,7 @@
 <div class="page-header">
     <h1>{{'passwordGenerator' | i18n}}</h1>
 </div>
-<app-callout type="primary" *ngIf="hasPolicyInEffect()">
+<app-callout type="info" *ngIf="hasPolicyInEffect()">
     {{'passwordGeneratorPolicyInEffect' | i18n}}
 </app-callout>
 <div class="card card-password bg-light my-4">

--- a/src/app/tools/password-generator.component.html
+++ b/src/app/tools/password-generator.component.html
@@ -17,7 +17,7 @@
     </div>
     <div class="form-check form-check-inline">
         <input id="generate-passphrase" name="type" value="passphrase" class="form-check-input" type="radio"
-            (change)="saveOptions()" [(ngModel)]="options.type">`
+            (change)="saveOptions()" [(ngModel)]="options.type">
         <label for="generate-passphrase" class="form-check-label">{{'passphrase' | i18n}}</label>
     </div>
 </div>

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -2977,5 +2977,8 @@
   },
   "passwordGeneratorPolicyDesc": {
     "message": "Set minimum requirements for password generator configuration."
+  },
+  "passwordGeneratorPolicyInEffect": {
+    "message": "One or more organization policies are affecting your generator settings."
   }
 }


### PR DESCRIPTION
## Objective
> While an organizational password generator policy is enabled, alert the user that all/some settings are being adjusted.

## Code Changes
- **password-generator.component.html**: Added `app-callout` banner and made visible when a policy is in effect
- **messages.json**: Added `passwordGeneratorPolicyInEffect` string

## Screenshots
<img width="1037" alt="0-pg-policy-banner" src="https://user-images.githubusercontent.com/26154748/75571663-40733700-5a1f-11ea-83e5-00348fb4b12b.png">
