### PR TITLE
[Policy] Personal Ownership

### DIFF
--- a/src/app/organizations/manage/policies.component.ts
+++ b/src/app/organizations/manage/policies.component.ts
@@ -4,7 +4,6 @@ import {
     OnInit,
     ViewChild,
     ViewContainerRef,
-    AfterViewInit,
 } from '@angular/core';
 import {
     ActivatedRoute,

--- a/src/app/organizations/manage/policies.component.ts
+++ b/src/app/organizations/manage/policies.component.ts
@@ -93,6 +93,13 @@ export class PoliciesComponent implements OnInit {
                     enabled: false,
                     display: organization.useSso,
                 },
+                {
+                    name: this.i18nService.t('personalOwnership'),
+                    description: this.i18nService.t('personalOwnershipPolicyDesc'),
+                    type: PolicyType.PersonalOwnership,
+                    enabled: false,
+                    display: true,
+                },
             ];
             await this.load();
         });

--- a/src/app/organizations/manage/policies.component.ts
+++ b/src/app/organizations/manage/policies.component.ts
@@ -4,6 +4,7 @@ import {
     OnInit,
     ViewChild,
     ViewContainerRef,
+    AfterViewInit,
 } from '@angular/core';
 import {
     ActivatedRoute,
@@ -102,6 +103,28 @@ export class PoliciesComponent implements OnInit {
                 },
             ];
             await this.load();
+
+            // Handle policies component launch from Event message
+            const queryParamsSub = this.route.queryParams.subscribe(async (qParams) => {
+                if (qParams.policyId != null) {
+                    const policyIdFromEvents: string = qParams.policyId;
+                    for (const orgPolicy of this.orgPolicies) {
+                        if (orgPolicy.id === policyIdFromEvents) {
+                            for (let i = 0; i < this.policies.length; i++) {
+                                if (this.policies[i].type === orgPolicy.type) {
+                                    this.edit(this.policies[i]);
+                                    break;
+                                }
+                            }
+                            break;
+                        }
+                    }
+                }
+
+                if (queryParamsSub != null) {
+                    queryParamsSub.unsubscribe();
+                }
+            });
         });
 
         // Remove when removing deprecation warning

--- a/src/app/organizations/manage/policy-edit.component.html
+++ b/src/app/organizations/manage/policy-edit.component.html
@@ -29,6 +29,9 @@
                         {{'requireSsoExemption' | i18n}}
                     </app-callout>
                 </ng-container>
+                <app-callout type="warning" *ngIf="type === policyType.PersonalOwnership">
+                    {{'personalOwnershipExemption' | i18n}}
+                </app-callout>
                 <div class="form-group">
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="enabled" [(ngModel)]="enabled"

--- a/src/app/organizations/vault/add-edit.component.ts
+++ b/src/app/organizations/vault/add-edit.component.ts
@@ -10,6 +10,7 @@ import { I18nService } from 'jslib/abstractions/i18n.service';
 import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { PasswordGenerationService } from 'jslib/abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { PolicyService } from 'jslib/abstractions/policy.service';
 import { StateService } from 'jslib/abstractions/state.service';
 import { TotpService } from 'jslib/abstractions/totp.service';
 import { UserService } from 'jslib/abstractions/user.service';
@@ -36,14 +37,14 @@ export class AddEditComponent extends BaseAddEditComponent {
         userService: UserService, collectionService: CollectionService,
         totpService: TotpService, passwordGenerationService: PasswordGenerationService,
         private apiService: ApiService, messagingService: MessagingService,
-        eventService: EventService) {
+        eventService: EventService, policyService: PolicyService) {
         super(cipherService, folderService, i18nService, platformUtilsService, auditService, stateService,
             userService, collectionService, totpService, passwordGenerationService, messagingService,
-            eventService);
+            eventService, policyService);
     }
 
     protected allowOwnershipAssignment() {
-        if (this.ownershipOptions != null && this.ownershipOptions.length > 1) {
+        if (this.ownershipOptions != null && (this.ownershipOptions.length > 1 || !this.allowPersonal)) {
             if (this.organization != null) {
                 return this.cloneMode && this.organization.isAdmin;
             } else {

--- a/src/app/services/event.service.ts
+++ b/src/app/services/event.service.ts
@@ -165,6 +165,11 @@ export class EventService {
                 msg = this.i18nService.t('exportedOrganizationVault');
                 break;
             */
+            // Policies
+            case EventType.Policy_Updated:
+                msg = this.i18nService.t('modifiedPolicy', this.formatPolicyId(ev));
+                break;
+
             default:
                 break;
         }
@@ -248,6 +253,13 @@ export class EventService {
         const a = this.makeAnchor(shortId);
         a.setAttribute('href', '#/organizations/' + ev.organizationId + '/manage/people?search=' + shortId +
             '&viewEvents=' + ev.organizationUserId);
+        return a.outerHTML;
+    }
+
+    private formatPolicyId(ev: EventResponse) {
+        const shortId = this.getShortId(ev.policyId);
+        const a = this.makeAnchor(shortId);
+        a.setAttribute('href', '#/organizations/' + ev.organizationId + '/manage/policies?policyId=' + ev.policyId);
         return a.outerHTML;
     }
 

--- a/src/app/vault/add-edit.component.ts
+++ b/src/app/vault/add-edit.component.ts
@@ -12,6 +12,7 @@ import { I18nService } from 'jslib/abstractions/i18n.service';
 import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { PasswordGenerationService } from 'jslib/abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { PolicyService } from 'jslib/abstractions/policy.service';
 import { StateService } from 'jslib/abstractions/state.service';
 import { TotpService } from 'jslib/abstractions/totp.service';
 import { UserService } from 'jslib/abstractions/user.service';
@@ -41,9 +42,10 @@ export class AddEditComponent extends BaseAddEditComponent {
         auditService: AuditService, stateService: StateService,
         userService: UserService, collectionService: CollectionService,
         protected totpService: TotpService, protected passwordGenerationService: PasswordGenerationService,
-        protected messagingService: MessagingService, eventService: EventService) {
+        protected messagingService: MessagingService, eventService: EventService,
+        protected policyService: PolicyService) {
         super(cipherService, folderService, i18nService, platformUtilsService, auditService, stateService,
-            userService, collectionService, messagingService, eventService);
+            userService, collectionService, messagingService, eventService, policyService);
     }
 
     async ngOnInit() {
@@ -155,7 +157,8 @@ export class AddEditComponent extends BaseAddEditComponent {
     }
 
     protected allowOwnershipAssignment() {
-        return (!this.editMode || this.cloneMode) && this.ownershipOptions != null && this.ownershipOptions.length > 1;
+        return (!this.editMode || this.cloneMode) && this.ownershipOptions != null
+            && (this.ownershipOptions.length > 1 || !this.allowPersonal);
     }
 
     private async totpTick(intervalSeconds: number) {

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3359,7 +3359,6 @@
     "message": "There are no Sends to list.",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
-<<<<<<< HEAD
   "personalOwnership": {
     "message": "Personal Ownership"
   },
@@ -3380,12 +3379,11 @@
         "example": "Master Password"
       }
     }
-=======
+  },
   "planPrice": {
     "message": "Plan price"
   },
   "estimatedTax": {
     "message": "Estimated tax"
->>>>>>> master
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3361,5 +3361,14 @@
   },
   "personalOwnershipSubmitError": {
     "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership Option to an organization and choose from available Collections."
+  },
+  "modifiedPolicyId": {
+    "message": "Modified policy $ID$.",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "Master Password"
+      }
+    }
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3349,5 +3349,17 @@
   "noSendsInList": {
     "message": "There are no Sends to list.",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "personalOwnership": {
+    "message": "Personal Ownership"
+  },
+  "personalOwnershipPolicyDesc": {
+    "message": "Require users to save vault items to an organization by removing the personal ownership option."
+  },
+  "personalOwnershipExemption": {
+    "message": "Organization Owners and Administrators are exempt from this policy's enforcement."
+  },
+  "personalOwnershipSubmitError": {
+    "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership Option to an organization and choose from available Collections."
   }
 }


### PR DESCRIPTION
## Objective
> When the Personal Ownership policy is enabled, require all org users (who are not Owners or Admins) to save newly created or newly cloned ciphers to an organization/collection(s). Add ability to correctly view Policy modifications in the Event Logs section.

## Code Changes
- **policies.component.ts**: Added new policy to the policies array. Added handling of query param string from event message: will properly pull open the modified policy.
- **policy-edit.component.html**: Added app callout for exemption status
- **Organization/add-edit.component.ts**: Updated constructor. Adjusted `allowOwnershipOptions` to include logic check to keep it clear which org is selected (even if only one is available)
- **event.service.ts**: I wanted to keep this lightweight to mimic the other implementations, but had to get around the fact that there is no search function for policies. In order to accomplish this, the `policyId` will be appended as a query param to signify that a certain policy should be focused (will pop modal of the modified policy)
- **vault/add-edit.component.ts**: Updated constructor. Adjusted `allowOwnershipOptions` to include logic check to keep it clear which org is selected (even if only one is available)
- **messages.json**: Added new strings

## Screenshots
<img width="1292" alt="0-error" src="https://user-images.githubusercontent.com/26154748/101531323-b6b2ab80-3958-11eb-86d5-e6ce1e427f31.png">
<img width="810" alt="1-edit" src="https://user-images.githubusercontent.com/26154748/101531331-b87c6f00-3958-11eb-84c3-78973e6598f7.png">
