### PR TITLE
Enforce passphrase policy

### DIFF
--- a/src/app/organizations/manage/policy-edit.component.html
+++ b/src/app/organizations/manage/policy-edit.component.html
@@ -62,6 +62,16 @@
                 </ng-container>
                 <ng-container *ngIf="type === policyType.PasswordGenerator">
                     <div class="row">
+                        <div class="col-6 form-group  mb-0">
+                            <label for="passGenDefaultType">{{'passwordGeneratorPolicyDefaultType' | i18n}}</label>
+                            <select id="passGenDefaultType" name="PassGenDefaultType" [(ngModel)]="passGenDefaultType"
+                                class="form-control">
+                                <option *ngFor="let o of defaultTypes" [ngValue]="o.value">{{o.name}}</option>
+                            </select>
+                        </div>
+                    </div>
+                    <h3 class="mt-4">{{'password' | i18n}}</h3>
+                    <div class="row">
                         <div class="col-6 form-group">
                             <label for="passGenMinLength">{{'minLength' | i18n}}</label>
                             <input id="passGenMinLength" class="form-control" type="number" name="PassGenMinLength"
@@ -99,6 +109,24 @@
                         <input class="form-check-input" type="checkbox" id="passGenUseSpecial"
                             [(ngModel)]="passGenUseSpecial" name="PassGenUseSpecial">
                         <label class="form-check-label" for="passGenUseSpecial">!@#$%^&amp;*</label>
+                    </div>
+                    <h3 class="mt-4">{{'passphrase' | i18n}}</h3>
+                    <div class="row">
+                        <div class="col-6 form-group">
+                            <label for="passGenMinNumberWords">{{'minimumNumberOfWords' | i18n}}</label>
+                            <input id="passGenMinNumberWords" class="form-control" type="number"
+                                name="PassGenMinNumberWords" min="3" max="20" [(ngModel)]="passGenMinNumberWords">
+                        </div>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="passGenCapitalize"
+                            [(ngModel)]="passGenCapitalize" name="PassGenCapitalize">
+                        <label class="form-check-label" for="passGenCapitalize">{{'capitalize' | i18n}}</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="passGenIncludeNumber"
+                            [(ngModel)]="passGenIncludeNumber" name="PassGenIncludeNumber">
+                        <label class="form-check-label" for="passGenIncludeNumber">{{'includeNumber' | i18n}}</label>
                     </div>
                 </ng-container>
             </div>

--- a/src/app/organizations/manage/policy-edit.component.html
+++ b/src/app/organizations/manage/policy-edit.component.html
@@ -63,7 +63,7 @@
                 <ng-container *ngIf="type === policyType.PasswordGenerator">
                     <div class="row">
                         <div class="col-6 form-group  mb-0">
-                            <label for="passGenDefaultType">{{'passwordGeneratorPolicyDefaultType' | i18n}}</label>
+                            <label for="passGenDefaultType">{{'defaultType' | i18n}}</label>
                             <select id="passGenDefaultType" name="PassGenDefaultType" [(ngModel)]="passGenDefaultType"
                                 class="form-control">
                                 <option *ngFor="let o of defaultTypes" [ngValue]="o.value">{{o.name}}</option>

--- a/src/app/organizations/manage/policy-edit.component.ts
+++ b/src/app/organizations/manage/policy-edit.component.ts
@@ -72,7 +72,7 @@ export class PolicyEditComponent implements OnInit {
             { name: i18nService.t('strong') + ' (4)', value: 4 },
         ];
         this.defaultTypes = [
-            { name: i18nService.t('passwordGeneratorPolicyUserPreference'), value: '' },
+            { name: i18nService.t('userPreference'), value: null },
             { name: i18nService.t('password'), value: 'password' },
             { name: i18nService.t('passphrase'), value: 'passphrase' },
         ];
@@ -92,8 +92,7 @@ export class PolicyEditComponent implements OnInit {
                 if (this.policy.data != null) {
                     switch (this.type) {
                         case PolicyType.PasswordGenerator:
-                            this.passGenDefaultType = this.policy.data.defaultType == null
-                                ? '' : this.policy.data.defaultType;
+                            this.passGenDefaultType = this.policy.data.defaultType;
                             this.passGenMinLength = this.policy.data.minLength;
                             this.passGenUseUpper = this.policy.data.useUpper;
                             this.passGenUseLower = this.policy.data.useLower;

--- a/src/app/organizations/manage/policy-edit.component.ts
+++ b/src/app/organizations/manage/policy-edit.component.ts
@@ -34,6 +34,7 @@ export class PolicyEditComponent implements OnInit {
     enabled = false;
     formPromise: Promise<any>;
     passwordScores: any[];
+    defaultTypes: any[];
 
     // Master password
 
@@ -46,6 +47,7 @@ export class PolicyEditComponent implements OnInit {
 
     // Password generator
 
+    passGenDefaultType?: string;
     passGenMinLength?: number;
     passGenUseUpper?: boolean;
     passGenUseLower?: boolean;
@@ -53,6 +55,9 @@ export class PolicyEditComponent implements OnInit {
     passGenUseSpecial?: boolean;
     passGenMinNumbers?: number;
     passGenMinSpecial?: number;
+    passGenMinNumberWords?: number;
+    passGenCapitalize?: boolean;
+    passGenIncludeNumber?: boolean;
 
     private policy: PolicyResponse;
 
@@ -65,6 +70,11 @@ export class PolicyEditComponent implements OnInit {
             { name: i18nService.t('weak') + ' (2)', value: 2 },
             { name: i18nService.t('good') + ' (3)', value: 3 },
             { name: i18nService.t('strong') + ' (4)', value: 4 },
+        ];
+        this.defaultTypes = [
+            { name: i18nService.t('passwordGeneratorPolicyUserPreference'), value: '' },
+            { name: i18nService.t('password'), value: 'password' },
+            { name: i18nService.t('passphrase'), value: 'passphrase' },
         ];
     }
 
@@ -82,6 +92,8 @@ export class PolicyEditComponent implements OnInit {
                 if (this.policy.data != null) {
                     switch (this.type) {
                         case PolicyType.PasswordGenerator:
+                            this.passGenDefaultType = this.policy.data.defaultType == null
+                                ? '' : this.policy.data.defaultType;
                             this.passGenMinLength = this.policy.data.minLength;
                             this.passGenUseUpper = this.policy.data.useUpper;
                             this.passGenUseLower = this.policy.data.useLower;
@@ -89,6 +101,9 @@ export class PolicyEditComponent implements OnInit {
                             this.passGenUseSpecial = this.policy.data.useSpecial;
                             this.passGenMinNumbers = this.policy.data.minNumbers;
                             this.passGenMinSpecial = this.policy.data.minSpecial;
+                            this.passGenMinNumberWords = this.policy.data.minNumberWords;
+                            this.passGenCapitalize = this.policy.data.capitalize;
+                            this.passGenIncludeNumber = this.policy.data.includeNumber;
                             break;
                         case PolicyType.MasterPassword:
                             this.masterPassMinComplexity = this.policy.data.minComplexity;
@@ -120,6 +135,7 @@ export class PolicyEditComponent implements OnInit {
         switch (this.type) {
             case PolicyType.PasswordGenerator:
                 request.data = {
+                    defaultType: this.passGenDefaultType,
                     minLength: this.passGenMinLength || null,
                     useUpper: this.passGenUseUpper,
                     useLower: this.passGenUseLower,
@@ -127,6 +143,9 @@ export class PolicyEditComponent implements OnInit {
                     useSpecial: this.passGenUseSpecial,
                     minNumbers: this.passGenMinNumbers || null,
                     minSpecial: this.passGenMinSpecial || null,
+                    minNumberWords: this.passGenMinNumberWords || null,
+                    capitalize: this.passGenCapitalize,
+                    includeNumber: this.passGenIncludeNumber,
                 };
                 break;
             case PolicyType.MasterPassword:

--- a/src/app/tools/password-generator.component.html
+++ b/src/app/tools/password-generator.component.html
@@ -1,7 +1,7 @@
 <div class="page-header">
     <h1>{{'passwordGenerator' | i18n}}</h1>
 </div>
-<app-callout type="info" *ngIf="policyInEffect">
+<app-callout type="info" *ngIf="enforcedPolicyOptions?.inEffect()">
     {{'passwordGeneratorPolicyInEffect' | i18n}}
 </app-callout>
 <div class="card card-password bg-light my-4">
@@ -37,12 +37,12 @@
     <div class="form-group">
         <div class="form-check">
             <input id="capitalize" class="form-check-input" type="checkbox" (change)="saveOptions()"
-                [(ngModel)]="options.capitalize">
+                [(ngModel)]="options.capitalize" [disabled]="enforcedPolicyOptions?.capitalize">
             <label for="capitalize" class="form-check-label">{{'capitalize' | i18n}}</label>
         </div>
         <div class="form-check">
             <input id="include-number" class="form-check-input" type="checkbox" (change)="saveOptions()"
-                [(ngModel)]="options.includeNumber">
+                [(ngModel)]="options.includeNumber" [disabled]="enforcedPolicyOptions?.includeNumber">
             <label for="include-number" class="form-check-label">{{'includeNumber' | i18n}}</label>
         </div>
     </div>

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3031,5 +3031,20 @@
   },
   "masterPasswordPolicyRequirementsNotMet": {
     "message": "Your new master password does not meet the policy requirements."
+  },
+  "allowPassword": {
+    "message": "Allow users to generate passwords"
+  },
+  "allowPassphrase": {
+    "message": "Allow users to generate passphrases"
+  },
+  "minimumNumberOfWords": {
+    "message": "Minimum Number of Words"
+  },
+  "passwordGeneratorPolicyDefaultType": {
+    "message": "Default Type"
+  },
+  "passwordGeneratorPolicyUserPreference": {
+    "message": "User Preference"
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3032,12 +3032,6 @@
   "masterPasswordPolicyRequirementsNotMet": {
     "message": "Your new master password does not meet the policy requirements."
   },
-  "allowPassword": {
-    "message": "Allow users to generate passwords"
-  },
-  "allowPassphrase": {
-    "message": "Allow users to generate passphrases"
-  },
   "minimumNumberOfWords": {
     "message": "Minimum Number of Words"
   },

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3035,10 +3035,10 @@
   "minimumNumberOfWords": {
     "message": "Minimum Number of Words"
   },
-  "passwordGeneratorPolicyDefaultType": {
+  "defaultType": {
     "message": "Default Type"
   },
-  "passwordGeneratorPolicyUserPreference": {
+  "userPreference": {
     "message": "User Preference"
   }
 }


### PR DESCRIPTION
## Objective
> Add missing components for passphrase policy. Use existing data structures/patterns to implement a shared password generator (password/passphrase)

## Code Changes
- **policy-edit.component.html**: Added default types dropdown along with fields needed to enforce passphrase generation (minimum number of words, capitlize, and include numbers)
- **policy-edit.component.ts**: Created default types list and updated the loading/submitting of password generator policy settings to include passphrase options.
- **password-generator.component.html**: Updated existing fields to respect potentially enforced options for passphrase generation
- **messages.json**: Added new strings

## Screenshots
### Default
<img width="497" alt="0-pgp-default" src="https://user-images.githubusercontent.com/26154748/76353233-5c5bc000-62de-11ea-8c37-b399f766de76.png">

### Filled
<img width="497" alt="1-pgp-full" src="https://user-images.githubusercontent.com/26154748/76353264-6978af00-62de-11ea-9183-60f99c62b2e1.png">

### Passphrase Default Applied
<img width="760" alt="2-pgp-passphrase" src="https://user-images.githubusercontent.com/26154748/76353284-71385380-62de-11ea-8b68-361d25e050e3.png">


