### PR TITLE
[Bug] Update 2fa navigate action to pass along Org Identifier

### DIFF
--- a/src/app/accounts/two-factor.component.ts
+++ b/src/app/accounts/two-factor.component.ts
@@ -69,7 +69,11 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
                 this.router.navigate([loginRedirect.route], { queryParams: loginRedirect.qParams });
                 await this.stateService.remove('loginRedirect');
             } else {
-                this.router.navigate([this.successRoute]);
+                this.router.navigate([this.successRoute], {
+                    queryParams: {
+                        identifier: this.identifier,
+                    },
+                });
             }
         }
     }

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -95,7 +95,7 @@ const secureStorageService: StorageServiceAbstraction = new MemoryStorageService
 const cryptoFunctionService: CryptoFunctionServiceAbstraction = new WebCryptoFunctionService(window,
     platformUtilsService);
 const cryptoService = new CryptoService(storageService,
-    platformUtilsService.isDev() ? storageService : secureStorageService, cryptoFunctionService);
+    platformUtilsService.isDev() ? storageService : secureStorageService, cryptoFunctionService, platformUtilsService);
 const tokenService = new TokenService(storageService);
 const appIdService = new AppIdService(storageService);
 const apiService = new ApiService(tokenService, platformUtilsService,

--- a/src/services/webPlatformUtils.service.ts
+++ b/src/services/webPlatformUtils.service.ts
@@ -281,4 +281,8 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
     authenticateBiometric() {
         return Promise.resolve(false);
     }
+
+    supportsSecureStorage() {
+        return true;
+    }
 }


### PR DESCRIPTION
## Objective
> During the SSO auto provision flow - if an org has 2fa required and the user's account is brand new, the `OrgIdentifer` was not being properly passed along to the `set-password` component.  This resulted in the user's organization status remaining in an `invited` state.

## Linked Issues
- [Server - 996](https://github.com/bitwarden/server/issues/996)

## Code Changes
- **jslib**: Update from 6563dcc to d9d13bb
- **two-factor.component.ts**: Added query parameter `identifier` to the route data. 
- **webPlatformUtils**: Added new interface method. Web supports `secureStoreage` via `memoryStorage.service`
- **services.module**: Added `platformUtilsService` to the `crypto.service`