### PR TITLE
Update complexity score display

### DIFF
--- a/src/app/accounts/register.component.html
+++ b/src/app/accounts/register.component.html
@@ -25,7 +25,7 @@
                             <p>{{'masterPasswordPolicyInEffect' | i18n}}</p>
                             <ul>
                                 <li *ngIf="enforcedPolicyOptions?.minComplexity > 0">
-                                    {{'policyInEffectMinComplexity' | i18n : enforcedPolicyOptions?.minComplexity.toString()}}
+                                    {{'policyInEffectMinComplexity' | i18n : getPasswordScoreAlertDisplay()}}
                                 </li>
                                 <li *ngIf="enforcedPolicyOptions?.minLength > 0">
                                     {{'policyInEffectMinLength' | i18n : enforcedPolicyOptions?.minLength.toString()}}

--- a/src/app/accounts/register.component.ts
+++ b/src/app/accounts/register.component.ts
@@ -46,20 +46,16 @@ export class RegisterComponent extends BaseRegisterComponent {
             return '';
         }
 
+        let str: string;
         switch (this.enforcedPolicyOptions.minComplexity) {
             case 4:
-                return this.i18nService.t('strong') + ' (4)';
+                str = this.i18nService.t('strong');
             case 3:
-                return this.i18nService.t('good') + ' (3)';
-            case 2:
-                return this.i18nService.t('weak') + ' (2)';
-            case 1:
-                return this.i18nService.t('weak') + ' (1)';
-            case 0:
-                return this.i18nService.t('weak') + ' (0)';
+                str = this.i18nService.t('good');
             default:
-                return '';
+                str = this.i18nService.t('weak');
         }
+        return str + ' (' + this.enforcedPolicyOptions.minComplexity + ')';
     }
 
     async ngOnInit() {

--- a/src/app/accounts/register.component.ts
+++ b/src/app/accounts/register.component.ts
@@ -27,9 +27,9 @@ import { PolicyData } from 'jslib/models/data/policyData';
 export class RegisterComponent extends BaseRegisterComponent {
     showCreateOrgMessage = false;
     showTerms = true;
+    enforcedPolicyOptions: MasterPasswordPolicyOptions;
 
     private policies: Policy[];
-    enforcedPolicyOptions: MasterPasswordPolicyOptions;
 
     constructor(authService: AuthService, router: Router,
         i18nService: I18nService, cryptoService: CryptoService,
@@ -39,6 +39,27 @@ export class RegisterComponent extends BaseRegisterComponent {
         super(authService, router, i18nService, cryptoService, apiService, stateService, platformUtilsService,
             passwordGenerationService);
         this.showTerms = !platformUtilsService.isSelfHost();
+    }
+
+    getPasswordScoreAlertDisplay() {
+        if (this.enforcedPolicyOptions == null) {
+            return '';
+        }
+
+        switch (this.enforcedPolicyOptions.minComplexity) {
+            case 4:
+                return this.i18nService.t('strong') + ' (4)';
+            case 3:
+                return this.i18nService.t('good') + ' (3)';
+            case 2:
+                return this.i18nService.t('weak') + ' (2)';
+            case 1:
+                return this.i18nService.t('weak') + ' (1)';
+            case 0:
+                return this.i18nService.t('weak') + ' (0)';
+            default:
+                return '';
+        }
     }
 
     async ngOnInit() {

--- a/src/app/organizations/manage/policy-edit.component.html
+++ b/src/app/organizations/manage/policy-edit.component.html
@@ -28,8 +28,10 @@
                     <div class="row">
                         <div class="col-6 form-group">
                             <label for="masterPassMinComplexity">{{'minComplexityScore' | i18n}}</label>
-                            <input id="masterPassMinComplexity" class="form-control" type="number"
-                                name="MasterPassMinComplexity" [(ngModel)]="masterPassMinComplexity" min="0" max="4">
+                            <select id="masterPassMinComplexity" name="MasterPassMinComplexity"
+                                [(ngModel)]="masterPassMinComplexity" class="form-control">
+                                <option *ngFor="let o of passwordScores" [ngValue]="o.value">{{o.name}}</option>
+                            </select>
                         </div>
                         <div class="col-6 form-group">
                             <label for="masterPassMinLength">{{'minLength' | i18n}}</label>

--- a/src/app/organizations/manage/policy-edit.component.ts
+++ b/src/app/organizations/manage/policy-edit.component.ts
@@ -33,6 +33,7 @@ export class PolicyEditComponent implements OnInit {
     loading = true;
     enabled = false;
     formPromise: Promise<any>;
+    passwordScores: any[];
 
     // Master password
 
@@ -56,7 +57,16 @@ export class PolicyEditComponent implements OnInit {
     private policy: PolicyResponse;
 
     constructor(private apiService: ApiService, private i18nService: I18nService,
-        private analytics: Angulartics2, private toasterService: ToasterService) { }
+        private analytics: Angulartics2, private toasterService: ToasterService) {
+        this.passwordScores = [
+            { name: '', value: null },
+            { name: i18nService.t('weak') + ' (0)', value: 0 },
+            { name: i18nService.t('weak') + ' (1)', value: 1 },
+            { name: i18nService.t('weak') + ' (2)', value: 2 },
+            { name: i18nService.t('good') + ' (3)', value: 3 },
+            { name: i18nService.t('strong') + ' (4)', value: 4 },
+        ];
+    }
 
     async ngOnInit() {
         await this.load();

--- a/src/app/settings/change-password.component.html
+++ b/src/app/settings/change-password.component.html
@@ -3,7 +3,7 @@
     <p>{{'masterPasswordPolicyInEffect' | i18n}}</p>
     <ul>
         <li *ngIf="enforcedPolicyOptions?.minComplexity > 0">
-            {{'policyInEffectMinComplexity' | i18n : enforcedPolicyOptions?.minComplexity.toString()}}
+            {{'policyInEffectMinComplexity' | i18n : getPasswordScoreAlertDisplay()}}
         </li>
         <li *ngIf="enforcedPolicyOptions?.minLength > 0">
             {{'policyInEffectMinLength' | i18n : enforcedPolicyOptions?.minLength.toString()}}

--- a/src/app/settings/change-password.component.ts
+++ b/src/app/settings/change-password.component.ts
@@ -61,20 +61,16 @@ export class ChangePasswordComponent implements OnInit {
             return '';
         }
 
+        let str: string;
         switch (this.enforcedPolicyOptions.minComplexity) {
             case 4:
-                return this.i18nService.t('strong') + ' (4)';
+                str = this.i18nService.t('strong');
             case 3:
-                return this.i18nService.t('good') + ' (3)';
-            case 2:
-                return this.i18nService.t('weak') + ' (2)';
-            case 1:
-                return this.i18nService.t('weak') + ' (1)';
-            case 0:
-                return this.i18nService.t('weak') + ' (0)';
+                str = this.i18nService.t('good');
             default:
-                return '';
+                str = this.i18nService.t('weak');
         }
+        return str + ' (' + this.enforcedPolicyOptions.minComplexity + ')';
     }
 
     async submit() {

--- a/src/app/settings/change-password.component.ts
+++ b/src/app/settings/change-password.component.ts
@@ -56,6 +56,27 @@ export class ChangePasswordComponent implements OnInit {
         this.enforcedPolicyOptions = await this.policyService.getMasterPasswordPolicyOptions();
     }
 
+    getPasswordScoreAlertDisplay() {
+        if (this.enforcedPolicyOptions == null) {
+            return '';
+        }
+
+        switch (this.enforcedPolicyOptions.minComplexity) {
+            case 4:
+                return this.i18nService.t('strong') + ' (4)';
+            case 3:
+                return this.i18nService.t('good') + ' (3)';
+            case 2:
+                return this.i18nService.t('weak') + ' (2)';
+            case 1:
+                return this.i18nService.t('weak') + ' (1)';
+            case 0:
+                return this.i18nService.t('weak') + ' (0)';
+            default:
+                return '';
+        }
+    }
+
     async submit() {
         const hasEncKey = await this.cryptoService.hasEncKey();
         if (!hasEncKey) {


### PR DESCRIPTION
## Objective
> Make the complexity score requirement less cryptic: add readable display strings for different scores

## Code Changes
- **register.component.html**: Updated string param to pull result from the `getPasswordScoreAlertDisplay()` function
- **register.component.ts**: Fixed lint warning with variable creation. Added helper method to return the correct display string for password scores
- **policy-edit.component.html**: Changed UI field to a dropdown and used the `passwordScores` list to populate it
- **policy-edit.component.ts**: Created `passwordScores` list for use in displaying readable scores
- **change-password.component.html**: Updated string param to pull result from the `getPasswordScoreAlertDisplay()` function
- **change-password.component.ts**: Added helper method to return the correct display string for password scores

## Screenshots
<img width="498" alt="0-mp-score" src="https://user-images.githubusercontent.com/26154748/75815152-864e3900-5d58-11ea-947f-fe432f8d8f8e.png">

<img width="776" alt="2-mp-change-score" src="https://user-images.githubusercontent.com/26154748/75815158-8a7a5680-5d58-11ea-83c5-8c8a0e2859da.png">

<img width="399" alt="2-mp-create-score" src="https://user-images.githubusercontent.com/26154748/75815164-8e0ddd80-5d58-11ea-822c-840047b51352.png">
