### PR TITLE
Updated readme to note how to run the app against production

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ### Requirements
 
-- [Node.js](https://nodejs.org) v8.11-v13.9.0
+- [Node.js](https://nodejs.org) v8.11 or greater
 
 ### Run the app
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ npm install
 npm run build:prod:watch
 ```
 
+## Common Issues:
+
+### CORS
+
+If you run the frontend and receive a notification after attempting to login that says:
+```
+An error has occurred.
+NetworkError when attempting to fetch resource.
+```
+And in the console:
+```
+Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://api.bitwarden.com/accounts/prelogin. (Reason: CORS header ‘Access-Control-Allow-Origin’ missing).
+```
+This means that you are having a CORS header issue. This can be mitigated by using a CORS header changing extension in your browser such as [this one.](https://mybrowseraddon.com/access-control-allow-origin.html)
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@
 
 ### Requirements
 
-- [Node.js](https://nodejs.org) v8.11 or greater
+- [Node.js](https://nodejs.org) v8.11-v13.9.0
 
 ### Run the app
+
+For local development, run the app with:
 
 ```
 npm install
@@ -39,6 +41,7 @@ await apiService.setUrls({
     base: isDev ? null : window.location.origin,
     api: isDev ? 'http://mylocalapi' : null,
     identity: isDev ? 'http://mylocalidentity' : null,
+    events: isDev ? 'http://mylocalevents' : null,
 });
 ```
 
@@ -49,7 +52,15 @@ await apiService.setUrls({
     base: null,
     api: 'https://api.bitwarden.com',
     identity: 'https://identity.bitwarden.com',
+    events: 'https://events.bitwarden.com',
 });
+```
+
+And note to run the app with:
+
+```
+npm install
+npm run build:prod:watch
 ```
 
 


### PR DESCRIPTION
Hi Bitwarden, 

I am working on a feature for this repo, and I ran into some issue running the [app against production](https://community.bitwarden.com/t/catch-and-prompt-user-of-potential-duplicate-passwords-on-import/14955/14). I found solutions to my issues ([major one here](https://github.com/bitwarden/web/issues/666)), and I wanted to update the README so others don't run into the same issues.

Changes:

- Noted Node.js version can only be up to 13.9.0 because of SCSS version support

- Added events url to reflect how services.module.ts actually looks

- Added instructions for how to use the correct npm command for running the app against production

Please let me know what you think about these changes, and if there is anything I should add or remove.

Best,
Josh
