### PR TITLE
Attachments with long file names go beyond the window. #695

### DIFF
--- a/src/app/vault/attachments.component.html
+++ b/src/app/vault/attachments.component.html
@@ -19,7 +19,7 @@
                                 <i class="fa fa-spinner fa-lg fa-fw fa-spin" *ngIf="a.downloading"
                                     aria-hidden="true"></i>
                             </td>
-                            <td>
+                            <td class="wrap">
                                 <div class="d-flex">
                                     <a href="#" appStopClick (click)="download(a)">{{a.fileName}}</a>
                                     <div *ngIf="showFixOldAttachments(a)" class="ml-2">


### PR DESCRIPTION
Fixes #695 