### PR TITLE
Update web sso content to indicate window OK to close

### DIFF
--- a/src/app/accounts/sso.component.ts
+++ b/src/app/accounts/sso.component.ts
@@ -53,6 +53,9 @@ export class SsoComponent extends BaseSsoComponent {
 
     async submit() {
         await this.storageService.save(IdentifierStorageKey, this.identifier);
+        if (this.clientId === 'browser') {
+            document.cookie = `ssoHandOffMessage = ${this.i18nService.t('ssoHandOff')}`
+        }
         super.submit();
     }
 }

--- a/src/app/accounts/sso.component.ts
+++ b/src/app/accounts/sso.component.ts
@@ -54,7 +54,7 @@ export class SsoComponent extends BaseSsoComponent {
     async submit() {
         await this.storageService.save(IdentifierStorageKey, this.identifier);
         if (this.clientId === 'browser') {
-            document.cookie = `ssoHandOffMessage = ${this.i18nService.t('ssoHandOff')}`
+            document.cookie = `ssoHandOffMessage=${this.i18nService.t('ssoHandOff')};SameSite=strict`
         }
         super.submit();
     }

--- a/src/connectors/sso.html
+++ b/src/connectors/sso.html
@@ -19,9 +19,11 @@
     <div class="mt-5 d-flex justify-content-center">
         <div>
             <img src="../images/logo-dark@2x.png" class="mb-4 logo" alt="Bitwarden">
-            <p class="text-center">
-                <i class="fa fa-spinner fa-spin fa-2x text-muted" title="Loading" aria-hidden="true"></i>
-            </p>
+            <div id="content">
+                <p class="text-center">
+                    <i class="fa fa-spinner fa-spin fa-2x text-muted" title="Loading" aria-hidden="true"></i>
+                </p>
+            </div>
         </div>
     </div>
 </body>

--- a/src/connectors/sso.ts
+++ b/src/connectors/sso.ts
@@ -37,8 +37,9 @@ function getQsParam(name: string) {
 
 function initiateBrowserSso(code: string, state: string) {
     window.postMessage({ command: 'authResult', code: code, state: state }, '*');
-    document.getElementById('content').innerHTML = '<p>Successfully passed off authentication to the extension.</p>' +
-        '<p>You may now close this tab and return to the extension.</p>';
+    let handOffMessage = ('; ' + document.cookie).split('; ssoHandOffMessage=').pop().split(';').shift();
+    document.getElementById('content').innerHTML =
+        `<p>${handOffMessage}</p>`;
 }
 
 function extractFromRegex(s: string, regexString: string) {

--- a/src/connectors/sso.ts
+++ b/src/connectors/sso.ts
@@ -37,6 +37,8 @@ function getQsParam(name: string) {
 
 function initiateBrowserSso(code: string, state: string) {
     window.postMessage({ command: 'authResult', code: code, state: state }, '*');
+    document.getElementById('content').innerHTML = '<p>Successfully passed off authentication to the extension.</p>' +
+        '<p>You may now close this tab and return to the extension.</p>';
 }
 
 function extractFromRegex(s: string, regexString: string) {

--- a/src/connectors/sso.ts
+++ b/src/connectors/sso.ts
@@ -38,6 +38,7 @@ function getQsParam(name: string) {
 function initiateBrowserSso(code: string, state: string) {
     window.postMessage({ command: 'authResult', code: code, state: state }, '*');
     let handOffMessage = ('; ' + document.cookie).split('; ssoHandOffMessage=').pop().split(';').shift();
+    document.cookie = 'ssoHandOffMessage=;SameSite=strict;max-age=0'
     document.getElementById('content').innerHTML =
         `<p>${handOffMessage}</p>`;
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3193,6 +3193,9 @@
   "enterpriseSingleSignOn": {
     "message": "Enterprise Single Sign-On"
   },
+  "ssoHandOff": {
+    "message": "You may now close this tab and continue in the extension."
+  },
   "businessPortal": {
     "message": "Business Portal",
     "description": "The web portal used by business organizations for configuring certain features."


### PR DESCRIPTION
This is done after the authResult handoff message is delivered to the
extension. It is not possible to close the window from javascript as
closing a window is limited to the script that opened it.

If we maintain a reference to the web window, it should be possible to
subscribe to the authResult message and close the web windows from the
browser.

# Overview
updates the web sso logon page to indicate it is OK to close.

# Image
<img width="791" alt="image" src="https://user-images.githubusercontent.com/18214891/100247344-dd57f780-2eff-11eb-9787-5f28b8df775d.png">
