### PR TITLE
fix: icons, labels and check boxes vertical align

### DIFF
--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -406,6 +406,7 @@ input[type="search"]::-webkit-search-cancel-button {
         width: 45px;
         max-width: 45px;
         text-align: center;
+        line-height: 0;
 
         img {
             @extend .rounded;
@@ -417,6 +418,7 @@ input[type="search"]::-webkit-search-cancel-button {
     td.table-list-checkbox {
         width: 35px;
         max-width: 35px;
+        line-height: 0;
     }
 
     td.table-list-strike {
@@ -738,6 +740,11 @@ app-user-billing {
     &:not(.mt-2) {
         @extend .mt-3;
     }
+}
+
+.form-check-label {
+    margin: 0.3rem 0 0 0.3rem;
+    line-height: 16px;
 }
 
 .form-inline {


### PR DESCRIPTION
Check box elements, site icons and labels were not properly vertically aligned.  
Setting up the `line-height: 0;` on few elements, and also new properties for `.form-check-label` class, fix those issues.