### PR TITLE
Null check `allUsers`

### DIFF
--- a/src/app/organizations/manage/people.component.ts
+++ b/src/app/organizations/manage/people.component.ts
@@ -122,7 +122,7 @@ export class PeopleComponent implements OnInit {
     }
 
     get allCount() {
-        return this.allUsers.length;
+        return this.allUsers != null ? this.allUsers.length : 0;
     }
 
     get invitedCount() {


### PR DESCRIPTION
Causes errors on the initial page load.