### PR TITLE
Fix text overflow css in special characters label

### DIFF
--- a/src/app/tools/password-generator.component.html
+++ b/src/app/tools/password-generator.component.html
@@ -60,7 +60,7 @@
                 [(ngModel)]="options.minNumber" (change)="minNumberChanged()">
         </div>
         <div class="form-group col-4">
-            <label for="min-special">{{'minSpecial' | i18n}}</label>
+            <label class="min-inline-size-fix" for="min-special">{{'minSpecial' | i18n}}</label>
             <input id="min-special" class="form-control" type="number" min="0" max="9" (blur)="saveOptions()"
                 [(ngModel)]="options.minSpecial" (change)="minSpecialChanged()">
         </div>

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -832,3 +832,7 @@ img.logo {
 .cursor-move {
     cursor: move !important;
 }
+
+.min-inline-size-fix{
+    min-inline-size: max-content;
+}


### PR DESCRIPTION
Fixes the unexpected behavior reported in #503 

_Password generator page element is out of alignment after changing the language_