### PR TITLE
[Require SSO] Enterprise policy adjustment

### DIFF
--- a/src/app/organizations/manage/policies.component.html
+++ b/src/app/organizations/manage/policies.component.html
@@ -13,7 +13,7 @@
 <table class="table table-hover table-list" *ngIf="!loading">
     <tbody>
         <tr *ngFor="let p of policies">
-            <td>
+            <td *ngIf="p.display">
                 <a href="#" appStopClick (click)="edit(p)">{{p.name}}</a>
                 <span class="badge badge-success" *ngIf="p.enabled">{{'enabled' | i18n}}</span>
                 <small class="text-muted d-block">{{p.description}}</small>

--- a/src/app/organizations/manage/policies.component.ts
+++ b/src/app/organizations/manage/policies.component.ts
@@ -34,6 +34,7 @@ export class PoliciesComponent implements OnInit {
 
     loading = true;
     organizationId: string;
+    orgIdentifier: string;
     policies: any[];
 
     // Remove when removing deprecation warning
@@ -85,6 +86,7 @@ export class PoliciesComponent implements OnInit {
                 this.router.navigate(['/organizations', this.organizationId]);
                 return;
             }
+            this.orgIdentifier = organization.identifier;
             this.updatePolicyVisibility(organization);
             await this.load();
         });
@@ -125,6 +127,7 @@ export class PoliciesComponent implements OnInit {
         childComponent.type = p.type;
         childComponent.organizationId = this.organizationId;
         childComponent.policiesEnabledMap = this.policiesEnabledMap;
+        childComponent.orgIdentifier = this.orgIdentifier;
         childComponent.onSavedPolicy.subscribe(() => {
             this.modal.close();
             this.load();
@@ -156,8 +159,8 @@ export class PoliciesComponent implements OnInit {
     private updatePolicyVisibility(organization: Organization) {
         if (organization.useSso) {
             this.policies.push({
-                name: this.i18nService.t('requireSsoAuthentication'),
-                description: this.i18nService.t('requireSsoAuthenticationPolicyDesc'),
+                name: this.i18nService.t('requireSso'),
+                description: this.i18nService.t('requireSsoPolicyDesc'),
                 type: PolicyType.RequireSso,
                 enabled: false,
             });

--- a/src/app/organizations/manage/policies.component.ts
+++ b/src/app/organizations/manage/policies.component.ts
@@ -127,7 +127,6 @@ export class PoliciesComponent implements OnInit {
         childComponent.type = p.type;
         childComponent.organizationId = this.organizationId;
         childComponent.policiesEnabledMap = this.policiesEnabledMap;
-        childComponent.orgIdentifier = this.orgIdentifier;
         childComponent.onSavedPolicy.subscribe(() => {
             this.modal.close();
             this.load();

--- a/src/app/organizations/manage/policies.component.ts
+++ b/src/app/organizations/manage/policies.component.ts
@@ -23,6 +23,7 @@ import { PolicyResponse } from 'jslib/models/response/policyResponse';
 import { ModalComponent } from '../../modal.component';
 
 import { PolicyEditComponent } from './policy-edit.component';
+import { Organization } from 'jslib/models/domain/organization';
 
 @Component({
     selector: 'app-org-policies',
@@ -84,6 +85,7 @@ export class PoliciesComponent implements OnInit {
                 this.router.navigate(['/organizations', this.organizationId]);
                 return;
             }
+            this.updatePolicyVisibility(organization);
             await this.load();
         });
 
@@ -122,6 +124,7 @@ export class PoliciesComponent implements OnInit {
         childComponent.description = p.description;
         childComponent.type = p.type;
         childComponent.organizationId = this.organizationId;
+        childComponent.policiesEnabledMap = this.policiesEnabledMap;
         childComponent.onSavedPolicy.subscribe(() => {
             this.modal.close();
             this.load();
@@ -148,5 +151,11 @@ export class PoliciesComponent implements OnInit {
             }
         } catch { }
         this.enterpriseTokenPromise = null;
+    }
+
+    private updatePolicyVisibility(organization: Organization) {
+        if (organization.useSso) {
+
+        }
     }
 }

--- a/src/app/organizations/manage/policies.component.ts
+++ b/src/app/organizations/manage/policies.component.ts
@@ -155,7 +155,12 @@ export class PoliciesComponent implements OnInit {
 
     private updatePolicyVisibility(organization: Organization) {
         if (organization.useSso) {
-
+            this.policies.push({
+                name: this.i18nService.t('requireSsoAuthentication'),
+                description: this.i18nService.t('requireSsoAuthenticationPolicyDesc'),
+                type: PolicyType.RequireSso,
+                enabled: false,
+            });
         }
     }
 }

--- a/src/app/organizations/manage/policies.component.ts
+++ b/src/app/organizations/manage/policies.component.ts
@@ -23,7 +23,6 @@ import { PolicyResponse } from 'jslib/models/response/policyResponse';
 import { ModalComponent } from '../../modal.component';
 
 import { PolicyEditComponent } from './policy-edit.component';
-import { Organization } from 'jslib/models/domain/organization';
 
 @Component({
     selector: 'app-org-policies',
@@ -34,7 +33,6 @@ export class PoliciesComponent implements OnInit {
 
     loading = true;
     organizationId: string;
-    orgIdentifier: string;
     policies: any[];
 
     // Remove when removing deprecation warning
@@ -49,34 +47,7 @@ export class PoliciesComponent implements OnInit {
     constructor(private apiService: ApiService, private route: ActivatedRoute,
         private i18nService: I18nService, private componentFactoryResolver: ComponentFactoryResolver,
         private platformUtilsService: PlatformUtilsService, private userService: UserService,
-        private router: Router, private environmentService: EnvironmentService) {
-        this.policies = [
-            {
-                name: i18nService.t('twoStepLogin'),
-                description: i18nService.t('twoStepLoginPolicyDesc'),
-                type: PolicyType.TwoFactorAuthentication,
-                enabled: false,
-            },
-            {
-                name: i18nService.t('masterPass'),
-                description: i18nService.t('masterPassPolicyDesc'),
-                type: PolicyType.MasterPassword,
-                enabled: false,
-            },
-            {
-                name: i18nService.t('passwordGenerator'),
-                description: i18nService.t('passwordGeneratorPolicyDesc'),
-                type: PolicyType.PasswordGenerator,
-                enabled: false,
-            },
-            {
-                name: i18nService.t('onlyOrg'),
-                description: i18nService.t('onlyOrgDesc'),
-                type: PolicyType.OnlyOrg,
-                enabled: false,
-            },
-        ];
-    }
+        private router: Router, private environmentService: EnvironmentService) { }
 
     async ngOnInit() {
         this.route.parent.parent.params.subscribe(async (params) => {
@@ -86,8 +57,43 @@ export class PoliciesComponent implements OnInit {
                 this.router.navigate(['/organizations', this.organizationId]);
                 return;
             }
-            this.orgIdentifier = organization.identifier;
-            this.updatePolicyVisibility(organization);
+            this.policies = [
+                {
+                    name: this.i18nService.t('twoStepLogin'),
+                    description: this.i18nService.t('twoStepLoginPolicyDesc'),
+                    type: PolicyType.TwoFactorAuthentication,
+                    enabled: false,
+                    display: true,
+                },
+                {
+                    name: this.i18nService.t('masterPass'),
+                    description: this.i18nService.t('masterPassPolicyDesc'),
+                    type: PolicyType.MasterPassword,
+                    enabled: false,
+                    display: true,
+                },
+                {
+                    name: this.i18nService.t('passwordGenerator'),
+                    description: this.i18nService.t('passwordGeneratorPolicyDesc'),
+                    type: PolicyType.PasswordGenerator,
+                    enabled: false,
+                    display: true,
+                },
+                {
+                    name: this.i18nService.t('onlyOrg'),
+                    description: this.i18nService.t('onlyOrgDesc'),
+                    type: PolicyType.OnlyOrg,
+                    enabled: false,
+                    display: true,
+                },
+                {
+                    name: this.i18nService.t('requireSso'),
+                    description: this.i18nService.t('requireSsoPolicyDesc'),
+                    type: PolicyType.RequireSso,
+                    enabled: false,
+                    display: organization.useSso,
+                },
+            ];
             await this.load();
         });
 
@@ -153,16 +159,5 @@ export class PoliciesComponent implements OnInit {
             }
         } catch { }
         this.enterpriseTokenPromise = null;
-    }
-
-    private updatePolicyVisibility(organization: Organization) {
-        if (organization.useSso) {
-            this.policies.push({
-                name: this.i18nService.t('requireSso'),
-                description: this.i18nService.t('requireSsoPolicyDesc'),
-                type: PolicyType.RequireSso,
-                enabled: false,
-            });
-        }
     }
 }

--- a/src/app/organizations/manage/policy-edit.component.html
+++ b/src/app/organizations/manage/policy-edit.component.html
@@ -21,14 +21,13 @@
                     icon="fa-warning">
                     {{'onlyOrgPolicyWarning' | i18n}}
                 </app-callout>
-                <ng-container *ngIf="type === policyType.SsoAuthentication">
-                    <app-callout type="info" title="{{'prerequisite' | i18n}}" icon="fa-warning">
-                        {{'requireSsoAuthenticationPolicyReq' | i18n}}
-                    </app-callout>
-                    <app-callout type="info" title="{{'prerequisite' | i18n}}" icon="fa-warning">
-                        {{'requireSsoAuthenticationConfigReq' | i18n}}
-                    </app-callout>
-                </ng-container>
+                <app-callout type="info" title="{{'prerequisites' | i18n}}" *ngIf="type === policyType.RequireSso">
+                    {{'requireSsoCalloutMessage' | i18n}}
+                    <ul class="mb-0">
+                        <li>{{'requireSsoPolicyReq' | i18n}}</li>
+                        <li>{{'requireSsoConfigReq' | i18n}}</li>
+                    </ul>
+                </app-callout>
                 <div class="form-group">
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="enabled" [(ngModel)]="enabled"
@@ -143,7 +142,7 @@
                 </ng-container>
             </div>
             <div class="modal-footer">
-                <button (click)="prevalidate()" class="btn btn-primary btn-submit" [disabled]="form.loading">
+                <button type="submit" class="btn btn-primary btn-submit" [disabled]="form.loading">
                     <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
                     <span>{{'save' | i18n}}</span>
                 </button>

--- a/src/app/organizations/manage/policy-edit.component.html
+++ b/src/app/organizations/manage/policy-edit.component.html
@@ -21,12 +21,8 @@
                     icon="fa-warning">
                     {{'onlyOrgPolicyWarning' | i18n}}
                 </app-callout>
-                <app-callout type="info" title="{{'prerequisites' | i18n}}" *ngIf="type === policyType.RequireSso">
-                    {{'requireSsoCalloutMessage' | i18n}}
-                    <ul class="mb-0">
-                        <li>{{'requireSsoPolicyReq' | i18n}}</li>
-                        <li>{{'requireSsoConfigReq' | i18n}}</li>
-                    </ul>
+                <app-callout type="tip" title="{{'prerequisite' | i18n}}" *ngIf="type === policyType.RequireSso">
+                    {{'requireSsoPolicyReq' | i18n}}
                 </app-callout>
                 <div class="form-group">
                     <div class="form-check">

--- a/src/app/organizations/manage/policy-edit.component.html
+++ b/src/app/organizations/manage/policy-edit.component.html
@@ -17,10 +17,18 @@
                     title="{{'warning' | i18n}}" icon="fa-warning">
                     {{'twoStepLoginPolicyWarning' | i18n}}
                 </app-callout>
-                <app-callout type="warning" *ngIf="type === policyType.OnlyOrg"
-                    title="{{'warning' | i18n}}" icon="fa-warning">
+                <app-callout type="warning" *ngIf="type === policyType.OnlyOrg" title="{{'warning' | i18n}}"
+                    icon="fa-warning">
                     {{'onlyOrgPolicyWarning' | i18n}}
                 </app-callout>
+                <ng-container *ngIf="type === policyType.SsoAuthentication">
+                    <app-callout type="info" title="{{'prerequisite' | i18n}}" icon="fa-warning">
+                        {{'requireSsoAuthenticationPolicyReq' | i18n}}
+                    </app-callout>
+                    <app-callout type="info" title="{{'prerequisite' | i18n}}" icon="fa-warning">
+                        {{'requireSsoAuthenticationConfigReq' | i18n}}
+                    </app-callout>
+                </ng-container>
                 <div class="form-group">
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="enabled" [(ngModel)]="enabled"
@@ -135,7 +143,7 @@
                 </ng-container>
             </div>
             <div class="modal-footer">
-                <button type="submit" class="btn btn-primary btn-submit" [disabled]="form.loading">
+                <button (click)="prevalidate()" class="btn btn-primary btn-submit" [disabled]="form.loading">
                     <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
                     <span>{{'save' | i18n}}</span>
                 </button>

--- a/src/app/organizations/manage/policy-edit.component.ts
+++ b/src/app/organizations/manage/policy-edit.component.ts
@@ -184,14 +184,12 @@ export class PolicyEditComponent implements OnInit {
                 if (!(this.policiesEnabledMap.has(PolicyType.OnlyOrg)
                     && this.policiesEnabledMap.get(PolicyType.OnlyOrg))) {
                     this.toasterService.popAsync('error', null, this.i18nService.t('requireSsoPolicyReqError'));
-                    this.enabled = false;
                     return false;
                 }
                 // Can Prevalidate for SSO use?
                 if (this.orgIdentifier == null || this.orgIdentifier === '') {
                     this.toasterService.popAsync('error', this.i18nService.t('ssoValidationFailed'),
                         this.i18nService.t('ssoIdentifierRequired'));
-                    this.enabled = false;
                     return false;
                 }
 

--- a/src/app/organizations/manage/policy-edit.component.ts
+++ b/src/app/organizations/manage/policy-edit.component.ts
@@ -27,6 +27,7 @@ export class PolicyEditComponent implements OnInit {
     @Input() description: string;
     @Input() type: PolicyType;
     @Input() organizationId: string;
+    @Input() policiesEnabledMap: Map<PolicyType, boolean> = new Map<PolicyType, boolean>();
     @Output() onSavedPolicy = new EventEmitter();
 
     policyType = PolicyType;
@@ -123,6 +124,28 @@ export class PolicyEditComponent implements OnInit {
             } else {
                 throw e;
             }
+        }
+    }
+
+    async prevalidate() {
+        switch (this.type) {
+            case PolicyType.SsoAuthentication:
+                if (!this.enabled) { // Don't need prevalidation checks if not enabling
+                    this.submit();
+                    return;
+                }
+                // Have OnlyOrg policy enabled?
+                if (this.policiesEnabledMap.has(PolicyType.OnlyOrg)
+                    && this.policiesEnabledMap.get(PolicyType.OnlyOrg)) {
+                    this.toasterService.popAsync('error', null, this.i18nService.t('requireSsoAuthenticationPolicyReqError'));
+                    return;
+                }
+                // Can Prevalidate for SSO use?
+                this.submit();
+                break;
+
+            default:
+                this.submit();
         }
     }
 

--- a/src/app/organizations/manage/policy-edit.component.ts
+++ b/src/app/organizations/manage/policy-edit.component.ts
@@ -28,7 +28,6 @@ export class PolicyEditComponent implements OnInit {
     @Input() type: PolicyType;
     @Input() organizationId: string;
     @Input() policiesEnabledMap: Map<PolicyType, boolean> = new Map<PolicyType, boolean>();
-    @Input() orgIdentifier: string;
     @Output() onSavedPolicy = new EventEmitter();
 
     policyType = PolicyType;
@@ -129,8 +128,7 @@ export class PolicyEditComponent implements OnInit {
     }
 
     async submit() {
-        this.formPromise = this.preValidate();
-        if (await this.formPromise) {
+        if (this.preValidate()) {
             const request = new PolicyRequest();
             request.enabled = this.enabled;
             request.type = this.type;
@@ -174,7 +172,7 @@ export class PolicyEditComponent implements OnInit {
         }
     }
 
-    private async preValidate(): Promise<boolean> {
+    private preValidate(): boolean {
         switch (this.type) {
             case PolicyType.RequireSso:
                 if (!this.enabled) { // Don't need prevalidation checks if submitting to disable
@@ -186,14 +184,7 @@ export class PolicyEditComponent implements OnInit {
                     this.toasterService.popAsync('error', null, this.i18nService.t('requireSsoPolicyReqError'));
                     return false;
                 }
-                // Can Prevalidate for SSO use?
-                if (this.orgIdentifier == null || this.orgIdentifier === '') {
-                    this.toasterService.popAsync('error', this.i18nService.t('ssoValidationFailed'),
-                        this.i18nService.t('ssoIdentifierRequired'));
-                    return false;
-                }
-
-                return await this.apiService.preValidateSso(this.orgIdentifier);
+                return true;
 
             default:
                 return true;

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3228,17 +3228,11 @@
   "requireSsoPolicyDesc": {
     "message": "Require users to log in with the Enterprise Single Sign-On method."
   },
-  "prerequisites": {
-    "message": "Prerequisites"
-  },
-  "requireSsoCalloutMessage": {
-    "message": "The following requirements must be met before enabling this policy:"
+  "prerequisite": {
+    "message": "Prerequisite"
   },
   "requireSsoPolicyReq": {
-    "message": "Enable the Single Organization enterprise policy."
-  },
-  "requireSsoConfigReq": {
-    "message": "Setup and enable your organization's SSO configuration. Please visit the Business Portal to complete this action."
+    "message": "The Single Organization enterprise policy must be enabled before activating this policy."
   },
   "requireSsoPolicyReqError": {
     "message": "Single Organization policy not enabled."

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3221,5 +3221,26 @@
   },
   "onlyOrgPolicyWarning": {
     "message": "Organization members who are already a member of another organization will be removed from your organization."
+  },
+  "requireSsoAuthentication": {
+    "message": "Single Sign-On Authentication"
+  },
+  "requireSsoAuthenticationPolicyDesc": {
+    "message": "Require organization members to use the Enterprise Single Sign-On method in order to log in."
+  },
+  "prerequisite": {
+    "message": "Prerequisite"
+  },
+  "requireSsoAuthenticationPolicyReq": {
+    "message": "You must enable the Single Organization Only policy before you're able to activate this policy."
+  },
+  "requireSsoAuthenticationConfigReq": {
+    "message": "Your organization's SSO configuration must be enabled before you're able to active this policy. Please visit the Business Portal to complete this action."
+  },
+  "requireSsoAuthenticationPolicyReqError": {
+    "message": "You must enable the Single Organization Only policy before you're able to activate this policy."
+  },
+  "requireSsoAuthenticationConfigReqError": {
+    "message": "Your organization's SSO configuration must be enabled before you're able to active this policy. Please visit the Business Portal to complete this action."
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3226,21 +3226,21 @@
     "message": "Single Sign-On Authentication"
   },
   "requireSsoPolicyDesc": {
-    "message": "Require organization members to use the Enterprise Single Sign-On method in order to log in."
+    "message": "Require users to log in with the Enterprise Single Sign-On method."
   },
   "prerequisites": {
     "message": "Prerequisites"
   },
   "requireSsoCalloutMessage": {
-    "message": "The following requirements must be met for enabling this policy:"
+    "message": "The following requirements must be met before enabling this policy:"
   },
   "requireSsoPolicyReq": {
-    "message": "Enable the Only Organization enterprise policy."
+    "message": "Enable the Single Organization enterprise policy."
   },
   "requireSsoConfigReq": {
     "message": "Setup and enable your organization's SSO configuration. Please visit the Business Portal to complete this action."
   },
   "requireSsoPolicyReqError": {
-    "message": "Only Organization policy not enabled."
+    "message": "Single Organization policy not enabled."
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3238,9 +3238,9 @@
     "message": "Your organization's SSO configuration must be enabled before you're able to active this policy. Please visit the Business Portal to complete this action."
   },
   "requireSsoAuthenticationPolicyReqError": {
-    "message": "You must enable the Single Organization Only policy before you're able to activate this policy."
+    "message": "Only Organization policy not enabled."
   },
   "requireSsoAuthenticationConfigReqError": {
-    "message": "Your organization's SSO configuration must be enabled before you're able to active this policy. Please visit the Business Portal to complete this action."
+    "message": "SSO Config not enabled."
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3222,25 +3222,25 @@
   "onlyOrgPolicyWarning": {
     "message": "Organization members who are already a member of another organization will be removed from your organization."
   },
-  "requireSsoAuthentication": {
+  "requireSso": {
     "message": "Single Sign-On Authentication"
   },
-  "requireSsoAuthenticationPolicyDesc": {
+  "requireSsoPolicyDesc": {
     "message": "Require organization members to use the Enterprise Single Sign-On method in order to log in."
   },
-  "prerequisite": {
-    "message": "Prerequisite"
+  "prerequisites": {
+    "message": "Prerequisites"
   },
-  "requireSsoAuthenticationPolicyReq": {
-    "message": "You must enable the Single Organization Only policy before you're able to activate this policy."
+  "requireSsoCalloutMessage": {
+    "message": "The following requirements must be met for enabling this policy:"
   },
-  "requireSsoAuthenticationConfigReq": {
-    "message": "Your organization's SSO configuration must be enabled before you're able to active this policy. Please visit the Business Portal to complete this action."
+  "requireSsoPolicyReq": {
+    "message": "Enable the Only Organization enterprise policy."
   },
-  "requireSsoAuthenticationPolicyReqError": {
+  "requireSsoConfigReq": {
+    "message": "Setup and enable your organization's SSO configuration. Please visit the Business Portal to complete this action."
+  },
+  "requireSsoPolicyReqError": {
     "message": "Only Organization policy not enabled."
-  },
-  "requireSsoAuthenticationConfigReqError": {
-    "message": "SSO Config not enabled."
   }
 }


### PR DESCRIPTION
## Objective 
>  Add a new enterprise policy that requires users within an organization to log in with SSO. 

## Code Changes
- **policies.component.ts**: Created function to dynamically add `RequireSso` policy if necessary.  Passed along the `policiesEnabledMap` to the Edit modal.
- **policy-edit.component.html**: Added new callout for the `RequireSso` policy
- **policy-edit.component.ts**: Added new input variables required for pre-validation.  Adjusted `submit` function to first call the `preValidate` function.  For the `RequireSso` policy, the `SingleOrg` policy must be enabled in order to submit an enabled policy.
- **messages.json**: Added strings

## Screenshots
<img width="1004" alt="0-policy-list" src="https://user-images.githubusercontent.com/26154748/96652249-2236b000-12fc-11eb-8b97-2ac106905930.png">
<img width="521" alt="1-edit-policy" src="https://user-images.githubusercontent.com/26154748/97083971-51d60880-15d9-11eb-9b15-9fddadccb825.png">
<img width="1151" alt="2-single-org-error" src="https://user-images.githubusercontent.com/26154748/97109785-3d5e4280-16a3-11eb-83e5-4de9397cca69.png">



