### PR TITLE
[Soft Delete] - Deleted message (sent to trash)

### DIFF
--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -461,10 +461,10 @@
     "message": "Are you sure you want to delete this item?"
   },
   "deletedItem": {
-    "message": "Deleted item"
+    "message": "Item sent to trash"
   },
   "deletedItems": {
-    "message": "Deleted items"
+    "message": "Items sent to trash"
   },
   "movedItems": {
     "message": "Moved items"
@@ -2249,7 +2249,7 @@
     }
   },
   "deletedItemId": {
-    "message": "Deleted item $ID$.",
+    "message": "Sent item $ID$ to trash.",
     "placeholders": {
       "id": {
         "content": "$1",


### PR DESCRIPTION
Updated deleted messages for the toast displayed when an item is really soft-deleted (sent to trash) vs. permanently deleted.