### PR TITLE
Add jslib to npm dependency tree

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ install:
     $env:PUSH_DOCKER = "false"
     $env:PROD_DEPLOY = "false"
     $env:TAG_NAME = ""
+    git submodule update --init --recursive
     if($env:APPVEYOR_REPO_TAG -eq "true" -and $env:APPVEYOR_RE_BUILD -eq "True") {
       $env:PROD_DEPLOY = "true"
       $env:TAG_NAME = $env:APPVEYOR_REPO_TAG_NAME.TrimStart("v")

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@angular/platform-browser": "9.1.12",
     "@angular/platform-browser-dynamic": "9.1.12",
     "@angular/router": "9.1.12",
+    "@bitwarden/jslib": "file:jslib",
     "@microsoft/signalr": "3.1.0",
     "@microsoft/signalr-protocol-msgpack": "3.1.0",
     "angular2-toaster": "8.0.0",


### PR DESCRIPTION
# Overview

Currently bitwarden/jslib is referenced only as a submodule and any new dependency in that repo needs to be manually added to all 4 client repositories that depend on jslib. I'm adding jslib as a local package dependency to npm, which includes it in dependency tree calculations.

# Files Changed

* **package.json**: jslib dependency addition.