### PR TITLE
[Policy] Single Org dependency chain

### DIFF
--- a/src/app/organizations/manage/policy-edit.component.ts
+++ b/src/app/organizations/manage/policy-edit.component.ts
@@ -186,6 +186,18 @@ export class PolicyEditComponent implements OnInit {
                 }
                 return true;
 
+            case PolicyType.SingleOrg:
+                if (this.enabled) { // Don't need prevalidation checks if submitting to enable
+                    return true;
+                }
+                // If RequireSso Policy is enabled prevent submittal
+                if (this.policiesEnabledMap.has(PolicyType.RequireSso)
+                    && this.policiesEnabledMap.get(PolicyType.RequireSso)) {
+                    this.toasterService.popAsync('error', null, this.i18nService.t('disableRequireSsoError'));
+                    return false;
+                }
+                return true;
+
             default:
                 return true;
         }

--- a/src/app/organizations/manage/policy-edit.component.ts
+++ b/src/app/organizations/manage/policy-edit.component.ts
@@ -175,7 +175,8 @@ export class PolicyEditComponent implements OnInit {
     private preValidate(): boolean {
         switch (this.type) {
             case PolicyType.RequireSso:
-                if (!this.enabled) { // Don't need prevalidation checks if submitting to disable
+                // Don't need prevalidation checks if submitting to disable
+                if (!this.enabled) {
                     return true;
                 }
                 // Have SingleOrg policy enabled?
@@ -187,7 +188,8 @@ export class PolicyEditComponent implements OnInit {
                 return true;
 
             case PolicyType.SingleOrg:
-                if (this.enabled) { // Don't need prevalidation checks if submitting to enable
+                // Don't need prevalidation checks if submitting to enable
+                if (this.enabled) {
                     return true;
                 }
                 // If RequireSso Policy is enabled prevent submittal

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3385,5 +3385,8 @@
   },
   "estimatedTax": {
     "message": "Estimated tax"
+  },
+  "disableRequireSsoError": {
+    "message": "You must manually disable the Single Sign-On Authentication policy before this policy can be disabled."
   }
 }


### PR DESCRIPTION
## Objective
> Do not allow users to **disable** the `SingleOrg` policy when the `RequireSso` policy is **enabled**.

## Code Changes
- **policy-edit.component**: Added explicit check for when saving the `SingleOrg` policy to check for the above condition.
- **messages**: Added new error string

## Screenshots
<img width="1148" alt="0-web-error" src="https://user-images.githubusercontent.com/26154748/102282341-13343e80-3ef6-11eb-9f97-8156acaf313c.png">

