### PR TITLE
show caret or icon, not just "blank" space

### DIFF
--- a/src/app/vault/groupings.component.html
+++ b/src/app/vault/groupings.component.html
@@ -62,7 +62,7 @@
                         <i class="fa fa-plus fa-fw" aria-hidden="true"></i>
                     </a>
                 </h3>
-                <ul class="fa-ul card-ul carets">
+                <ul class="fa-ul card-ul">
                     <ng-template #recursiveFolders let-folders>
                         <li *ngFor="let f of folders"
                             [ngClass]="{active: selectedFolder && f.node.id === selectedFolderId}">
@@ -70,7 +70,9 @@
                                 <i *ngIf="f.children.length" class="fa-li fa" title="{{'toggleCollapse' | i18n}}"
                                     [ngClass]="{'fa-caret-right': isCollapsed(f.node), 'fa-caret-down': !isCollapsed(f.node)}"
                                     (click)="collapse(f.node)"></i>
-                                <a href="#" appStopClick (click)="selectFolder(f.node)">{{f.node.name}}</a>
+                                <a href="#" appStopClick (click)="selectFolder(f.node)">
+                                    <i *ngIf="f.children.length === 0" class="fa-li fa fa-folder-o" aria-hidden="true"></i>{{f.node.name}}
+                                </a>
                                 <a href="#" class="text-muted ml-auto show-active" appStopClick
                                     (click)="editFolder(f.node)" appA11yTitle="{{'editFolder' | i18n}}"
                                     *ngIf="f.node.id">
@@ -89,13 +91,15 @@
             </ng-container>
             <ng-container *ngIf="showCollections && collections && collections.length">
                 <h3>{{'collections' | i18n}}</h3>
-                <ul class="fa-ul card-ul carets">
+                <ul class="fa-ul card-ul">
                     <ng-template #recursiveCollections let-collections>
                         <li *ngFor="let c of collections" [ngClass]="{active: c.node.id === selectedCollectionId}">
                             <i *ngIf="c.children.length" class="fa-li fa" title="{{'toggleCollapse' | i18n}}"
                                 [ngClass]="{'fa-caret-right': isCollapsed(c.node), 'fa-caret-down': !isCollapsed(c.node)}"
                                 (click)="collapse(c.node)"></i>
-                            <a href="#" appStopClick (click)="selectCollection(c.node)">{{c.node.name}}</a>
+                            <a href="#" appStopClick (click)="selectCollection(c.node)">
+                                <i *ngIf="c.children.length === 0" class="fa-li fa fa-cube" aria-hidden="true"></i>{{c.node.name}}
+                            </a>
                             <ul class="fa-ul card-ul carets" *ngIf="c.children.length && !isCollapsed(c.node)">
                                 <ng-container
                                     *ngTemplateOutlet="recursiveCollections; context:{ $implicit: c.children }">


### PR DESCRIPTION
Does a little bit of reversal on the removal of carets from *all* items (see PR https://github.com/bitwarden/web/pull/410), and instead uses an icon for the item OR a caret (if expandable) for folders and collections. Needed to remove some of the formatting based on the `.carets` class as well in this instance because we need things to align with the stuff higher up.

![image](https://user-images.githubusercontent.com/3904944/102663443-e29b1180-414e-11eb-9c5e-6422892909ad.png)
