### PR TITLE
Consistent: Replaced the clipboard icon with a clone icon to improve UX

### DIFF
--- a/src/app/tools/password-generator-history.component.html
+++ b/src/app/tools/password-generator-history.component.html
@@ -17,7 +17,7 @@
                     <div class="ml-auto">
                         <button class="btn btn-link" appA11yTitle="{{'copyPassword' | i18n}}"
                             (click)="copy(h.password)">
-                            <i class="fa fa-lg fa-clipboard" aria-hidden="true"></i>
+                            <i class="fa fa-lg fa-clone" aria-hidden="true"></i>
                         </button>
                     </div>
                 </li>

--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -44,7 +44,7 @@
                                     <button type="button" class="btn btn-outline-secondary"
                                         appA11yTitle="{{'copyUsername' | i18n}}"
                                         (click)="copy(cipher.login.username, 'username', 'Username')" tabindex="-1">
-                                        <i class="fa fa-lg fa-clipboard" aria-hidden="true"></i>
+                                        <i class="fa fa-lg fa-clone" aria-hidden="true"></i>
                                     </button>
                                 </div>
                             </div>
@@ -84,7 +84,7 @@
                                         appA11yTitle="{{'copyPassword' | i18n}}"
                                         (click)="copy(cipher.login.password, 'password', 'Password')" tabindex="-1"
                                         [disabled]="!cipher.viewPassword">
-                                        <i class="fa fa-lg fa-clipboard" aria-hidden="true"></i>
+                                        <i class="fa fa-lg fa-clone" aria-hidden="true"></i>
                                     </button>
                                 </div>
                             </div>
@@ -126,7 +126,7 @@
                                 <button type="button" class="btn btn-link"
                                     appA11yTitle="{{'copyVerificationCode' | i18n}}"
                                     (click)="copy(totpCode, 'verificationCodeTotp', 'TOTP')">
-                                    <i class="fa fa-clipboard" aria-hidden="true"></i>
+                                    <i class="fa fa-clone" aria-hidden="true"></i>
                                 </button>
                             </div>
                         </div>
@@ -148,7 +148,7 @@
                                         <button type="button" class="btn btn-outline-secondary"
                                             appA11yTitle="{{'copyUri' | i18n}}" (click)="copy(u.uri, 'uri', 'URI')"
                                             tabindex="-1">
-                                            <i class="fa fa-lg fa-clipboard" aria-hidden="true"></i>
+                                            <i class="fa fa-lg fa-clone" aria-hidden="true"></i>
                                         </button>
                                     </div>
                                 </div>
@@ -209,7 +209,7 @@
                                     <button type="button" class="btn btn-outline-secondary"
                                         appA11yTitle="{{'copyNumber' | i18n}}"
                                         (click)="copy(cipher.card.number, 'number', 'Number')" tabindex="-1">
-                                        <i class="fa fa-lg fa-clipboard" aria-hidden="true"></i>
+                                        <i class="fa fa-lg fa-clone" aria-hidden="true"></i>
                                     </button>
                                 </div>
                             </div>
@@ -246,7 +246,7 @@
                                     <button type="button" class="btn btn-outline-secondary"
                                         appA11yTitle="{{'securityCode' | i18n}}"
                                         (click)="copy(cipher.card.code, 'securityCode', 'Security Code')" tabindex="-1">
-                                        <i class="fa fa-lg fa-clipboard" aria-hidden="true"></i>
+                                        <i class="fa fa-lg fa-clone" aria-hidden="true"></i>
                                     </button>
                                 </div>
                             </div>
@@ -395,7 +395,7 @@
                                         <button type="button" class="btn btn-outline-secondary"
                                             appA11yTitle="{{'copyValue' | i18n}}"
                                             (click)="copy(f.value, 'value', 'Field')" tabindex="-1">
-                                            <i class="fa fa-lg fa-clipboard" aria-hidden="true"></i>
+                                            <i class="fa fa-lg fa-clone" aria-hidden="true"></i>
                                         </button>
                                     </div>
                                 </div>
@@ -416,7 +416,7 @@
                                             appA11yTitle="{{'copyValue' | i18n}}"
                                             (click)="copy(f.value, 'value', f.type === fieldType.Hidden ? 'H_Field' : 'Field')"
                                             tabindex="-1" [disabled]="!cipher.viewPassword && !f.newField">
-                                            <i class="fa fa-lg fa-clipboard" aria-hidden="true"></i>
+                                            <i class="fa fa-lg fa-clone" aria-hidden="true"></i>
                                         </button>
                                     </div>
                                 </div>

--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -55,7 +55,7 @@
                             <a class="dropdown-item" href="#" appStopClick
                                 *ngIf="((!organization && !c.organizationId) || organization) && !c.isDeleted"
                                 (click)="clone(c)">
-                                <i class="fa fa-fw fa-clone" aria-hidden="true"></i>
+                                <i class="fa fa-fw fa-files-o" aria-hidden="true"></i>
                                 {{'clone' | i18n}}
                             </a>
                             <a class="dropdown-item" href="#" appStopClick 

--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -39,7 +39,7 @@
                             <ng-container *ngIf="c.type === cipherType.Login && !c.isDeleted">
                                 <a class="dropdown-item" href="#" appStopClick
                                     (click)="copy(c, c.login.password, 'password', 'password')" *ngIf="c.viewPassword">
-                                    <i class="fa fa-fw fa-clipboard" aria-hidden="true"></i>
+                                    <i class="fa fa-fw fa-clone" aria-hidden="true"></i>
                                     {{'copyPassword' | i18n}}
                                 </a>
                                 <a class="dropdown-item" href="#" appStopClick *ngIf="c.login.canLaunch"


### PR DESCRIPTION
According to: https://github.com/bitwarden/desktop/pull/490

Replace the "copy value" icon with `fa-clone`.