### PR TITLE
Show reason for invite accept failure if available

### DIFF
--- a/src/app/accounts/accept-organization.component.ts
+++ b/src/app/accounts/accept-organization.component.ts
@@ -44,6 +44,7 @@ export class AcceptOrganizationComponent implements OnInit {
             fired = true;
             await this.stateService.remove('orgInvitation');
             let error = qParams.organizationId == null || qParams.organizationUserId == null || qParams.token == null;
+            let errorMessage: string = null;
             if (!error) {
                 this.authed = await this.userService.isAuthenticated();
                 if (this.authed) {
@@ -61,8 +62,9 @@ export class AcceptOrganizationComponent implements OnInit {
                         };
                         this.toasterService.popAsync(toast);
                         this.router.navigate(['/vault']);
-                    } catch {
+                    } catch (e) {
                         error = true;
+                        errorMessage = e.message;
                     }
                 } else {
                     await this.stateService.save('orgInvitation', qParams);
@@ -76,7 +78,14 @@ export class AcceptOrganizationComponent implements OnInit {
             }
 
             if (error) {
-                this.toasterService.popAsync('error', null, this.i18nService.t('inviteAcceptFailed'));
+                const toast: Toast = {
+                    type: 'error',
+                    title: null,
+                    body: errorMessage != null ? this.i18nService.t('inviteAcceptFailedShort', errorMessage) :
+                        this.i18nService.t('inviteAcceptFailed'),
+                    timeout: 10000,
+                };
+                this.toasterService.popAsync(toast);
                 this.router.navigate(['/']);
             }
 

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -2578,6 +2578,15 @@
   "inviteAcceptFailed": {
     "message": "Unable to accept invitation. Ask an organization admin to send a new invitation."
   },
+  "inviteAcceptFailedShort": {
+    "message": "Unable to accept invitation. $DESCRIPTION$",
+    "placeholders": {
+      "description": {
+        "content": "$1",
+        "example": "You must enable 2FA on your user account before you can join this organization."
+      }
+    }
+  },
   "rememberEmail": {
     "message": "Remember email"
   },


### PR DESCRIPTION
If the invite to org fails for the user and a server error message is available, show them why.

![image](https://user-images.githubusercontent.com/1190944/75582667-11b68a00-5a3a-11ea-8319-74240084b030.png)
