### PR TITLE
only use memory storage for vault data keys

### DIFF
--- a/src/services/htmlStorage.service.ts
+++ b/src/services/htmlStorage.service.ts
@@ -9,7 +9,8 @@ export class HtmlStorageService implements StorageService {
         ConstantsService.vaultTimeoutKey, ConstantsService.vaultTimeoutActionKey, ConstantsService.ssoCodeVerifierKey,
         ConstantsService.ssoStateKey, 'ssoOrgIdentifier']);
     private localStorageStartsWithKeys = ['twoFactorToken_', ConstantsService.collapsedGroupingsKey + '_'];
-    private sessionMemoryStorage = new Map<string, string>()
+    private memoryStorageStartsWithKeys = ['ciphers_', 'folders_', 'collections_', 'settings_'];
+    private memoryStorage = new Map<string, string>()
 
     constructor(private platformUtilsService: PlatformUtilsService) { }
 
@@ -31,8 +32,10 @@ export class HtmlStorageService implements StorageService {
         let json: string = null;
         if (this.isLocalStorage(key)) {
             json = window.localStorage.getItem(key);
+        } else if (this.isMemoryStorage(key)) {
+            json = this.memoryStorage.get(key);
         } else {
-            json = this.sessionMemoryStorage.get(key);
+            json = window.sessionStorage.getItem(key);
         }
         if (json != null) {
             const obj = JSON.parse(json);
@@ -49,8 +52,10 @@ export class HtmlStorageService implements StorageService {
         const json = JSON.stringify(obj);
         if (this.isLocalStorage(key)) {
             window.localStorage.setItem(key, json);
+        } else if (this.isMemoryStorage(key)) {
+            this.memoryStorage.set(key, json);
         } else {
-            this.sessionMemoryStorage.set(key, json);
+            window.sessionStorage.setItem(key, json);
         }
         return Promise.resolve();
     }
@@ -58,8 +63,10 @@ export class HtmlStorageService implements StorageService {
     remove(key: string): Promise<any> {
         if (this.isLocalStorage(key)) {
             window.localStorage.removeItem(key);
+        } else if (this.isMemoryStorage(key)) {
+            this.memoryStorage.delete(key);
         } else {
-            this.sessionMemoryStorage.delete(key);
+            window.sessionStorage.removeItem(key);
         }
         return Promise.resolve();
     }
@@ -69,6 +76,15 @@ export class HtmlStorageService implements StorageService {
             return true;
         }
         for (const swKey of this.localStorageStartsWithKeys) {
+            if (key.startsWith(swKey)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private isMemoryStorage(key: string): boolean {
+        for (const swKey of this.memoryStorageStartsWithKeys) {
             if (key.startsWith(swKey)) {
                 return true;
             }

--- a/src/services/htmlStorage.service.ts
+++ b/src/services/htmlStorage.service.ts
@@ -9,7 +9,7 @@ export class HtmlStorageService implements StorageService {
         ConstantsService.vaultTimeoutKey, ConstantsService.vaultTimeoutActionKey, ConstantsService.ssoCodeVerifierKey,
         ConstantsService.ssoStateKey, 'ssoOrgIdentifier']);
     private localStorageStartsWithKeys = ['twoFactorToken_', ConstantsService.collapsedGroupingsKey + '_'];
-    private memoryStorageStartsWithKeys = ['ciphers_', 'folders_', 'collections_', 'settings_'];
+    private memoryStorageStartsWithKeys = ['ciphers_', 'folders_', 'collections_', 'settings_', 'lastSync_'];
     private memoryStorage = new Map<string, string>()
 
     constructor(private platformUtilsService: PlatformUtilsService) { }


### PR DESCRIPTION
Recently I changed this storage service to use memory storage instead of session storage to address the limitations with session storage lengths. This was probably a bit too aggressive since the only keys were data grows large is in the vault. This change adds checks for only using memory storage for specific vault data keys so that other keys can still use session storage. This prevents things like the user being logged out completely on page refresh.