### PR TITLE
[Policy] Personal Ownership error message

### DIFF
--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3369,7 +3369,7 @@
     "message": "Organization Owners and Administrators are exempt from this policy's enforcement."
   },
   "personalOwnershipSubmitError": {
-    "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership Option to an organization and choose from available Collections."
+    "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership option to an organization and choose from available Collections."
   },
   "modifiedPolicyId": {
     "message": "Modified policy $ID$.",


### PR DESCRIPTION
## Objective
> Fix small casing issue with the personal ownership error message

## Code Changes
- **messages.json**: Lowered case for `option`