### PR TITLE
Exclude deleted items from any/all reports

### DIFF
--- a/src/app/tools/exposed-passwords-report.component.ts
+++ b/src/app/tools/exposed-passwords-report.component.ts
@@ -43,7 +43,7 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
         const exposedPasswordCiphers: CipherView[] = [];
         const promises: Promise<void>[] = [];
         allCiphers.forEach((c) => {
-            if (c.type !== CipherType.Login || c.login.password == null || c.login.password === '') {
+            if (c.type !== CipherType.Login || c.login.password == null || c.login.password === '' || c.isDeleted) {
                 return;
             }
             const promise = this.auditService.passwordLeaked(c.login.password).then((exposedCount) => {

--- a/src/app/tools/inactive-two-factor-report.component.ts
+++ b/src/app/tools/inactive-two-factor-report.component.ts
@@ -45,7 +45,8 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
             const promises: Promise<void>[] = [];
             const docs = new Map<string, string>();
             allCiphers.forEach((c) => {
-                if (c.type !== CipherType.Login || (c.login.totp != null && c.login.totp !== '') || !c.login.hasUris) {
+                if (c.type !== CipherType.Login || (c.login.totp != null && c.login.totp !== '') || !c.login.hasUris ||
+                    c.isDeleted) {
                     return;
                 }
                 for (let i = 0; i < c.login.uris.length; i++) {

--- a/src/app/tools/reused-passwords-report.component.ts
+++ b/src/app/tools/reused-passwords-report.component.ts
@@ -37,7 +37,7 @@ export class ReusedPasswordsReportComponent extends CipherReportComponent implem
         const ciphersWithPasswords: CipherView[] = [];
         this.passwordUseMap = new Map<string, number>();
         allCiphers.forEach((c) => {
-            if (c.type !== CipherType.Login || c.login.password == null || c.login.password === '') {
+            if (c.type !== CipherType.Login || c.login.password == null || c.login.password === '' || c.isDeleted) {
                 return;
             }
             ciphersWithPasswords.push(c);

--- a/src/app/tools/unsecured-websites-report.component.ts
+++ b/src/app/tools/unsecured-websites-report.component.ts
@@ -33,7 +33,7 @@ export class UnsecuredWebsitesReportComponent extends CipherReportComponent impl
     async setCiphers() {
         const allCiphers = await this.getAllCiphers();
         const unsecuredCiphers = allCiphers.filter((c) => {
-            if (c.type !== CipherType.Login || !c.login.hasUris) {
+            if (c.type !== CipherType.Login || !c.login.hasUris || c.isDeleted) {
                 return false;
             }
             return c.login.uris.some((u) => u.uri != null && u.uri.indexOf('http://') === 0);

--- a/src/app/tools/weak-passwords-report.component.ts
+++ b/src/app/tools/weak-passwords-report.component.ts
@@ -40,7 +40,7 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
         const allCiphers = await this.getAllCiphers();
         const weakPasswordCiphers: CipherView[] = [];
         allCiphers.forEach((c) => {
-            if (c.type !== CipherType.Login || c.login.password == null || c.login.password === '') {
+            if (c.type !== CipherType.Login || c.login.password == null || c.login.password === '' || c.isDeleted) {
                 return;
             }
             const hasUsername = c.login.username != null && c.login.username.trim() !== '';


### PR DESCRIPTION
Resolves and closes #699 

## Overview
After the introduction of soft-delete (the trash bin) feature, we've seen some functions, features and tools still continue to use soft-deleted items, such as reports. This change filters deleted items currently in the Trash bin from being included in this reporting.

Future Consideration: Perhaps a new or special report that compares deleted items from the trash, etc.; however that is out of scope for this change.

## Note
This should wait to be merged until after our upcoming release 11/12/2020 to ensure adequate testing time before release.