### PR TITLE
List cipher's collections in cipher add-edit component

### DIFF
--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -106,7 +106,7 @@ const cipherService = new CipherService(cryptoService, userService, settingsServ
 const folderService = new FolderService(cryptoService, userService, apiService, storageService,
     i18nService, cipherService);
 const collectionService = new CollectionService(cryptoService, userService, storageService, cipherService, i18nService);
-searchService = new SearchService(cipherService, platformUtilsService);
+searchService = new SearchService(cipherService);
 const policyService = new PolicyService(userService, storageService);
 const vaultTimeoutService = new VaultTimeoutService(cipherService, folderService, collectionService,
     cryptoService, platformUtilsService, storageService, messagingService, searchService, userService, tokenService,

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -105,7 +105,7 @@ const cipherService = new CipherService(cryptoService, userService, settingsServ
     apiService, storageService, i18nService, () => searchService);
 const folderService = new FolderService(cryptoService, userService, apiService, storageService,
     i18nService, cipherService);
-const collectionService = new CollectionService(cryptoService, userService, storageService, i18nService);
+const collectionService = new CollectionService(cryptoService, userService, storageService, cipherService, i18nService);
 searchService = new SearchService(cipherService, platformUtilsService);
 const policyService = new PolicyService(userService, storageService);
 const vaultTimeoutService = new VaultTimeoutService(cipherService, folderService, collectionService,

--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -476,6 +476,10 @@
                 </ng-container>
                 <ng-container *ngIf="editMode">
                     <div class="small text-muted mt-4">
+                        <div *ngIf="cipherCollectionNames.length > 0">
+                            <b class="font-weight-semibold">Collections: </b>
+                            <span>{{cipherCollectionNames.join(", ")}}</span>
+                        </div>
                         <div>
                             <b class="font-weight-semibold">{{'dateUpdated' | i18n}}:</b>
                             {{cipher.revisionDate | date:'medium'}}

--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -477,7 +477,7 @@
                 <ng-container *ngIf="editMode">
                     <div class="small text-muted mt-4">
                         <div *ngIf="cipherCollectionNames.length > 0">
-                            <b class="font-weight-semibold">Collections: </b>
+                            <b class="font-weight-semibold">{{'collections' | i18n}}: </b>
                             <span>{{cipherCollectionNames.join(", ")}}</span>
                         </div>
                         <div>

--- a/src/app/vault/add-edit.component.ts
+++ b/src/app/vault/add-edit.component.ts
@@ -178,8 +178,8 @@ export class AddEditComponent extends BaseAddEditComponent {
 
     private async getCipherCollectionNames(): Promise<string[]> {
         const collectionNames: string[] = [];
-        for (const id of this.cipher.collectionIds) {
-            const collection = await this.collectionService.get(id);
+        const cipherCollections = await this.collectionService.getManyByCipherId(this.cipherId);
+        for (const collection of cipherCollections) {
             const name = await collection.name.decrypt(this.cipher.organizationId)
             collectionNames.push(name)
         }

--- a/src/app/vault/add-edit.component.ts
+++ b/src/app/vault/add-edit.component.ts
@@ -35,6 +35,7 @@ export class AddEditComponent extends BaseAddEditComponent {
     viewingPasswordHistory = false;
 
     protected totpInterval: number;
+    protected cipherCollectionNames: string[];
 
     constructor(cipherService: CipherService, folderService: FolderService,
         i18nService: I18nService, platformUtilsService: PlatformUtilsService,
@@ -63,6 +64,11 @@ export class AddEditComponent extends BaseAddEditComponent {
             this.totpInterval = window.setInterval(async () => {
                 await this.totpTick(interval);
             }, 1000);
+        }
+        if (this.cipher.collectionIds?.length > 0 && this.cipher.organizationId) {
+            this.getCipherCollectionNames().then(collectionNames => {
+                this.cipherCollectionNames = collectionNames;
+            })
         }
     }
 
@@ -168,5 +174,15 @@ export class AddEditComponent extends BaseAddEditComponent {
         if (mod === 0) {
             await this.totpUpdateCode();
         }
+    }
+
+    private async getCipherCollectionNames(): Promise<string[]> {
+        const collectionNames: string[] = [];
+        for (const id of this.cipher.collectionIds) {
+            const collection = await this.collectionService.get(id);
+            const name = await collection.name.decrypt(this.cipher.organizationId)
+            collectionNames.push(name)
+        }
+        return collectionNames.sort()
     }
 }


### PR DESCRIPTION
Since I thought it would be nice and more convenient to see the collections of a password entry when clicking on it, instead of heaving to use the Options > Collections menu and scroll through maybe dozens of collections. So I added a view lines to add a small comma-separated read-only collection list at the end of the add-edit component.
If you have suggestion for improvements (design-wise, code-wise, etc), please let me know I and I will adjust it accordingly.

![BW-Web-PR](https://user-images.githubusercontent.com/28662686/92906593-e3702900-f424-11ea-9ba1-5eee8d797aa0.png)
