### PR TITLE
Add totp copy to clipboard button to cipher view

### DIFF
--- a/src/app/organizations/vault/ciphers.component.ts
+++ b/src/app/organizations/vault/ciphers.component.ts
@@ -11,9 +11,10 @@ import { ApiService } from 'jslib/abstractions/api.service';
 import { CipherService } from 'jslib/abstractions/cipher.service';
 import { EventService } from 'jslib/abstractions/event.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
-import { TotpService } from 'jslib/abstractions/index';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 import { SearchService } from 'jslib/abstractions/search.service';
+import { TotpService } from 'jslib/abstractions/totp.service';
+import { UserService } from 'jslib/abstractions/user.service';
 
 import { Organization } from 'jslib/models/domain/organization';
 import { CipherView } from 'jslib/models/view/cipherView';
@@ -35,9 +36,9 @@ export class CiphersComponent extends BaseCiphersComponent {
     constructor(searchService: SearchService, analytics: Angulartics2,
         toasterService: ToasterService, i18nService: I18nService,
         platformUtilsService: PlatformUtilsService, cipherService: CipherService,
-        private apiService: ApiService, eventService: EventService, totpService: TotpService) {
+        private apiService: ApiService, eventService: EventService, totpService: TotpService, userService: UserService) {
         super(searchService, analytics, toasterService, i18nService, platformUtilsService,
-            cipherService, eventService, totpService);
+            cipherService, eventService, totpService, userService);
     }
 
     async load(filter: (cipher: CipherView) => boolean = null) {

--- a/src/app/organizations/vault/ciphers.component.ts
+++ b/src/app/organizations/vault/ciphers.component.ts
@@ -11,6 +11,7 @@ import { ApiService } from 'jslib/abstractions/api.service';
 import { CipherService } from 'jslib/abstractions/cipher.service';
 import { EventService } from 'jslib/abstractions/event.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
+import { TotpService } from 'jslib/abstractions/index';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 import { SearchService } from 'jslib/abstractions/search.service';
 
@@ -34,9 +35,9 @@ export class CiphersComponent extends BaseCiphersComponent {
     constructor(searchService: SearchService, analytics: Angulartics2,
         toasterService: ToasterService, i18nService: I18nService,
         platformUtilsService: PlatformUtilsService, cipherService: CipherService,
-        private apiService: ApiService, eventService: EventService) {
+        private apiService: ApiService, eventService: EventService, totpService: TotpService) {
         super(searchService, analytics, toasterService, i18nService, platformUtilsService,
-            cipherService, eventService);
+            cipherService, eventService, totpService);
     }
 
     async load(filter: (cipher: CipherView) => boolean = null) {

--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -48,10 +48,11 @@
                                     {{'copyPassword' | i18n}}
                                 </a>
                                 <a class="dropdown-item" href="#" appStopClick (click)="copy(c, c.login.totp, 'verificationCodeTotp', 'TOTP')"
-                                    *ngIf="c.login.hasTotp">
+                                    *ngIf="displayTotpCopyButton(c)">
                                     <i class="fa fa-fw fa-clone" aria-hidden="true"></i>
                                     {{'copyVerificationCode' | i18n}}
-                                </a> <a class="dropdown-item" href="#" appStopClick *ngIf="c.login.canLaunch"
+                                </a>
+                                <a class="dropdown-item" href="#" appStopClick *ngIf="c.login.canLaunch"
                                     (click)="launch(c.login.launchUri)">
                                     <i class="fa fa-fw fa-share-square-o" aria-hidden="true"></i>
                                     {{'launch' | i18n}}

--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -47,7 +47,11 @@
                                     <i class="fa fa-fw fa-clone" aria-hidden="true"></i>
                                     {{'copyPassword' | i18n}}
                                 </a>
-                                <a class="dropdown-item" href="#" appStopClick *ngIf="c.login.canLaunch"
+                                <a class="dropdown-item" href="#" appStopClick (click)="copy(c, c.login.totp, 'verificationCodeTotp', 'TOTP')"
+                                    *ngIf="c.login.hasTotp && c.viewPassword">
+                                    <i class="fa fa-fw fa-clone" aria-hidden="true"></i>
+                                    {{'copyVerificationCode' | i18n}}
+                                </a> <a class="dropdown-item" href="#" appStopClick *ngIf="c.login.canLaunch"
                                     (click)="launch(c.login.launchUri)">
                                     <i class="fa fa-fw fa-share-square-o" aria-hidden="true"></i>
                                     {{'launch' | i18n}}

--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -48,7 +48,7 @@
                                     {{'copyPassword' | i18n}}
                                 </a>
                                 <a class="dropdown-item" href="#" appStopClick (click)="copy(c, c.login.totp, 'verificationCodeTotp', 'TOTP')"
-                                    *ngIf="c.login.hasTotp && c.viewPassword">
+                                    *ngIf="c.login.hasTotp">
                                     <i class="fa fa-fw fa-clone" aria-hidden="true"></i>
                                     {{'copyVerificationCode' | i18n}}
                                 </a> <a class="dropdown-item" href="#" appStopClick *ngIf="c.login.canLaunch"


### PR DESCRIPTION
# Overview

Offering copying of totp from context menu covers only one method-of-use. Offering another quick-copy button on the tabs/cipher list view closes this gap.

# Files Changed

* **organizations/ciphers.component.ts**: Include totpService now required by parent.
* **cipher.component.html**: Include Copy Verification Code in context menu if totp is present
* **ciphers.component.ts**: Get totp from totpService, add to clipboard, and notify of hidden field revealed.

# Screenshots

## With Totp
<img width="505" alt="image" src="https://user-images.githubusercontent.com/18214891/102014624-8b470c80-3d1c-11eb-9eeb-55182b787352.png">

## Without Totp
<img width="505" alt="image" src="https://user-images.githubusercontent.com/18214891/102014639-9ac65580-3d1c-11eb-9802-974cf2c8dd2b.png">

# Draft Reason

Waiting on bitwarden/jslib#225