### PR TITLE
Updated Firefox Import Instructions

### DIFF
--- a/src/app/tools/import.component.html
+++ b/src/app/tools/import.component.html
@@ -77,10 +77,9 @@
                 https://help.bitwarden.com/article/import-from-chrome/</a>
         </ng-container>
         <ng-container *ngIf="format === 'firefoxcsv'">
-            Use the
-            <a target="_blank" rel="noopener"
-                href="https://github.com/kspearrin/ff-password-exporter/blob/master/README.md#ff-password-exporter">
-                FF Password Exporter</a> application to export your passwords to a CSV file.
+             See detailed instructions on our help site at
+            <a target="_blank" rel="noopener" href="https://bitwarden.com/help/article/import-from-firefox/">
+                https://bitwarden.com/help/article/import-from-firefox/</a>.
         </ng-container>
         <ng-container *ngIf="format === '1password1pif' || format === '1passwordwincsv'">
             See detailed instructions on our help site at


### PR DESCRIPTION
The current method of using FF importer is outdated. Firefox has a native exporter which is convenient to use. 
Added hyperlink to https://bitwarden.com/help/article/import-from-firefox/