### PR TITLE
Use properly transpiled SweetAlert2 lib

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import * as jq from 'jquery';
-import Swal from 'sweetalert2/src/sweetalert2.js';
+import Swal from 'sweetalert2/dist/sweetalert2.js';
 
 import {
     BodyOutputType,

--- a/src/services/webPlatformUtils.service.ts
+++ b/src/services/webPlatformUtils.service.ts
@@ -1,4 +1,4 @@
-import Swal, { SweetAlertIcon } from 'sweetalert2/src/sweetalert2.js';
+import Swal, { SweetAlertIcon } from 'sweetalert2/dist/sweetalert2.js';
 
 import { DeviceType } from 'jslib/enums/deviceType';
 


### PR DESCRIPTION
Resolves and closes #681 

## Overview
Blamed on: https://github.com/bitwarden/web/pull/465 (introduced the issue)
Exposed by: https://github.com/bitwarden/web/pull/572 (caused the issue to surface)

Fix: Reference the already transpiled dist version of the sweetalert2 module vs. using the src version which skips compilation (and we're not using Babel, etc. for transpiling vendor libraries).