### PR TITLE
Enforce Master Password Policies (Change/Register)

### DIFF
--- a/src/app/accounts/register.component.html
+++ b/src/app/accounts/register.component.html
@@ -30,14 +30,14 @@
                                 <li *ngIf="enforcedPolicyOptions?.minLength > 0">
                                     {{'policyInEffectMinLength' | i18n : enforcedPolicyOptions?.minLength.toString()}}
                                 </li>
-                                <li *ngIf="enforcedPolicyOptions?.requireUpper">{{'policyInEffectUppercase' | i18n}}
-                                </li>
-                                <li *ngIf="enforcedPolicyOptions?.requireLower">{{'policyInEffectLowercase' | i18n}}
-                                </li>
-                                <li *ngIf="enforcedPolicyOptions?.requireNumbers">{{'policyInEffectNumbers' | i18n}}
-                                </li>
-                                <li *ngIf="enforcedPolicyOptions?.requireSpecial">{{'policyInEffectSpecial' | i18n}}
-                                </li>
+                                <li *ngIf="enforcedPolicyOptions?.requireUpper">
+                                    {{'policyInEffectUppercase' | i18n}}</li>
+                                <li *ngIf="enforcedPolicyOptions?.requireLower">
+                                    {{'policyInEffectLowercase' | i18n}}</li>
+                                <li *ngIf="enforcedPolicyOptions?.requireNumbers">
+                                    {{'policyInEffectNumbers' | i18n}}</li>
+                                <li *ngIf="enforcedPolicyOptions?.requireSpecial">
+                                    {{'policyInEffectSpecial' | i18n : '!@#$%^&*'}}</li>
                             </ul>
                         </app-callout>
                         <label for="masterPassword">{{'masterPass' | i18n}}</label>

--- a/src/app/accounts/register.component.html
+++ b/src/app/accounts/register.component.html
@@ -21,6 +21,25 @@
                         <small class="form-text text-muted">{{'yourNameDesc' | i18n}}</small>
                     </div>
                     <div class="form-group">
+                        <app-callout type="info" *ngIf="enforcedPolicyOptions">
+                            <p>{{'masterPasswordPolicyInEffect' | i18n}}</p>
+                            <ul>
+                                <li *ngIf="enforcedPolicyOptions?.minComplexity > 0">
+                                    {{'policyInEffectMinComplexity' | i18n : enforcedPolicyOptions?.minComplexity.toString()}}
+                                </li>
+                                <li *ngIf="enforcedPolicyOptions?.minLength > 0">
+                                    {{'policyInEffectMinLength' | i18n : enforcedPolicyOptions?.minLength.toString()}}
+                                </li>
+                                <li *ngIf="enforcedPolicyOptions?.requireUpper">{{'policyInEffectUppercase' | i18n}}
+                                </li>
+                                <li *ngIf="enforcedPolicyOptions?.requireLower">{{'policyInEffectLowercase' | i18n}}
+                                </li>
+                                <li *ngIf="enforcedPolicyOptions?.requireNumbers">{{'policyInEffectNumbers' | i18n}}
+                                </li>
+                                <li *ngIf="enforcedPolicyOptions?.requireSpecial">{{'policyInEffectSpecial' | i18n}}
+                                </li>
+                            </ul>
+                        </app-callout>
                         <label for="masterPassword">{{'masterPass' | i18n}}</label>
                         <div class="d-flex">
                             <div class="w-100">

--- a/src/app/accounts/register.component.ts
+++ b/src/app/accounts/register.component.ts
@@ -75,18 +75,14 @@ export class RegisterComponent extends BaseRegisterComponent {
     }
 
     async submit() {
-        if (this.enforcedPolicyOptions == null) {
-            super.submit();
-            return;
-        }
-
-        if (!this.policyService.evaluateMasterPassword(this.masterPasswordScore, this.masterPassword,
-            this.enforcedPolicyOptions)) {
+        if (this.enforcedPolicyOptions != null &&
+            !this.policyService.evaluateMasterPassword(this.masterPasswordScore, this.masterPassword,
+                this.enforcedPolicyOptions)) {
             this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
                 this.i18nService.t('masterPasswordPolicyRequirementsNotMet'));
             return;
         }
 
-        super.submit();
+        await super.submit();
     }
 }

--- a/src/app/accounts/register.component.ts
+++ b/src/app/accounts/register.component.ts
@@ -10,10 +10,12 @@ import { CryptoService } from 'jslib/abstractions/crypto.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
 import { PasswordGenerationService } from 'jslib/abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { PolicyService } from 'jslib/abstractions/policy.service';
 import { StateService } from 'jslib/abstractions/state.service';
 
 import { RegisterComponent as BaseRegisterComponent } from 'jslib/angular/components/register.component';
 
+import { MasterPasswordPolicyOptions } from 'jslib/models/domain/masterPasswordPolicyOptions';
 import { Policy } from 'jslib/models/domain/policy';
 
 import { PolicyData } from 'jslib/models/data/policyData';
@@ -27,12 +29,13 @@ export class RegisterComponent extends BaseRegisterComponent {
     showTerms = true;
 
     private policies: Policy[];
+    private enforcedPolicyOptions: MasterPasswordPolicyOptions;
 
     constructor(authService: AuthService, router: Router,
         i18nService: I18nService, cryptoService: CryptoService,
         apiService: ApiService, private route: ActivatedRoute,
         stateService: StateService, platformUtilsService: PlatformUtilsService,
-        passwordGenerationService: PasswordGenerationService) {
+        passwordGenerationService: PasswordGenerationService, private policyService: PolicyService) {
         super(authService, router, i18nService, cryptoService, apiService, stateService, platformUtilsService,
             passwordGenerationService);
         this.showTerms = !platformUtilsService.isSelfHost();
@@ -64,6 +67,10 @@ export class RegisterComponent extends BaseRegisterComponent {
                     this.policies = policiesData.map((p) => new Policy(p));
                 }
             } catch { }
+        }
+
+        if (this.policies != null) {
+            //this.enforcedPolicyOptions = await this.policyService.getMasterPasswordPolicyOptions(this.policies);
         }
     }
 }

--- a/src/app/accounts/register.component.ts
+++ b/src/app/accounts/register.component.ts
@@ -69,8 +69,31 @@ export class RegisterComponent extends BaseRegisterComponent {
             } catch { }
         }
 
+        // this.enforcedPolicyOptions = new MasterPasswordPolicyOptions();
+        // this.enforcedPolicyOptions.minComplexity = 2;
+        // this.enforcedPolicyOptions.minLength = 10;
+        // this.enforcedPolicyOptions.requireUpper = true;
+        // this.enforcedPolicyOptions.requireLower = true;
+        // this.enforcedPolicyOptions.requireNumbers = true;
+        // this.enforcedPolicyOptions.requireSpecial = true;
         if (this.policies != null) {
-            //this.enforcedPolicyOptions = await this.policyService.getMasterPasswordPolicyOptions(this.policies);
+            this.enforcedPolicyOptions = await this.policyService.getMasterPasswordPolicyOptions(this.policies);
         }
+    }
+
+    async submit() {
+        if (this.enforcedPolicyOptions == null) {
+            super.submit();
+            return;
+        }
+
+        if (!(this.policyService.evaluateMasterPassword(this.masterPasswordScore, this.masterPassword,
+            this.enforcedPolicyOptions))) {
+            this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
+                this.i18nService.t('masterPasswordPolicyRequirementsNotMet'));
+            return;
+        }
+
+        super.submit();
     }
 }

--- a/src/app/accounts/register.component.ts
+++ b/src/app/accounts/register.component.ts
@@ -29,7 +29,7 @@ export class RegisterComponent extends BaseRegisterComponent {
     showTerms = true;
 
     private policies: Policy[];
-    private enforcedPolicyOptions: MasterPasswordPolicyOptions;
+    enforcedPolicyOptions: MasterPasswordPolicyOptions;
 
     constructor(authService: AuthService, router: Router,
         i18nService: I18nService, cryptoService: CryptoService,
@@ -80,8 +80,8 @@ export class RegisterComponent extends BaseRegisterComponent {
             return;
         }
 
-        if (!(this.policyService.evaluateMasterPassword(this.masterPasswordScore, this.masterPassword,
-            this.enforcedPolicyOptions))) {
+        if (!this.policyService.evaluateMasterPassword(this.masterPasswordScore, this.masterPassword,
+            this.enforcedPolicyOptions)) {
             this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
                 this.i18nService.t('masterPasswordPolicyRequirementsNotMet'));
             return;

--- a/src/app/accounts/register.component.ts
+++ b/src/app/accounts/register.component.ts
@@ -69,13 +69,6 @@ export class RegisterComponent extends BaseRegisterComponent {
             } catch { }
         }
 
-        // this.enforcedPolicyOptions = new MasterPasswordPolicyOptions();
-        // this.enforcedPolicyOptions.minComplexity = 2;
-        // this.enforcedPolicyOptions.minLength = 10;
-        // this.enforcedPolicyOptions.requireUpper = true;
-        // this.enforcedPolicyOptions.requireLower = true;
-        // this.enforcedPolicyOptions.requireNumbers = true;
-        // this.enforcedPolicyOptions.requireSpecial = true;
         if (this.policies != null) {
             this.enforcedPolicyOptions = await this.policyService.getMasterPasswordPolicyOptions(this.policies);
         }

--- a/src/app/organizations/manage/policy-edit.component.html
+++ b/src/app/organizations/manage/policy-edit.component.html
@@ -33,7 +33,7 @@
                         </div>
                         <div class="col-6 form-group">
                             <label for="masterPassMinLength">{{'minLength' | i18n}}</label>
-                            <input id="masterPassMinLength" class="form-control" type="number"
+                            <input id="masterPassMinLength" class="form-control" type="number" min="8"
                                 name="MasterPassMinLength" [(ngModel)]="masterPassMinLength">
                         </div>
                     </div>

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -142,8 +142,8 @@ export function initFactory(): Function {
         }
         apiService.setUrls({
             base: isDev ? null : window.location.origin,
-            api: isDev ? 'http://localhost:5000' : null,
-            identity: isDev ? 'http://localhost:33657' : null,
+            api: isDev ? 'http://localhost:4000' : null,
+            identity: isDev ? 'http://localhost:33656' : null,
             events: isDev ? 'http://localhost:46273' : null,
 
             // Uncomment these (and comment out the above) if you want to target production

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -142,8 +142,8 @@ export function initFactory(): Function {
         }
         apiService.setUrls({
             base: isDev ? null : window.location.origin,
-            api: isDev ? 'http://localhost:4000' : null,
-            identity: isDev ? 'http://localhost:33656' : null,
+            api: isDev ? 'http://localhost:5000' : null,
+            identity: isDev ? 'http://localhost:33657' : null,
             events: isDev ? 'http://localhost:46273' : null,
 
             // Uncomment these (and comment out the above) if you want to target production

--- a/src/app/settings/change-password.component.html
+++ b/src/app/settings/change-password.component.html
@@ -1,4 +1,20 @@
 <app-callout type="warning">{{'loggedOutWarning' | i18n}}</app-callout>
+<app-callout type="info" *ngIf="enforcedPolicyOptions">
+    <p>{{'masterPasswordPolicyInEffect' | i18n}}</p>
+    <ul>
+        <li *ngIf="enforcedPolicyOptions?.minComplexity > 0">
+            {{'policyInEffectMinComplexity' | i18n : enforcedPolicyOptions?.minComplexity.toString()}}
+        </li>
+        <li *ngIf="enforcedPolicyOptions?.minLength > 0">
+            {{'policyInEffectMinLength' | i18n : enforcedPolicyOptions?.minLength.toString()}}
+        </li>
+        <li *ngIf="enforcedPolicyOptions?.requireUpper">{{'policyInEffectUppercase' | i18n}}</li>
+        <li *ngIf="enforcedPolicyOptions?.requireLower">{{'policyInEffectLowercase' | i18n}}</li>
+        <li *ngIf="enforcedPolicyOptions?.requireNumbers">{{'policyInEffectNumbers' | i18n}}</li>
+        <li *ngIf="enforcedPolicyOptions?.requireSpecial">{{'policyInEffectSpecial' | i18n}}</li>
+    </ul>
+</app-callout>
+
 <form #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate autocomplete="off">
     <div class="row">
         <div class="col-6">

--- a/src/app/settings/change-password.component.html
+++ b/src/app/settings/change-password.component.html
@@ -11,7 +11,7 @@
         <li *ngIf="enforcedPolicyOptions?.requireUpper">{{'policyInEffectUppercase' | i18n}}</li>
         <li *ngIf="enforcedPolicyOptions?.requireLower">{{'policyInEffectLowercase' | i18n}}</li>
         <li *ngIf="enforcedPolicyOptions?.requireNumbers">{{'policyInEffectNumbers' | i18n}}</li>
-        <li *ngIf="enforcedPolicyOptions?.requireSpecial">{{'policyInEffectSpecial' | i18n}}</li>
+        <li *ngIf="enforcedPolicyOptions?.requireSpecial">{{'policyInEffectSpecial' | i18n : '!@#$%^&*'}}</li>
     </ul>
 </app-callout>
 

--- a/src/app/settings/change-password.component.ts
+++ b/src/app/settings/change-password.component.ts
@@ -84,7 +84,7 @@ export class ChangePasswordComponent implements OnInit {
             this.getPasswordStrengthUserInput());
 
         if (this.enforcedPolicyOptions != null &&
-            !(await this.policyService.evaluateMasterPassword(
+            !(this.policyService.evaluateMasterPassword(
                 strengthResult.score,
                 this.newMasterPassword,
                 this.enforcedPolicyOptions))) {

--- a/src/app/settings/change-password.component.ts
+++ b/src/app/settings/change-password.component.ts
@@ -84,10 +84,10 @@ export class ChangePasswordComponent implements OnInit {
             this.getPasswordStrengthUserInput());
 
         if (this.enforcedPolicyOptions != null &&
-            !(this.policyService.evaluateMasterPassword(
+            !this.policyService.evaluateMasterPassword(
                 strengthResult.score,
                 this.newMasterPassword,
-                this.enforcedPolicyOptions))) {
+                this.enforcedPolicyOptions)) {
             this.toasterService.popAsync('error', this.i18nService.t('errorOccurred'),
                 this.i18nService.t('masterPasswordPolicyRequirementsNotMet'));
             return;

--- a/src/app/settings/change-password.component.ts
+++ b/src/app/settings/change-password.component.ts
@@ -14,10 +14,12 @@ import { I18nService } from 'jslib/abstractions/i18n.service';
 import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { PasswordGenerationService } from 'jslib/abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { PolicyService } from 'jslib/abstractions/policy.service';
 import { SyncService } from 'jslib/abstractions/sync.service';
 import { UserService } from 'jslib/abstractions/user.service';
 
 import { CipherString } from 'jslib/models/domain/cipherString';
+import { MasterPasswordPolicyOptions } from 'jslib/models/domain/masterPasswordPolicyOptions';
 import { SymmetricCryptoKey } from 'jslib/models/domain/symmetricCryptoKey';
 
 import { CipherWithIdRequest } from 'jslib/models/request/cipherWithIdRequest';
@@ -36,6 +38,7 @@ export class ChangePasswordComponent implements OnInit {
     formPromise: Promise<any>;
     masterPasswordScore: number;
     rotateEncKey = false;
+    enforcedPolicyOptions: MasterPasswordPolicyOptions;
 
     private masterPasswordStrengthTimeout: any;
     private email: string;
@@ -45,10 +48,12 @@ export class ChangePasswordComponent implements OnInit {
         private cryptoService: CryptoService, private messagingService: MessagingService,
         private userService: UserService, private passwordGenerationService: PasswordGenerationService,
         private platformUtilsService: PlatformUtilsService, private folderService: FolderService,
-        private cipherService: CipherService, private syncService: SyncService) { }
+        private cipherService: CipherService, private syncService: SyncService,
+        private policyService: PolicyService) { }
 
     async ngOnInit() {
         this.email = await this.userService.getEmail();
+        this.enforcedPolicyOptions = await this.policyService.getMasterPasswordPolicyOptions();
     }
 
     async submit() {
@@ -77,6 +82,17 @@ export class ChangePasswordComponent implements OnInit {
 
         const strengthResult = this.passwordGenerationService.passwordStrength(this.newMasterPassword,
             this.getPasswordStrengthUserInput());
+
+        if (this.enforcedPolicyOptions != null &&
+            !(await this.policyService.evaluateMasterPassword(
+                strengthResult.score,
+                this.newMasterPassword,
+                this.enforcedPolicyOptions))) {
+            this.toasterService.popAsync('error', this.i18nService.t('errorOccurred'),
+                this.i18nService.t('masterPasswordPolicyRequirementsNotMet'));
+            return;
+        }
+
         if (strengthResult != null && strengthResult.score < 3) {
             const result = await this.platformUtilsService.showDialog(this.i18nService.t('weakMasterPasswordDesc'),
                 this.i18nService.t('weakMasterPassword'), this.i18nService.t('yes'), this.i18nService.t('no'),

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -2989,5 +2989,41 @@
   },
   "passwordGeneratorPolicyInEffect": {
     "message": "One or more organization policies are affecting your generator settings."
+  },
+  "masterPasswordPolicyInEffect": {
+    "message": "One or more organization policies require your master password to meet the following requirements:"
+  },
+  "policyInEffectMinComplexity": {
+    "message": "Minimum complexity score of $SCORE$",
+    "placeholders": {
+      "score": {
+        "content": "$1",
+        "example": "4"
+      }
+    }
+  },
+  "policyInEffectMinLength": {
+    "message": "Minimum length of $LENGTH$",
+    "placeholders": {
+      "length": {
+        "content": "$1",
+        "example": "14"
+      }
+    }
+  },
+  "policyInEffectUppercase": {
+    "message": "Contain one or more uppercase characters"
+  },
+  "policyInEffectLowercase": {
+    "message": "Contain one or more lowercase characters"
+  },
+  "policyInEffectNumbers": {
+    "message": "Contain one or more numbers"
+  },
+  "policyInEffectSpecial": {
+    "message": "Contain one or more of the following special characters !@#$%^&*"
+  },
+  "masterPasswordPolicyRequirementsNotMet": {
+    "message": "Your new master password does not meet the policy requirements."
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3021,7 +3021,13 @@
     "message": "Contain one or more numbers"
   },
   "policyInEffectSpecial": {
-    "message": "Contain one or more of the following special characters !@#$%^&*"
+    "message": "Contain one or more of the following special characters $CHARS$",
+    "placeholders": {
+      "chars": {
+        "content": "$1",
+        "example": "!@#$%^&*"
+      }
+    }
   },
   "masterPasswordPolicyRequirementsNotMet": {
     "message": "Your new master password does not meet the policy requirements."


### PR DESCRIPTION
## Objective
> Enforce Organizational policies regarding master password strength during the Change Password and Register Account (for Org Invite) flows. 

## Code Changes
- **register.component.html**: Added `app-callout` banner to alert users of policy restrictions that will be enforced during account creation within the org acceptance flow
- **register.component.ts**: Added logic to retrieve and enforce the organization's policy.  The above banner will be shown when applicable and on submit, the password will be evaluated. If there are no policies to evaluate, it is skipped and normal operations resume.
- **policy-edit.component.html**: Added a minimum value of 8 for the password length field. Users can leave the field empty if desired.
- **change-password.component.html**: Added `app-callout` banner to alert users of policy restrictions that will be enforced during the change password flow
- **change-password.component.ts**: Added logic to retrieve and enforce the organizations' policies.  The `app-callout` banner will be shown when applicable and on submit, the password will be evaluated. If there are no policies to evaluate, it is skipped and normal operations resume.
- **messages.json**: Added all necessary strings for the master password policy

## Org Acceptance
<img width="433" alt="0-mp-policy-create" src="https://user-images.githubusercontent.com/26154748/75790530-f0eb7e80-5d30-11ea-9f4a-91968f467fb1.png">
<img width="1087" alt="1-mp-policy-create-failure" src="https://user-images.githubusercontent.com/26154748/75790538-f34dd880-5d30-11ea-9c01-5d5bc23112bd.png">

## Change Password
<img width="761" alt="0-mp-policy-callout" src="https://user-images.githubusercontent.com/26154748/75790569-fd6fd700-5d30-11ea-9842-df84a1cbe32d.png">
<img width="1154" alt="1-mp-policy-failure" src="https://user-images.githubusercontent.com/26154748/75790574-fea10400-5d30-11ea-8ffb-f6b12c5da08d.png">


