### PR TITLE
issue567 Prevent users from using their password as the password hint

### DIFF
--- a/src/app/accounts/register.component.ts
+++ b/src/app/accounts/register.component.ts
@@ -117,6 +117,7 @@ export class RegisterComponent extends BaseRegisterComponent {
                 this.i18nService.t('masterPasswordPolicyRequirementsNotMet'));
             return;
         }
+        this.verifyPasswordhint();
 
         await super.submit();
     }


### PR DESCRIPTION
It's not very secure to allow the user to use their actual password as the hint, and it seems like some users that do not speak the language are confused by the hint prompt and have been typing their password into it. I think the UI itself is straightforward enough and shouldn't cause confusion, but I think we should prevent the user from actually submitting a hint that matches the master password. Link to issue: https://github.com/bitwarden/web/issues/567#issuecomment-719014993