### PR TITLE
Add 'Copy Username' button

### DIFF
--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -38,6 +38,11 @@
                         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
                             <ng-container *ngIf="c.type === cipherType.Login && !c.isDeleted">
                                 <a class="dropdown-item" href="#" appStopClick
+                                    (click)="copy(c, c.login.username, 'username', 'username')">
+                                    <i class="fa fa-fw fa-clone" aria-hidden="true"></i>
+                                    {{'copyUsername' | i18n}}
+                                </a>
+                                <a class="dropdown-item" href="#" appStopClick
                                     (click)="copy(c, c.login.password, 'password', 'password')" *ngIf="c.viewPassword">
                                     <i class="fa fa-fw fa-clone" aria-hidden="true"></i>
                                     {{'copyPassword' | i18n}}


### PR DESCRIPTION
This adds a 'Copy Username' button above the 'Copy Password' button in the dropdown for individual entries in the safe. This matches the capabilities of the desktop app, where you can right-click on any entry and get options for both 'copy password' and 'copy username'.

Currently the only way to easily copy the username is to manually highlight the name under the entry name. Double-clicking or triple-clicking to highlight the entire username often isn't suitable either, because it usually results in extraneous whitespace being copied.