### PR TITLE
653 - fix user agent detection for Edge

### DIFF
--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -106,7 +106,7 @@ const cipherService = new CipherService(cryptoService, userService, settingsServ
 const folderService = new FolderService(cryptoService, userService, apiService, storageService,
     i18nService, cipherService);
 const collectionService = new CollectionService(cryptoService, userService, storageService, i18nService);
-searchService = new SearchService(cipherService, platformUtilsService);
+searchService = new SearchService(cipherService);
 const policyService = new PolicyService(userService, storageService);
 const vaultTimeoutService = new VaultTimeoutService(cipherService, folderService, collectionService,
     cryptoService, platformUtilsService, storageService, messagingService, searchService, userService, tokenService,

--- a/src/services/webPlatformUtils.service.ts
+++ b/src/services/webPlatformUtils.service.ts
@@ -24,7 +24,7 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
             this.browserCache = DeviceType.FirefoxBrowser;
         } else if (navigator.userAgent.indexOf(' OPR/') >= 0) {
             this.browserCache = DeviceType.OperaBrowser;
-        } else if (navigator.userAgent.indexOf(' Edge/') !== -1 || navigator.userAgent.indexOf(' Edg/') !== -1) {
+        } else if (navigator.userAgent.indexOf(' Edg/') !== -1) {
             this.browserCache = DeviceType.EdgeBrowser;
         } else if (navigator.userAgent.indexOf(' Vivaldi/') !== -1) {
             this.browserCache = DeviceType.VivaldiBrowser;

--- a/src/services/webPlatformUtils.service.ts
+++ b/src/services/webPlatformUtils.service.ts
@@ -24,7 +24,7 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
             this.browserCache = DeviceType.FirefoxBrowser;
         } else if (navigator.userAgent.indexOf(' OPR/') >= 0) {
             this.browserCache = DeviceType.OperaBrowser;
-        } else if (navigator.userAgent.indexOf(' Edge/') !== -1) {
+        } else if (navigator.userAgent.indexOf(' Edge/') !== -1 || navigator.userAgent.indexOf(' Edg/') !== -1) {
             this.browserCache = DeviceType.EdgeBrowser;
         } else if (navigator.userAgent.indexOf(' Vivaldi/') !== -1) {
             this.browserCache = DeviceType.VivaldiBrowser;


### PR DESCRIPTION
Fixes and closes #653 

## Overview
This is caused by the Edge browser detection from the user-agent string provided by the Edge browser, which Microsoft changed to use the `Edg/` token vs. the `Edge/` token previously used to help differentiate over confusion from the prior, Trident based IE Edge browser.