### PR TITLE
WIP: dirty fix to SSO web vs browser redirect logic split

### DIFF
--- a/src/connectors/sso.ts
+++ b/src/connectors/sso.ts
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
     const code = getQsParam('code');
     const state = getQsParam('state');
 
-    if (state != null && state.endsWith(':clientId=browser')) {
+    if (state != null && state.endsWith(':clientId=browser_identifier=sso')) {
         initiateBrowserSso(code, state);
     } else {
         window.location.href = window.location.origin + '/#/sso?code=' + code + '&state=' + state;

--- a/src/connectors/sso.ts
+++ b/src/connectors/sso.ts
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
     const code = getQsParam('code');
     const state = getQsParam('state');
 
-    if (state != null && state.endsWith(':clientId=browser_identifier=sso')) {
+    if (state != null && state.includes(':clientId=browser')) {
         initiateBrowserSso(code, state);
     } else {
         window.location.href = window.location.origin + '/#/sso?code=' + code + '&state=' + state;


### PR DESCRIPTION
 # Objective

Currently, SSO sign on from the browser extension signs into web. It should open a webpage to allow for specification of SSO settings, complete SSO, and redirect to the extension for vault decryption.

# Files Changed

* **sso.ts**: state string was changed to include the organization identifier, but this broke the pivot we were using for web vs browser sign-ons. This is a quick fix for this, but it may be that a contains is better suited or even moving/removing identifier.  I don't really have the expertise in the feature to understand the implecations of changing the state string. It's clearly pretty fragile.