### PR TITLE
fix: package.json info

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "bitwarden-web",
   "version": "2.13.2",
+  "license": "GPL-3.0",
+  "repository": "https://github.com/bitwarden/web",
   "scripts": {
     "sub:init": "git submodule update --init --recursive",
     "sub:update": "git submodule update --remote",


### PR DESCRIPTION
This additions fix the `npm WARN issues`:

- npm WARN bitwarden-web@2.13.2 No repository field.
- npm WARN bitwarden-web@2.13.2 No license field.