### PR TITLE
Use mobile's trash message for item delete

### DIFF
--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -461,7 +461,7 @@
     "message": "Delete Attachment"
   },
   "deleteItemConfirmation": {
-    "message": "Are you sure you want to delete this item?"
+    "message": "Do you really want to send to the trash?"
   },
   "deletedItem": {
     "message": "Item sent to trash"


### PR DESCRIPTION
# Objective

Align messages for item delete across platforms. Mobile's example of "Do you really want to send to the trash?" makes it clear that an item is only going to be soft deleted, so that was used everywhere.

# Files Changed

* **messages.json**: Updated the `deleteItemConfirmation` message to Mobile's message.