### PR TITLE
Default selection plan upgrade fix

### DIFF
--- a/src/app/organizations/settings/change-plan.component.html
+++ b/src/app/organizations/settings/change-plan.component.html
@@ -4,8 +4,8 @@
                 aria-hidden="true">&times;</span></button>
         <h2 class="card-body-header">{{'changeBillingPlan' | i18n}}</h2>
         <p class="mb-0">{{'changeBillingPlanUpgrade' | i18n}}</p>
-        <app-organization-plans [showFree]="false" [showCancel]="true" plan="families" [organizationId]="organizationId"
-            (onCanceled)="cancel()">
+        <app-organization-plans [showFree]="false" [showCancel]="true" [plan]="defaultUpgradePlan"
+            [product]="defaultUpgradeProduct" [organizationId]="organizationId" (onCanceled)="cancel()">
         </app-organization-plans>
     </div>
 </div>

--- a/src/app/organizations/settings/change-plan.component.ts
+++ b/src/app/organizations/settings/change-plan.component.ts
@@ -8,6 +8,9 @@ import {
 import { ApiService } from 'jslib/abstractions/api.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 
+import { PlanType } from 'jslib/enums/planType';
+import { ProductType } from 'jslib/enums/productType';
+
 @Component({
     selector: 'app-change-plan',
     templateUrl: 'change-plan.component.html',
@@ -18,6 +21,8 @@ export class ChangePlanComponent {
     @Output() onCanceled = new EventEmitter();
 
     formPromise: Promise<any>;
+    defaultUpgradePlan: PlanType = PlanType.FamiliesAnnually;
+    defaultUpgradeProduct: ProductType = ProductType.Families
 
     constructor(private apiService: ApiService, private platformUtilsService: PlatformUtilsService) { }
 

--- a/src/app/organizations/settings/change-plan.component.ts
+++ b/src/app/organizations/settings/change-plan.component.ts
@@ -22,7 +22,7 @@ export class ChangePlanComponent {
 
     formPromise: Promise<any>;
     defaultUpgradePlan: PlanType = PlanType.FamiliesAnnually;
-    defaultUpgradeProduct: ProductType = ProductType.Families
+    defaultUpgradeProduct: ProductType = ProductType.Families;
 
     constructor(private apiService: ApiService, private platformUtilsService: PlatformUtilsService) { }
 


### PR DESCRIPTION
### Issue
Changing plan & product information to use enums broke the default selection of "Families" when upgrading a free org

### Solution
Passing the correct enum to the organization plans component from the change plan component fixes this, and Families is selected by default