### PR TITLE
[Exemption] Updated policy messages

### DIFF
--- a/src/app/organizations/manage/policy-edit.component.html
+++ b/src/app/organizations/manage/policy-edit.component.html
@@ -21,9 +21,14 @@
                     icon="fa-warning">
                     {{'singleOrgPolicyWarning' | i18n}}
                 </app-callout>
-                <app-callout type="tip" title="{{'prerequisite' | i18n}}" *ngIf="type === policyType.RequireSso">
-                    {{'requireSsoPolicyReq' | i18n}}
-                </app-callout>
+                <ng-container *ngIf="type === policyType.RequireSso">
+                    <app-callout type="tip" title="{{'prerequisite' | i18n}}">
+                        {{'requireSsoPolicyReq' | i18n}}
+                    </app-callout>
+                    <app-callout type="warning">
+                        {{'requireSsoExemption' | i18n}}
+                    </app-callout>
+                </ng-container>
                 <div class="form-group">
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="enabled" [(ngModel)]="enabled"

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -2991,7 +2991,7 @@
     "message": "Require users to set up two-step login on their personal accounts."
   },
   "twoStepLoginPolicyWarning": {
-    "message": "Organization Users and Managers who do not have two-step login enabled for their personal account will be removed from the organization and will receive an email notifying them about the change."
+    "message": "Organization members who are not Owners or Administrators and do not have two-step login enabled for their personal account will be removed from the organization and will receive an email notifying them about the change."
   },
   "twoStepLoginPolicyUserWarning": {
     "message": "You are a member of an organization that requires two-step login to be enabled on your user account. If you disable all two-step login providers you will be automatically removed from these organizations."
@@ -3225,7 +3225,7 @@
     "message": "Your current organization has a policy that does not allow you to join more than one organization. Please contact your organization admins or sign up from a different Bitwarden account."
   },
   "singleOrgPolicyWarning": {
-    "message": "Organization Users and Managers who are already a member of another organization will be removed from your organization."
+    "message": "Organization members who are not Owners or Administrators and are already a member of another organization will be removed from your organization."
   },
   "requireSso": {
     "message": "Single Sign-On Authentication"
@@ -3243,7 +3243,7 @@
     "message": "Single Organization policy not enabled."
   },
   "requireSsoExemption": {
-    "message": "Organization Owners and Admins are exempt from this policy's enforcement."
+    "message": "Organization Owners and Administrators are exempt from this policy's enforcement."
   },
   "sendTypeFile": {
     "message": "File"

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3340,8 +3340,5 @@
   "noSendsInList": {
     "message": "There are no Sends to list.",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
-  },
-  "SingleOrgTwoFactorExemption": {
-    "message": "Owners and Admins of this organization will not be removed"
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -2991,7 +2991,7 @@
     "message": "Require users to set up two-step login on their personal accounts."
   },
   "twoStepLoginPolicyWarning": {
-    "message": "Organization members who do not have two-step login enabled for their personal account will be removed from the organization and will receive an email notifying them about the change."
+    "message": "Organization Users and Managers who do not have two-step login enabled for their personal account will be removed from the organization and will receive an email notifying them about the change."
   },
   "twoStepLoginPolicyUserWarning": {
     "message": "You are a member of an organization that requires two-step login to be enabled on your user account. If you disable all two-step login providers you will be automatically removed from these organizations."
@@ -3225,7 +3225,7 @@
     "message": "Your current organization has a policy that does not allow you to join more than one organization. Please contact your organization admins or sign up from a different Bitwarden account."
   },
   "singleOrgPolicyWarning": {
-    "message": "Organization members who are already a member of another organization will be removed from your organization."
+    "message": "Organization Users and Managers who are already a member of another organization will be removed from your organization."
   },
   "requireSso": {
     "message": "Single Sign-On Authentication"
@@ -3241,6 +3241,9 @@
   },
   "requireSsoPolicyReqError": {
     "message": "Single Organization policy not enabled."
+  },
+  "requireSsoExemption": {
+    "message": "Organization Owners and Admins are exempt from this policy's enforcement."
   },
   "sendTypeFile": {
     "message": "File"
@@ -3337,5 +3340,8 @@
   "noSendsInList": {
     "message": "There are no Sends to list.",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "SingleOrgTwoFactorExemption": {
+    "message": "Owners and Admins of this organization will not be removed"
   }
 }


### PR DESCRIPTION
## Objective
> UI Updates: Owners and admins are exempt from organization removal during policy saving for the following policies: **2fa, Single Org**. Owners and Admins are exempt from policy enforcement for **Require SSO** policy.

## Code Changes
- **policy-edit.component.html**: Added `warning` callout for **RequireSso** describing exemption rules.
- **messages.json**: Updated messages to include exemption rules.

## Screenshots
<img width="510" alt="web-0-2fa" src="https://user-images.githubusercontent.com/26154748/98690801-ef983a00-2332-11eb-905c-dbf16d22f499.png">
<img width="510" alt="web-1-single-org" src="https://user-images.githubusercontent.com/26154748/98690804-f0c96700-2332-11eb-95d5-c371edc02fc8.png">
<img width="510" alt="web-2-require-sso" src="https://user-images.githubusercontent.com/26154748/98690806-f161fd80-2332-11eb-928c-e84c437f80e0.png">

