### PR TITLE
Closed alerts on lock

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -203,6 +203,8 @@ export class AppComponent implements OnDestroy, OnInit {
                 this.toasterService.popAsync('warning', this.i18nService.t('loggedOut'),
                     this.i18nService.t('loginExpired'));
             }
+
+            Swal.close();
             this.router.navigate(['/']);
         });
     }


### PR DESCRIPTION
## Code changes
Close any alerts that might be open when locking the client after inactivity, before rerouting back to the home screen

Closes #535 