### PR TITLE
Moving appveyor to actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,3 +126,48 @@ jobs:
       - name: Log out of docker
         if: github.ref == 'refs/heads/master' || github.event_name == 'release'
         run: docker logout
+
+    windows:
+      runs-on: windows-latest
+      steps:
+        - name: Set up NuGet
+          uses: nuget/setup-nuget@v1
+          with:
+            nuget-version: 'latest'
+
+       - name: Set up MSBuild
+         uses: microsoft/setup-msbuild@v1
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+
+      - name: Print environment
+        run: |
+          nuget help
+          msbuild -version
+          dotnet --info
+          node --version
+          npm --version
+          Write-Output "GitHub ref: $env:GITHUB_REF"
+          Write-Output "GitHub event: $env:GITHUB_EVENT"
+        shell: pwsh
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_EVENT: ${{ github.event_name }}
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Restore
+        run: msbuild /t:restore
+        shell: pwsh
+
+      - name: Build solution
+        run: msbuild bitwarden-server.sln /p:Configuration=Debug /verbosity:minimal
+        shell: pwsh
+
+      - name: Test solution
+        run: dotnet test .\test\Core.Test\Core.Test.csproj --configuration Debug --no-build
+        shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,128 @@
+name: build
+
+on:
+  push:
+    branches-ignore:
+      - 'l10n_master'
+      - 'gh-pages'
+  releases:
+    types:
+      - published
+
+jobs:
+  cloc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Set up cloc
+        run: |
+          sudo apt update
+          sudo apt -y install cloc
+
+      - name: Print lines of code
+        run: cloc --include-lang TypeScript,JavaScript,HTML,Sass,CSS --vcs git
+
+  ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Node
+        uses: action/setup-node@v1
+        with:
+          node-version: '10.x'
+
+      - name: Print environment
+        run: |
+          whoami
+          node --version
+          npm --version
+          gulp --version
+          docker --version
+          echo "GitHub ref: $GITHUB_REF"
+          echo "GitHub event: $GITHUB_EVENT"
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_EVENT: ${{ github.event_name }}
+
+      - name: Log into docker
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+        run:  echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Setup Docker Trust
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+        run: |
+          mkdir -p ~/.docker/trust/private
+
+          echo "${{ secrets.DOCKER_DELEGATION_KEY }}" > ~/.docker/trust/private/$DOCKER_DELEGATION_KEY_ID.key
+          echo "${{ secrets.DOCKER_WEB_KEY }}" > ~/.docker/trust/private/$DOCKER_WEB_KEY_ID.key
+        env:
+          DOCKER_DELEGATION_KEY_ID: "5702b22123e058cbd96a7a43000cb981ae98ef3f2f4aa34138ab3dc1d011e446"
+          DOCKER_WEB_KEY_ID: "0f88641697187f42a31b584897cd4edfe80360a5209122d9e7f71af17a6422e4"
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Restore
+        run: dotnet tool restore
+
+      - name: Build
+        run: |
+          chmod +x ./build.sh
+          ./build.sh
+
+      - name: Tag dev
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+        run: ./build.sh tag dev
+
+      - name: Tag beta
+        if: github.event_name == 'release'
+        run: ./build.sh tag beta
+
+      - name: Tag version
+        if: github.event_name == 'release'
+        run: ./build.sh tag $($env:RELEASE_TAG_NAME.trimStart('v'))
+        shell: pwsh
+        env:
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+
+      - name: List docker images
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+        run: docker images
+
+      - name: Push dev images
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+        run: ./build.sh push dev
+        env: 
+          DOCKER_CONTENT_TRUST: 1
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
+
+      - name: Push beta images
+        if: github.event_name == 'release'
+        run: ./build.sh push beta
+        env: 
+          DOCKER_CONTENT_TRUST: 1
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
+
+      - name: Push latest images
+        if: github.event_name == 'release'
+        run: ./build.sh push latest
+        env: 
+          DOCKER_CONTENT_TRUST: 1
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
+
+      - name: Push version images
+        if: github.event_name == 'release'
+        run: ./build.sh push $($env:RELEASE_TAG_NAME.trimStart('v'))
+        shell: pwsh
+        env:
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          DOCKER_CONTENT_TRUST: 1
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
+
+      - name: Log out of docker
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+        run: docker logout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches-ignore:
       - 'l10n_master'
       - 'gh-pages'
-  releases:
+  release:
     types:
       - published
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,14 +160,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Restore
-        run: msbuild /t:restore
-        shell: pwsh
+      - name: npm install
+        run: npm install
 
-      - name: Build solution
-        run: msbuild bitwarden-server.sln /p:Configuration=Debug /verbosity:minimal
-        shell: pwsh
+      - name: npm build
+        run: npm run build:prod
 
-      - name: Test solution
-        run: dotnet test .\test\Core.Test\Core.Test.csproj --configuration Debug --no-build
-        shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Node
-        uses: action/setup-node@v1
+        uses: actions/setup-node@v1
         with:
           node-version: '10.x'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,39 +135,39 @@ jobs:
           with:
             nuget-version: 'latest'
 
-       - name: Set up MSBuild
-         uses: microsoft/setup-msbuild@v1
+        - name: Set up MSBuild
+          uses: microsoft/setup-msbuild@v1
 
-      - name: Set up Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: '10.x'
+        - name: Set up Node
+          uses: actions/setup-node@v1
+          with:
+            node-version: '10.x'
 
-      - name: Print environment
-        run: |
-          nuget help
-          msbuild -version
-          dotnet --info
-          node --version
-          npm --version
-          Write-Output "GitHub ref: $env:GITHUB_REF"
-          Write-Output "GitHub event: $env:GITHUB_EVENT"
-        shell: pwsh
-        env:
-          GITHUB_REF: ${{ github.ref }}
-          GITHUB_EVENT: ${{ github.event_name }}
+        - name: Print environment
+          run: |
+            nuget help
+            msbuild -version
+            dotnet --info
+            node --version
+            npm --version
+            Write-Output "GitHub ref: $env:GITHUB_REF"
+            Write-Output "GitHub event: $env:GITHUB_EVENT"
+          shell: pwsh
+          env:
+            GITHUB_REF: ${{ github.ref }}
+            GITHUB_EVENT: ${{ github.event_name }}
 
-      - name: Checkout repo
-        uses: actions/checkout@v2
+        - name: Checkout repo
+          uses: actions/checkout@v2
 
-      - name: Restore
-        run: msbuild /t:restore
-        shell: pwsh
+        - name: Restore
+          run: msbuild /t:restore
+          shell: pwsh
 
-      - name: Build solution
-        run: msbuild bitwarden-server.sln /p:Configuration=Debug /verbosity:minimal
-        shell: pwsh
+        - name: Build solution
+          run: msbuild bitwarden-server.sln /p:Configuration=Debug /verbosity:minimal
+          shell: pwsh
 
-      - name: Test solution
-        run: dotnet test .\test\Core.Test\Core.Test.csproj --configuration Debug --no-build
-        shell: pwsh
+        - name: Test solution
+          run: dotnet test .\test\Core.Test\Core.Test.csproj --configuration Debug --no-build
+          shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,47 +127,47 @@ jobs:
         if: github.ref == 'refs/heads/master' || github.event_name == 'release'
         run: docker logout
 
-    windows:
-      runs-on: windows-latest
-      steps:
-        - name: Set up NuGet
-          uses: nuget/setup-nuget@v1
-          with:
-            nuget-version: 'latest'
+  windows:
+    runs-on: windows-latest
+    steps:
+      - name: Set up NuGet
+        uses: nuget/setup-nuget@v1
+        with:
+          nuget-version: 'latest'
 
-        - name: Set up MSBuild
-          uses: microsoft/setup-msbuild@v1
+      - name: Set up MSBuild
+        uses: microsoft/setup-msbuild@v1
 
-        - name: Set up Node
-          uses: actions/setup-node@v1
-          with:
-            node-version: '10.x'
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
 
-        - name: Print environment
-          run: |
-            nuget help
-            msbuild -version
-            dotnet --info
-            node --version
-            npm --version
-            Write-Output "GitHub ref: $env:GITHUB_REF"
-            Write-Output "GitHub event: $env:GITHUB_EVENT"
-          shell: pwsh
-          env:
-            GITHUB_REF: ${{ github.ref }}
-            GITHUB_EVENT: ${{ github.event_name }}
+      - name: Print environment
+        run: |
+          nuget help
+          msbuild -version
+          dotnet --info
+          node --version
+          npm --version
+          Write-Output "GitHub ref: $env:GITHUB_REF"
+          Write-Output "GitHub event: $env:GITHUB_EVENT"
+        shell: pwsh
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_EVENT: ${{ github.event_name }}
 
-        - name: Checkout repo
-          uses: actions/checkout@v2
+      - name: Checkout repo
+        uses: actions/checkout@v2
 
-        - name: Restore
-          run: msbuild /t:restore
-          shell: pwsh
+      - name: Restore
+        run: msbuild /t:restore
+        shell: pwsh
 
-        - name: Build solution
-          run: msbuild bitwarden-server.sln /p:Configuration=Debug /verbosity:minimal
-          shell: pwsh
+      - name: Build solution
+        run: msbuild bitwarden-server.sln /p:Configuration=Debug /verbosity:minimal
+        shell: pwsh
 
-        - name: Test solution
-          run: dotnet test .\test\Core.Test\Core.Test.csproj --configuration Debug --no-build
-          shell: pwsh
+      - name: Test solution
+        run: dotnet test .\test\Core.Test\Core.Test.csproj --configuration Debug --no-build
+        shell: pwsh


### PR DESCRIPTION
## Change Summary
Moving the CI pipeline from AppVeyor to GitHub Actions. Adding in Docker Content Trust as well. 

:warning: Without the repo secrets below, the `Build:ubuntu` task will fail and the docker image will not be built or published.

## Files Changed
- .github/workflows/build.yml

## Confirmation of Secrets needed
- DOCKER_USERNAME
- DOCKER_PASSWORD
- DOCKER_WEB_KEY
- DOCKER_DELEGATION_KEY
- DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE (passphrase for the DOCKER_DELEGATION_KEY)

## Tests
- Clean runs for all 3 jobs without being master/release (reference: https://github.com/joseph-flinn/web/actions/runs/431530610)
- `master/release` tasks model `server` project so should work with the above secrets added. If desired, I can fully test these by setting up Docker Content Trust and pushing to my personal container registry.
