### PR TITLE
Fix modal-body div missing #583

### DIFF
--- a/src/app/organizations/manage/collections.component.ts
+++ b/src/app/organizations/manage/collections.component.ts
@@ -85,7 +85,7 @@ export class CollectionsComponent implements OnInit {
     }
 
     loadMore() {
-        if (!this.collections || this.collections.length <= this.pageSize) {
+        if (this.collections.length <= this.pageSize) {
             return;
         }
         const pagedLength = this.pagedCollections.length;
@@ -185,7 +185,7 @@ export class CollectionsComponent implements OnInit {
         if (searching && this.didScroll) {
             this.resetPaging();
         }
-        return !searching && this.collections && this.collections.length > this.pageSize;
+        return !searching && this.collections.length > this.pageSize;
     }
 
     private removeCollection(collection: CollectionView) {

--- a/src/app/organizations/manage/collections.component.ts
+++ b/src/app/organizations/manage/collections.component.ts
@@ -85,7 +85,7 @@ export class CollectionsComponent implements OnInit {
     }
 
     loadMore() {
-        if (this.collections.length <= this.pageSize) {
+        if (!this.collections || this.collections.length <= this.pageSize) {
             return;
         }
         const pagedLength = this.pagedCollections.length;
@@ -185,7 +185,7 @@ export class CollectionsComponent implements OnInit {
         if (searching && this.didScroll) {
             this.resetPaging();
         }
-        return !searching && this.collections.length > this.pageSize;
+        return !searching && this.collections && this.collections.length > this.pageSize;
     }
 
     private removeCollection(collection: CollectionView) {

--- a/src/app/organizations/manage/groups.component.ts
+++ b/src/app/organizations/manage/groups.component.ts
@@ -81,7 +81,7 @@ export class GroupsComponent implements OnInit {
     }
 
     loadMore() {
-        if (this.groups.length <= this.pageSize) {
+        if (!this.groups || this.groups.length <= this.pageSize) {
             return;
         }
         const pagedLength = this.pagedGroups.length;
@@ -179,7 +179,7 @@ export class GroupsComponent implements OnInit {
         if (searching && this.didScroll) {
             this.resetPaging();
         }
-        return !searching && this.groups.length > this.pageSize;
+        return !searching && this.groups && this.groups.length > this.pageSize;
     }
 
     private removeGroup(group: GroupResponse) {

--- a/src/app/organizations/manage/groups.component.ts
+++ b/src/app/organizations/manage/groups.component.ts
@@ -81,7 +81,7 @@ export class GroupsComponent implements OnInit {
     }
 
     loadMore() {
-        if (!this.groups || this.groups.length <= this.pageSize) {
+        if (this.groups.length <= this.pageSize) {
             return;
         }
         const pagedLength = this.pagedGroups.length;
@@ -179,7 +179,7 @@ export class GroupsComponent implements OnInit {
         if (searching && this.didScroll) {
             this.resetPaging();
         }
-        return !searching && this.groups && this.groups.length > this.pageSize;
+        return !searching && this.groups.length > this.pageSize;
     }
 
     private removeGroup(group: GroupResponse) {

--- a/src/app/organizations/manage/people.component.ts
+++ b/src/app/organizations/manage/people.component.ts
@@ -129,7 +129,7 @@ export class PeopleComponent implements OnInit {
     }
 
     loadMore() {
-        if (!this.users || this.users.length <= this.pageSize) {
+        if (this.users.length <= this.pageSize) {
             return;
         }
         const pagedLength = this.pagedUsers.length;
@@ -331,7 +331,7 @@ export class PeopleComponent implements OnInit {
         if (searching && this.didScroll) {
             this.resetPaging();
         }
-        return !searching && this.users && this.users.length > this.pageSize;
+        return !searching && this.users.length > this.pageSize;
     }
 
     private async doConfirmation(user: OrganizationUserUserDetailsResponse) {

--- a/src/app/organizations/manage/people.component.ts
+++ b/src/app/organizations/manage/people.component.ts
@@ -129,7 +129,7 @@ export class PeopleComponent implements OnInit {
     }
 
     loadMore() {
-        if (this.users.length <= this.pageSize) {
+        if (!this.users || this.users.length <= this.pageSize) {
             return;
         }
         const pagedLength = this.pagedUsers.length;
@@ -331,7 +331,7 @@ export class PeopleComponent implements OnInit {
         if (searching && this.didScroll) {
             this.resetPaging();
         }
-        return !searching && this.users.length > this.pageSize;
+        return !searching && this.users && this.users.length > this.pageSize;
     }
 
     private async doConfirmation(user: OrganizationUserUserDetailsResponse) {


### PR DESCRIPTION
Fixes #583 

This was originally introduced by #539 (paging) which caused, on initial render, the `this.users`, `this.collections` and/or `this.groups` arrays to not yet be initialized (were `undefined` or `null` and therefore caused JavaScript exceptions). This didn't impact other functionality because they would later become initialized and paging would work appropriately. However, if you clicked on a category/filter that was empty, and then tried to click "Add/Invite", etc., it would cause a re-render/init call based on Angular's 2-way bindings (for `isPaging()` and `reload()`) and these arrays would once again be `null` and/or `undefined` causing an exception and failing to render the component in the modal body once launched.