### PR TITLE
Implemented Custom role and permissions

### DIFF
--- a/src/app/accounts/sso.component.ts
+++ b/src/app/accounts/sso.component.ts
@@ -54,7 +54,7 @@ export class SsoComponent extends BaseSsoComponent {
     async submit() {
         await this.storageService.save(IdentifierStorageKey, this.identifier);
         if (this.clientId === 'browser') {
-            document.cookie = `ssoHandOffMessage=${this.i18nService.t('ssoHandOff')};SameSite=strict`
+            document.cookie = `ssoHandOffMessage=${this.i18nService.t('ssoHandOff')};SameSite=strict`;
         }
         super.submit();
     }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -90,7 +90,7 @@ import { UnauthGuardService } from './services/unauth-guard.service';
 
 import { AuthGuardService } from 'jslib/angular/services/auth-guard.service';
 
-import { OrganizationUserType } from 'jslib/enums/organizationUserType';
+import { Permissions } from 'jslib/enums/permissions';
 
 const routes: Routes = [
     {
@@ -236,35 +236,75 @@ const routes: Routes = [
                 path: 'tools',
                 component: OrgToolsComponent,
                 canActivate: [OrganizationTypeGuardService],
-                data: { allowedTypes: [OrganizationUserType.Owner, OrganizationUserType.Admin] },
+                data: { permissions: [Permissions.AccessImportExport, Permissions.AccessReports] },
                 children: [
-                    { path: '', pathMatch: 'full', redirectTo: 'import' },
-                    { path: 'import', component: OrgImportComponent, data: { titleId: 'importData' } },
-                    { path: 'export', component: OrgExportComponent, data: { titleId: 'exportVault' } },
+                    {
+                        path: '',
+                        pathMatch: 'full',
+                        redirectTo: 'import'
+                    },
+                    {
+                        path: 'import',
+                        component: OrgImportComponent,
+                        canActivate: [OrganizationTypeGuardService],
+                        data: {
+                            titleId: 'importData',
+                            permissions: [Permissions.AccessImportExport],
+                        }
+                    },
+                    {
+                        path: 'export',
+                        component: OrgExportComponent,
+                        canActivate: [OrganizationTypeGuardService],
+                        data: {
+                            titleId: 'exportVault',
+                            permissions: [Permissions.AccessImportExport]
+                        }
+                    },
                     {
                         path: 'exposed-passwords-report',
                         component: OrgExposedPasswordsReportComponent,
-                        data: { titleId: 'exposedPasswordsReport' },
+                        canActivate: [OrganizationTypeGuardService],
+                        data: {
+                            titleId: 'exposedPasswordsReport',
+                            permissions: [Permissions.AccessReports]
+                        },
                     },
                     {
                         path: 'inactive-two-factor-report',
                         component: OrgInactiveTwoFactorReportComponent,
-                        data: { titleId: 'inactive2faReport' },
+                        canActivate: [OrganizationTypeGuardService],
+                        data: {
+                            titleId: 'inactive2faReport',
+                            permissions: [Permissions.AccessReports]
+                        },
                     },
                     {
                         path: 'reused-passwords-report',
                         component: OrgReusedPasswordsReportComponent,
-                        data: { titleId: 'reusedPasswordsReport' },
+                        canActivate: [OrganizationTypeGuardService],
+                        data: {
+                            titleId: 'reusedPasswordsReport',
+                            permissions: [Permissions.AccessReports]
+                        },
                     },
                     {
                         path: 'unsecured-websites-report',
                         component: OrgUnsecuredWebsitesReportComponent,
-                        data: { titleId: 'unsecuredWebsitesReport' },
+                        canActivate: [OrganizationTypeGuardService],
+                        data: {
+                            titleId: 'unsecuredWebsitesReport',
+                            permissions: [Permissions.AccessReports]
+                        },
                     },
                     {
                         path: 'weak-passwords-report',
                         component: OrgWeakPasswordsReportComponent,
-                        data: { titleId: 'weakPasswordsReport' },
+                        canActivate: [OrganizationTypeGuardService],
+                        data: {
+                            titleId: 'weakPasswordsReport',
+                            permissions: [Permissions.AccessReports]
+                        },
                     },
                 ],
             },
@@ -273,26 +313,73 @@ const routes: Routes = [
                 component: OrgManageComponent,
                 canActivate: [OrganizationTypeGuardService],
                 data: {
-                    allowedTypes: [
-                        OrganizationUserType.Owner,
-                        OrganizationUserType.Admin,
-                        OrganizationUserType.Manager,
-                    ],
+                    permissions: [
+                        Permissions.ManageAssignedCollections,
+                        Permissions.ManageAllCollections,
+                        Permissions.AccessEventLogs,
+                        Permissions.ManageGroups,
+                        Permissions.ManageUsers,
+                        Permissions.ManagePolicies
+                    ]
                 },
                 children: [
-                    { path: '', pathMatch: 'full', redirectTo: 'people' },
-                    { path: 'collections', component: OrgManageCollectionsComponent, data: { titleId: 'collections' } },
-                    { path: 'events', component: OrgEventsComponent, data: { titleId: 'eventLogs' } },
-                    { path: 'groups', component: OrgGroupsComponent, data: { titleId: 'groups' } },
-                    { path: 'people', component: OrgPeopleComponent, data: { titleId: 'people' } },
-                    { path: 'policies', component: OrgPoliciesComponent, data: { titleId: 'policies' } },
+                    {
+                        path: '',
+                        pathMatch: 'full',
+                        redirectTo: 'people'
+                    },
+                    {
+                        path: 'collections',
+                        component: OrgManageCollectionsComponent,
+                        canActivate: [OrganizationTypeGuardService],
+                        data: {
+                            titleId: 'collections',
+                            permissions: [Permissions.ManageAssignedCollections, Permissions.ManageAllCollections]
+                        }
+                    },
+                    {
+                        path: 'events',
+                        component: OrgEventsComponent,
+                        canActivate: [OrganizationTypeGuardService],
+                        data: {
+                            titleId: 'eventLogs',
+                            permissions: [Permissions.AccessEventLogs]
+                        }
+                    },
+                    {
+                        path: 'groups',
+                        component: OrgGroupsComponent,
+                        canActivate: [OrganizationTypeGuardService],
+                        data: {
+                            titleId: 'groups',
+                            permissions: [Permissions.ManageGroups]
+                        }
+                    },
+                    {
+                        path: 'people',
+                        component: OrgPeopleComponent,
+                        canActivate: [OrganizationTypeGuardService],
+                        data: {
+                            titleId: 'people',
+                            permissions: [Permissions.ManageUsers]
+                        }
+                    },
+                    {
+                        path: 'policies',
+                        component: OrgPoliciesComponent,
+                        canActivate: [OrganizationTypeGuardService],
+                        data: {
+                            titleId: 'policies',
+                            permissions: [Permissions.ManagePolicies]
+                        }
+                    },
                 ],
             },
             {
                 path: 'settings',
                 component: OrgSettingsComponent,
                 canActivate: [OrganizationTypeGuardService],
-                data: { allowedTypes: [OrganizationUserType.Owner] },
+                data: { permissions: [Permissions.ManageOrganization] },
                 children: [
                     { path: '', pathMatch: 'full', redirectTo: 'account' },
                     { path: 'account', component: OrgAccountComponent, data: { titleId: 'myOrganization' } },
@@ -317,6 +404,7 @@ const routes: Routes = [
 @NgModule({
     imports: [RouterModule.forRoot(routes, {
         useHash: true,
+        paramsInheritanceStrategy: 'always'
         /*enableTracing: true,*/
     })],
     exports: [RouterModule],

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -282,7 +282,7 @@ const routes: Routes = [
                         canActivate: [OrganizationTypeGuardService],
                         data: {
                             titleId: 'exportVault',
-                            permissions: [Permissions.AccessImportExport]
+                            permissions: [Permissions.AccessImportExport],
                         },
                     },
                     {
@@ -343,7 +343,7 @@ const routes: Routes = [
                         Permissions.AccessEventLogs,
                         Permissions.ManageGroups,
                         Permissions.ManageUsers,
-                        Permissions.ManagePolicies
+                        Permissions.ManagePolicies,
                     ],
                 },
                 children: [
@@ -358,7 +358,7 @@ const routes: Routes = [
                         canActivate: [OrganizationTypeGuardService],
                         data: {
                             titleId: 'collections',
-                            permissions: [Permissions.ManageAssignedCollections, Permissions.ManageAllCollections]
+                            permissions: [Permissions.ManageAssignedCollections, Permissions.ManageAllCollections],
                         },
                     },
                     {
@@ -367,7 +367,7 @@ const routes: Routes = [
                         canActivate: [OrganizationTypeGuardService],
                         data: {
                             titleId: 'eventLogs',
-                            permissions: [Permissions.AccessEventLogs]
+                            permissions: [Permissions.AccessEventLogs],
                         },
                     },
                     {
@@ -376,7 +376,7 @@ const routes: Routes = [
                         canActivate: [OrganizationTypeGuardService],
                         data: {
                             titleId: 'groups',
-                            permissions: [Permissions.ManageGroups]
+                            permissions: [Permissions.ManageGroups],
                         },
                     },
                     {
@@ -385,7 +385,7 @@ const routes: Routes = [
                         canActivate: [OrganizationTypeGuardService],
                         data: {
                             titleId: 'people',
-                            permissions: [Permissions.ManageUsers]
+                            permissions: [Permissions.ManageUsers],
                         },
                     },
                     {
@@ -394,7 +394,7 @@ const routes: Routes = [
                         canActivate: [OrganizationTypeGuardService],
                         data: {
                             titleId: 'policies',
-                            permissions: [Permissions.ManagePolicies]
+                            permissions: [Permissions.ManagePolicies],
                         },
                     },
                 ],

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -93,8 +93,8 @@ import { AuthGuardService } from 'jslib/angular/services/auth-guard.service';
 
 import { Permissions } from 'jslib/enums/permissions';
 
-import { EmergencyAccessComponent } from './settings/emergency-access.component';
 import { EmergencyAccessViewComponent } from './settings/emergency-access-view.component';
+import { EmergencyAccessComponent } from './settings/emergency-access.component';
 
 const routes: Routes = [
     {
@@ -265,7 +265,7 @@ const routes: Routes = [
                     {
                         path: '',
                         pathMatch: 'full',
-                        redirectTo: 'import'
+                        redirectTo: 'import',
                     },
                     {
                         path: 'import',
@@ -274,7 +274,7 @@ const routes: Routes = [
                         data: {
                             titleId: 'importData',
                             permissions: [Permissions.AccessImportExport],
-                        }
+                        },
                     },
                     {
                         path: 'export',
@@ -283,7 +283,7 @@ const routes: Routes = [
                         data: {
                             titleId: 'exportVault',
                             permissions: [Permissions.AccessImportExport]
-                        }
+                        },
                     },
                     {
                         path: 'exposed-passwords-report',
@@ -291,7 +291,7 @@ const routes: Routes = [
                         canActivate: [OrganizationTypeGuardService],
                         data: {
                             titleId: 'exposedPasswordsReport',
-                            permissions: [Permissions.AccessReports]
+                            permissions: [Permissions.AccessReports],
                         },
                     },
                     {
@@ -300,7 +300,7 @@ const routes: Routes = [
                         canActivate: [OrganizationTypeGuardService],
                         data: {
                             titleId: 'inactive2faReport',
-                            permissions: [Permissions.AccessReports]
+                            permissions: [Permissions.AccessReports],
                         },
                     },
                     {
@@ -309,7 +309,7 @@ const routes: Routes = [
                         canActivate: [OrganizationTypeGuardService],
                         data: {
                             titleId: 'reusedPasswordsReport',
-                            permissions: [Permissions.AccessReports]
+                            permissions: [Permissions.AccessReports],
                         },
                     },
                     {
@@ -318,7 +318,7 @@ const routes: Routes = [
                         canActivate: [OrganizationTypeGuardService],
                         data: {
                             titleId: 'unsecuredWebsitesReport',
-                            permissions: [Permissions.AccessReports]
+                            permissions: [Permissions.AccessReports],
                         },
                     },
                     {
@@ -327,7 +327,7 @@ const routes: Routes = [
                         canActivate: [OrganizationTypeGuardService],
                         data: {
                             titleId: 'weakPasswordsReport',
-                            permissions: [Permissions.AccessReports]
+                            permissions: [Permissions.AccessReports],
                         },
                     },
                 ],
@@ -344,13 +344,13 @@ const routes: Routes = [
                         Permissions.ManageGroups,
                         Permissions.ManageUsers,
                         Permissions.ManagePolicies
-                    ]
+                    ],
                 },
                 children: [
                     {
                         path: '',
                         pathMatch: 'full',
-                        redirectTo: 'people'
+                        redirectTo: 'people',
                     },
                     {
                         path: 'collections',
@@ -359,7 +359,7 @@ const routes: Routes = [
                         data: {
                             titleId: 'collections',
                             permissions: [Permissions.ManageAssignedCollections, Permissions.ManageAllCollections]
-                        }
+                        },
                     },
                     {
                         path: 'events',
@@ -368,7 +368,7 @@ const routes: Routes = [
                         data: {
                             titleId: 'eventLogs',
                             permissions: [Permissions.AccessEventLogs]
-                        }
+                        },
                     },
                     {
                         path: 'groups',
@@ -377,7 +377,7 @@ const routes: Routes = [
                         data: {
                             titleId: 'groups',
                             permissions: [Permissions.ManageGroups]
-                        }
+                        },
                     },
                     {
                         path: 'people',
@@ -386,7 +386,7 @@ const routes: Routes = [
                         data: {
                             titleId: 'people',
                             permissions: [Permissions.ManageUsers]
-                        }
+                        },
                     },
                     {
                         path: 'policies',
@@ -395,7 +395,7 @@ const routes: Routes = [
                         data: {
                             titleId: 'policies',
                             permissions: [Permissions.ManagePolicies]
-                        }
+                        },
                     },
                 ],
             },
@@ -428,7 +428,7 @@ const routes: Routes = [
 @NgModule({
     imports: [RouterModule.forRoot(routes, {
         useHash: true,
-        paramsInheritanceStrategy: 'always'
+        paramsInheritanceStrategy: 'always',
         /*enableTracing: true,*/
     })],
     exports: [RouterModule],

--- a/src/app/layouts/organization-layout.component.html
+++ b/src/app/layouts/organization-layout.component.html
@@ -43,10 +43,10 @@
             </ul>
         </div>
         <div class="ml-auto d-flex align-items-center">
-            <button class="btn btn-primary" (click)="goToEnterprisePortal()" #enterpriseBtn
-                [appApiAction]="enterpriseTokenPromise" *ngIf="showEnterprisePortalButton">
-                <i class="fa fa-bank fa-fw" [hidden]="enterpriseBtn.loading" aria-hidden="true"></i>
-                <i class="fa fa-spinner fa-spin fa-fw" [hidden]="!enterpriseBtn.loading" title="{{'loading' | i18n}}"
+            <button class="btn btn-primary" (click)="goToBusinessPortal()" #businessBtn
+                [appApiAction]="businessTokenPromise" *ngIf="showBusinessPortalButton">
+                <i class="fa fa-bank fa-fw" [hidden]="businessBtn.loading" aria-hidden="true"></i>
+                <i class="fa fa-spinner fa-spin fa-fw" [hidden]="!businessBtn.loading" title="{{'loading' | i18n}}"
                     aria-hidden="true"></i>
                 {{'businessPortal' | i18n}} →
             </button>

--- a/src/app/layouts/organization-layout.component.html
+++ b/src/app/layouts/organization-layout.component.html
@@ -15,21 +15,21 @@
                     </div>
                 </div>
             </div>
-            <ul class="nav nav-tabs" *ngIf="organization.isManager">
+            <ul class="nav nav-tabs" *ngIf="showMenuBar">
                 <li class="nav-item">
                     <a class="nav-link" routerLink="vault" routerLinkActive="active">
                         <i class="fa fa-lock" aria-hidden="true"></i>
                         {{'vault' | i18n}}
                     </a>
                 </li>
-                <li class="nav-item">
-                    <a class="nav-link" routerLink="manage" routerLinkActive="active">
+                <li class="nav-item" *ngIf="showManageTab">
+                    <a class="nav-link" [routerLink]="manageRoute" routerLinkActive="active">
                         <i class="fa fa-sliders" aria-hidden="true"></i>
                         {{'manage' | i18n}}
                     </a>
                 </li>
-                <li class="nav-item" *ngIf="organization.isAdmin">
-                    <a class="nav-link" routerLink="tools" routerLinkActive="active">
+                <li class="nav-item" *ngIf="showToolsTab">
+                    <a class="nav-link" [routerLink]="toolsRoute" routerLinkActive="active">
                         <i class="fa fa-wrench" aria-hidden="true"></i>
                         {{'tools' | i18n}}
                     </a>
@@ -44,7 +44,7 @@
         </div>
         <div class="ml-auto d-flex align-items-center">
             <button class="btn btn-primary" (click)="goToEnterprisePortal()" #enterpriseBtn
-                [appApiAction]="enterpriseTokenPromise" *ngIf="organization.useBusinessPortal">
+                [appApiAction]="enterpriseTokenPromise" *ngIf="showEnterprisePortalButton">
                 <i class="fa fa-bank fa-fw" [hidden]="enterpriseBtn.loading" aria-hidden="true"></i>
                 <i class="fa fa-spinner fa-spin fa-fw" [hidden]="!enterpriseBtn.loading" title="{{'loading' | i18n}}"
                     aria-hidden="true"></i>

--- a/src/app/layouts/organization-layout.component.ts
+++ b/src/app/layouts/organization-layout.component.ts
@@ -24,9 +24,9 @@ const BroadcasterSubscriptionId = 'OrganizationLayoutComponent';
 })
 export class OrganizationLayoutComponent implements OnInit, OnDestroy {
     organization: Organization;
-    enterpriseTokenPromise: Promise<any>;
+    businessTokenPromise: Promise<any>;
     private organizationId: string;
-    private enterpriseUrl: string;
+    private businessUrl: string;
 
     constructor(private route: ActivatedRoute, private userService: UserService,
         private broadcasterService: BroadcasterService, private ngZone: NgZone,
@@ -34,11 +34,11 @@ export class OrganizationLayoutComponent implements OnInit, OnDestroy {
         private environmentService: EnvironmentService) { }
 
     ngOnInit() {
-        this.enterpriseUrl = 'https://portal.bitwarden.com';
+        this.businessUrl = 'https://portal.bitwarden.com';
         if (this.environmentService.enterpriseUrl != null) {
-            this.enterpriseUrl = this.environmentService.enterpriseUrl;
+            this.businessUrl = this.environmentService.enterpriseUrl;
         } else if (this.environmentService.baseUrl != null) {
-            this.enterpriseUrl = this.environmentService.baseUrl + '/portal';
+            this.businessUrl = this.environmentService.baseUrl + '/portal';
         }
 
         document.body.classList.remove('layout_frontend');
@@ -65,20 +65,20 @@ export class OrganizationLayoutComponent implements OnInit, OnDestroy {
         this.organization = await this.userService.getOrganization(this.organizationId);
     }
 
-    async goToEnterprisePortal() {
-        if (this.enterpriseTokenPromise != null) {
+    async goToBusinessPortal() {
+        if (this.businessTokenPromise != null) {
             return;
         }
         try {
-            this.enterpriseTokenPromise = this.apiService.getEnterprisePortalSignInToken();
-            const token = await this.enterpriseTokenPromise;
+            this.businessTokenPromise = this.apiService.getEnterprisePortalSignInToken();
+            const token = await this.businessTokenPromise;
             if (token != null) {
                 const userId = await this.userService.getUserId();
-                this.platformUtilsService.launchUri(this.enterpriseUrl + '/login?userId=' + userId +
+                this.platformUtilsService.launchUri(this.businessUrl + '/login?userId=' + userId +
                     '&token=' + (window as any).encodeURIComponent(token) + '&organizationId=' + this.organization.id);
             }
         } catch { }
-        this.enterpriseTokenPromise = null;
+        this.businessTokenPromise = null;
     }
 
     get showMenuBar() {
@@ -98,7 +98,7 @@ export class OrganizationLayoutComponent implements OnInit, OnDestroy {
         return this.organization.canAccessImportExport || this.organization.canAccessReports;
     }
 
-    get showEnterprisePortalButton(): boolean {
+    get showBusinessPortalButton(): boolean {
         return this.organization.useBusinessPortal && this.organization.canAccessBusinessPortal;
     }
 

--- a/src/app/layouts/organization-layout.component.ts
+++ b/src/app/layouts/organization-layout.component.ts
@@ -117,7 +117,7 @@ export class OrganizationLayoutComponent implements OnInit, OnDestroy {
             case this.organization.canManageAssignedCollections || this.organization.canManageAllCollections:
                 route = 'manage/collections';
                 break;
-            case this.organization.manageGroups:
+            case this.organization.canManageGroups:
                 route = 'manage/groups';
                 break;
             case this.organization.canManagePolicies:

--- a/src/app/layouts/organization-layout.component.ts
+++ b/src/app/layouts/organization-layout.component.ts
@@ -80,4 +80,53 @@ export class OrganizationLayoutComponent implements OnInit, OnDestroy {
         } catch { }
         this.enterpriseTokenPromise = null;
     }
+
+    get showMenuBar() {
+        return this.showManageTab || this.showToolsTab || this.organization.isOwner;
+    }
+
+    get showManageTab(): boolean {
+        return this.organization.canManageUsers ||
+            this.organization.canManageAssignedCollections ||
+            this.organization.canManageAllCollections ||
+            this.organization.canManageGroups ||
+            this.organization.canManagePolicies ||
+            this.organization.canAccessEventLogs;
+    }
+
+    get showToolsTab(): boolean {
+        return this.organization.canAccessImportExport || this.organization.canAccessReports;
+    }
+
+    get showEnterprisePortalButton(): boolean {
+        return this.organization.useBusinessPortal && this.organization.canAccessBusinessPortal;
+    }
+
+    get toolsRoute(): string {
+        return this.organization.canAccessImportExport ?
+            'tools/import' :
+            'tools/exposed-passwords-report';
+    }
+
+    get manageRoute(): string {
+        let route: string;
+        switch (true) {
+            case this.organization.canManageUsers:
+                route = 'manage/people';
+                break;
+            case this.organization.canManageAssignedCollections || this.organization.canManageAllCollections:
+                route = 'manage/collections';
+                break;
+            case this.organization.manageGroups:
+                route = 'manage/groups';
+                break;
+            case this.organization.canManagePolicies:
+                route = 'manage/policies';
+                break;
+            case this.organization.canAccessEventLogs:
+                route = 'manage/events';
+                break;
+        }
+        return route;
+    }
 }

--- a/src/app/organizations/manage/collections.component.ts
+++ b/src/app/organizations/manage/collections.component.ts
@@ -72,7 +72,7 @@ export class CollectionsComponent implements OnInit {
     async load() {
         const organization = await this.userService.getOrganization(this.organizationId);
         let response: ListResponse<CollectionResponse>;
-        if (organization.isAdmin) {
+        if (organization.canManageAllCollections) {
             response = await this.apiService.getCollections(this.organizationId);
         } else {
             response = await this.apiService.getUserCollections();

--- a/src/app/organizations/manage/manage.component.html
+++ b/src/app/organizations/manage/manage.component.html
@@ -5,22 +5,23 @@
                 <div class="card-header">{{'manage' | i18n}}</div>
                 <div class="list-group list-group-flush">
                     <a routerLink="people" class="list-group-item" routerLinkActive="active"
-                        *ngIf="organization.isAdmin">
+                        *ngIf="organization.canManageUsers">
                         {{'people' | i18n}}
                     </a>
-                    <a routerLink="collections" class="list-group-item" routerLinkActive="active">
+                    <a routerLink="collections" class="list-group-item" routerLinkActive="active"
+                        *ngIf="organization.canManageAssignedCollections || organization.canManageAllCollections">
                         {{'collections' | i18n}}
                     </a>
                     <a routerLink="groups" class="list-group-item" routerLinkActive="active"
-                        *ngIf="organization.isAdmin && accessGroups">
+                        *ngIf="organization.canManageGroups && accessGroups">
                         {{'groups' | i18n}}
                     </a>
                     <a routerLink="policies" class="list-group-item" routerLinkActive="active"
-                        *ngIf="organization.isAdmin && accessPolicies">
+                        *ngIf="organization.canManagePolicies && accessPolicies">
                         {{'policies' | i18n}}
                     </a>
                     <a routerLink="events" class="list-group-item" routerLinkActive="active"
-                        *ngIf="organization.isAdmin && accessEvents">
+                        *ngIf="organization.canAccessEventLogs && accessEvents">
                         {{'eventLogs' | i18n}}
                     </a>
                 </div>

--- a/src/app/organizations/manage/people.component.html
+++ b/src/app/organizations/manage/people.component.html
@@ -69,6 +69,7 @@
                         <span *ngIf="u.type === organizationUserType.Admin">{{'admin' | i18n}}</span>
                         <span *ngIf="u.type === organizationUserType.Manager">{{'manager' | i18n}}</span>
                         <span *ngIf="u.type === organizationUserType.User">{{'user' | i18n}}</span>
+                        <span *ngIf="u.type === organizationUserType.Custom">{{'custom' | i18n}}</span>
                     </td>
                     <td class="table-list-options">
                         <div class="dropdown" appListDropdown>

--- a/src/app/organizations/manage/people.component.ts
+++ b/src/app/organizations/manage/people.component.ts
@@ -79,7 +79,7 @@ export class PeopleComponent implements OnInit {
         this.route.parent.parent.params.subscribe(async (params) => {
             this.organizationId = params.organizationId;
             const organization = await this.userService.getOrganization(this.organizationId);
-            if (!organization.isAdmin) {
+            if (!organization.canManageUsers) {
                 this.router.navigate(['../collections'], { relativeTo: this.route });
                 return;
             }

--- a/src/app/organizations/manage/user-add-edit.component.html
+++ b/src/app/organizations/manage/user-add-edit.component.html
@@ -79,22 +79,15 @@
                         <div class="col-6">
                             <div class="mb-3">
                                 <label class="font-weight-bold mb-0">Manager Permissions</label>
-                                <hr class="my-0 mr-2"/>
+                                <hr class="my-0 mr-2" />
                                 <div class="form-group mb-0">
                                     <div class="form-check mt-1 form-check-block">
-                                        <input class="form-check-input" type="checkbox" name="manageAssignedCollections" id="manageAssignedCollections" 
-                                            [(ngModel)]="manageAssignedCollections">
-                                        <label class="form-check-label font-weight-normal" for="manageAssignedCollections">
+                                        <input class="form-check-input" type="checkbox" name="manageAssignedCollections"
+                                            id="manageAssignedCollections"
+                                            [(ngModel)]="permissions.manageAssignedCollections">
+                                        <label class="form-check-label font-weight-normal"
+                                            for="manageAssignedCollections">
                                             {{'manageAssignedCollections' | i18n}}
-                                        </label>
-                                    </div>
-                                </div>
-                                <div class="form-group mb-0">
-                                    <div class="form-check mt-1 form-check-block">
-                                        <input class="form-check-input" type="checkbox" name="viewUsers" id="viewUsers" 
-                                            [(ngModel)]="viewUsers">
-                                        <label class="form-check-label font-weight-normal" for="viewUsers">
-                                            {{'viewUsers' | i18n}}
                                         </label>
                                     </div>
                                 </div>
@@ -103,11 +96,11 @@
                         <div class="col-6">
                             <div class="mb-3">
                                 <label class="font-weight-bold mb-0">Admin Permissions</label>
-                                <hr class="my-0 mr-2"/>
+                                <hr class="my-0 mr-2" />
                                 <div class="form-group mb-0">
                                     <div class="form-check mt-1 form-check-block">
-                                        <input class="form-check-input" type="checkbox" name="accessBusinessPortal" id="accessBusinessPortal" 
-                                            [(ngModel)]="accessBusinessPortal">
+                                        <input class="form-check-input" type="checkbox" name="accessBusinessPortal"
+                                            id="accessBusinessPortal" [(ngModel)]="permissions.accessBusinessPortal">
                                         <label class="form-check-label font-weight-normal" for="accessBusinessPortal">
                                             {{'accessBusinessPortal' | i18n}}
                                         </label>
@@ -115,8 +108,8 @@
                                 </div>
                                 <div class="form-group mb-0">
                                     <div class="form-check mt-1 form-check-block">
-                                        <input class="form-check-input" type="checkbox" name="accessEventLogs" id="accessEventLogs" 
-                                            [(ngModel)]="accessEventLogs">
+                                        <input class="form-check-input" type="checkbox" name="accessEventLogs"
+                                            id="accessEventLogs" [(ngModel)]="permissions.accessEventLogs">
                                         <label class="form-check-label font-weight-normal" for="accessEventLogs">
                                             {{'accessEventLogs' | i18n}}
                                         </label>
@@ -124,8 +117,8 @@
                                 </div>
                                 <div class="form-group mb-0">
                                     <div class="form-check mt-1 form-check-block">
-                                        <input class="form-check-input" type="checkbox" name="accessImportExport" id="accessImportExport" 
-                                            [(ngModel)]="accessImportExport">
+                                        <input class="form-check-input" type="checkbox" name="accessImportExport"
+                                            id="accessImportExport" [(ngModel)]="permissions.accessImportExport">
                                         <label class="form-check-label font-weight-normal" for="accessImportExport">
                                             {{'accessImportExport' | i18n}}
                                         </label>
@@ -133,8 +126,8 @@
                                 </div>
                                 <div class="form-group mb-0">
                                     <div class="form-check mt-1 form-check-block">
-                                        <input class="form-check-input" type="checkbox" name="accessReports" id="accessReports" 
-                                            [(ngModel)]="accessReports">
+                                        <input class="form-check-input" type="checkbox" name="accessReports"
+                                            id="accessReports" [(ngModel)]="permissions.accessReports">
                                         <label class="form-check-label font-weight-normal" for="accessReports">
                                             {{'accessReports' | i18n}}
                                         </label>
@@ -142,8 +135,8 @@
                                 </div>
                                 <div class="form-group mb-0">
                                     <div class="form-check mt-1 form-check-block">
-                                        <input class="form-check-input" type="checkbox" name="manageAllCollections" id="manageAllCollections" 
-                                            [(ngModel)]="manageAllCollections">
+                                        <input class="form-check-input" type="checkbox" name="manageAllCollections"
+                                            id="manageAllCollections" [(ngModel)]="permissions.manageAllCollections">
                                         <label class="form-check-label font-weight-normal" for="manageAllCollections">
                                             {{'manageAllCollections' | i18n}}
                                         </label>
@@ -151,8 +144,8 @@
                                 </div>
                                 <div class="form-group mb-0">
                                     <div class="form-check mt-1 form-check-block">
-                                        <input class="form-check-input" type="checkbox" name="manageGroups" id="manageGroups" 
-                                            [(ngModel)]="manageGroups">
+                                        <input class="form-check-input" type="checkbox" name="manageGroups"
+                                            id="manageGroups" [(ngModel)]="permissions.manageGroups">
                                         <label class="form-check-label font-weight-normal" for="manageGroups">
                                             {{'manageGroups' | i18n}}
                                         </label>
@@ -160,8 +153,17 @@
                                 </div>
                                 <div class="form-group mb-0">
                                     <div class="form-check mt-1 form-check-block">
-                                        <input class="form-check-input" type="checkbox" name="managePolicies" id="managePolicies" 
-                                            [(ngModel)]="managePolicies">
+                                        <input class="form-check-input" type="checkbox" name="manageSso"
+                                            id="managePolicies" [(ngModel)]="permissions.manageSso">
+                                        <label class="form-check-label font-weight-normal" for="manageSso">
+                                            {{'manageSso' | i18n}}
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="form-group mb-0">
+                                    <div class="form-check mt-1 form-check-block">
+                                        <input class="form-check-input" type="checkbox" name="managePolicies"
+                                            id="managePolicies" [(ngModel)]="permissions.managePolicies">
                                         <label class="form-check-label font-weight-normal" for="managePolicies">
                                             {{'managePolicies' | i18n}}
                                         </label>
@@ -169,8 +171,8 @@
                                 </div>
                                 <div class="form-group mb-0">
                                     <div class="form-check mt-1 form-check-block">
-                                        <input class="form-check-input" type="checkbox" name="manageUsers" id="manageUsers" 
-                                            [(ngModel)]="manageUsers">
+                                        <input class="form-check-input" type="checkbox" name="manageUsers"
+                                            id="manageUsers" [(ngModel)]="permissions.manageUsers">
                                         <label class="form-check-label font-weight-normal" for="manageUsers">
                                             {{'manageUsers' | i18n}}
                                         </label>

--- a/src/app/organizations/manage/user-add-edit.component.html
+++ b/src/app/organizations/manage/user-add-edit.component.html
@@ -63,8 +63,125 @@
                         <small>{{'ownerDesc' | i18n}}</small>
                     </label>
                 </div>
+                <div class="form-check mt-2 form-check-block">
+                    <input class="form-check-input" type="radio" name="userType" id="userTypeCustom"
+                        [value]="organizationUserType.Custom" [(ngModel)]="type">
+                    <label class="form-check-label" for="userTypeCustom">
+                        {{'custom' | i18n}}
+                        <small>{{'customDesc' | i18n}}</small>
+                    </label>
+                </div>
+                <ng-container *ngIf="customUserTypeSelected">
+                    <h3 class="mt-4 d-flex">
+                        {{'permissions' | i18n}}
+                    </h3>
+                    <div class="row">
+                        <div class="col-6">
+                            <div class="mb-3">
+                                <label class="font-weight-bold mb-0">Manager Permissions</label>
+                                <hr class="my-0 mr-2"/>
+                                <div class="form-group mb-0">
+                                    <div class="form-check mt-1 form-check-block">
+                                        <input class="form-check-input" type="checkbox" name="manageAssignedCollections" id="manageAssignedCollections" 
+                                            [(ngModel)]="manageAssignedCollections">
+                                        <label class="form-check-label font-weight-normal" for="manageAssignedCollections">
+                                            {{'manageAssignedCollections' | i18n}}
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="form-group mb-0">
+                                    <div class="form-check mt-1 form-check-block">
+                                        <input class="form-check-input" type="checkbox" name="viewUsers" id="viewUsers" 
+                                            [(ngModel)]="viewUsers">
+                                        <label class="form-check-label font-weight-normal" for="viewUsers">
+                                            {{'viewUsers' | i18n}}
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-6">
+                            <div class="mb-3">
+                                <label class="font-weight-bold mb-0">Admin Permissions</label>
+                                <hr class="my-0 mr-2"/>
+                                <div class="form-group mb-0">
+                                    <div class="form-check mt-1 form-check-block">
+                                        <input class="form-check-input" type="checkbox" name="accessBusinessPortal" id="accessBusinessPortal" 
+                                            [(ngModel)]="accessBusinessPortal">
+                                        <label class="form-check-label font-weight-normal" for="accessBusinessPortal">
+                                            {{'accessBusinessPortal' | i18n}}
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="form-group mb-0">
+                                    <div class="form-check mt-1 form-check-block">
+                                        <input class="form-check-input" type="checkbox" name="accessEventLogs" id="accessEventLogs" 
+                                            [(ngModel)]="accessEventLogs">
+                                        <label class="form-check-label font-weight-normal" for="accessEventLogs">
+                                            {{'accessEventLogs' | i18n}}
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="form-group mb-0">
+                                    <div class="form-check mt-1 form-check-block">
+                                        <input class="form-check-input" type="checkbox" name="accessImportExport" id="accessImportExport" 
+                                            [(ngModel)]="accessImportExport">
+                                        <label class="form-check-label font-weight-normal" for="accessImportExport">
+                                            {{'accessImportExport' | i18n}}
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="form-group mb-0">
+                                    <div class="form-check mt-1 form-check-block">
+                                        <input class="form-check-input" type="checkbox" name="accessReports" id="accessReports" 
+                                            [(ngModel)]="accessReports">
+                                        <label class="form-check-label font-weight-normal" for="accessReports">
+                                            {{'accessReports' | i18n}}
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="form-group mb-0">
+                                    <div class="form-check mt-1 form-check-block">
+                                        <input class="form-check-input" type="checkbox" name="manageAllCollections" id="manageAllCollections" 
+                                            [(ngModel)]="manageAllCollections">
+                                        <label class="form-check-label font-weight-normal" for="manageAllCollections">
+                                            {{'manageAllCollections' | i18n}}
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="form-group mb-0">
+                                    <div class="form-check mt-1 form-check-block">
+                                        <input class="form-check-input" type="checkbox" name="manageGroups" id="manageGroups" 
+                                            [(ngModel)]="manageGroups">
+                                        <label class="form-check-label font-weight-normal" for="manageGroups">
+                                            {{'manageGroups' | i18n}}
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="form-group mb-0">
+                                    <div class="form-check mt-1 form-check-block">
+                                        <input class="form-check-input" type="checkbox" name="managePolicies" id="managePolicies" 
+                                            [(ngModel)]="managePolicies">
+                                        <label class="form-check-label font-weight-normal" for="managePolicies">
+                                            {{'managePolicies' | i18n}}
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="form-group mb-0">
+                                    <div class="form-check mt-1 form-check-block">
+                                        <input class="form-check-input" type="checkbox" name="manageUsers" id="manageUsers" 
+                                            [(ngModel)]="manageUsers">
+                                        <label class="form-check-label font-weight-normal" for="manageUsers">
+                                            {{'manageUsers' | i18n}}
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </ng-container>
                 <h3 class="mt-4 d-flex">
-                    <div class="mb-2">
+                    <div class="mb-3">
                         {{'accessControl' | i18n}}
                         <a target="_blank" rel="noopener" appA11yTitle="{{'learnMore' | i18n}}"
                             href="https://bitwarden.com/help/article/user-types-access-control/#access-control">

--- a/src/app/organizations/tools/exposed-passwords-report.component.ts
+++ b/src/app/organizations/tools/exposed-passwords-report.component.ts
@@ -29,7 +29,7 @@ export class ExposedPasswordsReportComponent extends BaseExposedPasswordsReportC
         super(cipherService, auditService, componentFactoryResolver, messagingService, userService);
     }
 
-    async ngOnInit() {
+    ngOnInit() {
         this.route.parent.parent.params.subscribe(async (params) => {
             this.organization = await this.userService.getOrganization(params.organizationId);
             this.manageableCiphers = await this.cipherService.getAll();

--- a/src/app/organizations/tools/exposed-passwords-report.component.ts
+++ b/src/app/organizations/tools/exposed-passwords-report.component.ts
@@ -14,26 +14,34 @@ import {
 } from '../../tools/exposed-passwords-report.component';
 
 import { CipherView } from 'jslib/models/view/cipherView';
+import { Cipher } from 'jslib/models/domain/cipher';
 
 @Component({
     selector: 'app-exposed-passwords-report',
     templateUrl: '../../tools/exposed-passwords-report.component.html',
 })
 export class ExposedPasswordsReportComponent extends BaseExposedPasswordsReportComponent {
+    manageableCiphers: Cipher[];
+
     constructor(cipherService: CipherService, auditService: AuditService,
         componentFactoryResolver: ComponentFactoryResolver, messagingService: MessagingService,
         userService: UserService, private route: ActivatedRoute) {
         super(cipherService, auditService, componentFactoryResolver, messagingService, userService);
     }
 
-    ngOnInit() {
+    async ngOnInit() {
         this.route.parent.parent.params.subscribe(async (params) => {
             this.organization = await this.userService.getOrganization(params.organizationId);
+            this.manageableCiphers = await this.cipherService.getAll();
             super.ngOnInit();
         });
     }
 
     getAllCiphers(): Promise<CipherView[]> {
         return this.cipherService.getAllFromApiForOrganization(this.organization.id);
+    }
+
+    canManageCipher(c: CipherView): boolean {
+        return this.manageableCiphers.some(x => x.id === c.id);
     }
 }

--- a/src/app/organizations/tools/reused-passwords-report.component.ts
+++ b/src/app/organizations/tools/reused-passwords-report.component.ts
@@ -8,6 +8,8 @@ import { CipherService } from 'jslib/abstractions/cipher.service';
 import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { UserService } from 'jslib/abstractions/user.service';
 
+import { Cipher } from 'jslib/models/domain/cipher';
+
 import { CipherView } from 'jslib/models/view/cipherView';
 
 import {
@@ -19,6 +21,8 @@ import {
     templateUrl: '../../tools/reused-passwords-report.component.html',
 })
 export class ReusedPasswordsReportComponent extends BaseReusedPasswordsReportComponent {
+    manageableCiphers: Cipher[];
+
     constructor(cipherService: CipherService, componentFactoryResolver: ComponentFactoryResolver,
         messagingService: MessagingService, userService: UserService,
         private route: ActivatedRoute) {
@@ -28,11 +32,16 @@ export class ReusedPasswordsReportComponent extends BaseReusedPasswordsReportCom
     async ngOnInit() {
         this.route.parent.parent.params.subscribe(async (params) => {
             this.organization = await this.userService.getOrganization(params.organizationId);
+            this.manageableCiphers = await this.cipherService.getAll();
             await super.ngOnInit();
         });
     }
 
     getAllCiphers(): Promise<CipherView[]> {
         return this.cipherService.getAllFromApiForOrganization(this.organization.id);
+    }
+
+    canManageCipher(c: CipherView): boolean {
+        return this.manageableCiphers.some(x => x.id === c.id);
     }
 }

--- a/src/app/organizations/tools/tools.component.html
+++ b/src/app/organizations/tools/tools.component.html
@@ -1,48 +1,54 @@
 <div class="container page-content">
-    <div class="row">
-        <div class="col-3">
-            <div class="card mb-4">
-                <div class="card-header">{{'tools' | i18n}}</div>
-                <div class="list-group list-group-flush">
-                    <a routerLink="import" class="list-group-item" routerLinkActive="active">
-                        {{'importData' | i18n}}
-                    </a>
-                    <a routerLink="export" class="list-group-item" routerLinkActive="active">
-                        {{'exportVault' | i18n}}
-                    </a>
-                </div>
-            </div>
-            <div class="card">
-                <div class="card-header d-flex">
-                    {{'reports' | i18n}}
-                    <div class="ml-auto">
-                        <a href="#" appStopClick class="badge badge-primary" *ngIf="!accessReports"
-                            (click)="upgradeOrganization()">
-                            {{'upgrade' | i18n}}
+    <ng-container *ngIf="loading">
+        <i class="fa fa-spinner fa-spin text-muted" title="{{'loading' | i18n}}" aria-hidden="true"></i>
+        <span class="sr-only">{{'loading' | i18n}}</span>
+    </ng-container>
+    <ng-container *ngIf="!loading">
+        <div class="row">
+            <div class="col-3">
+                <div class="card mb-4" *ngIf="organization.canAccessImportExport">
+                    <div class="card-header">{{'tools' | i18n}}</div>
+                    <div class="list-group list-group-flush">
+                        <a routerLink="import" class="list-group-item" routerLinkActive="active">
+                            {{'importData' | i18n}}
+                        </a>
+                        <a routerLink="export" class="list-group-item" routerLinkActive="active">
+                            {{'exportVault' | i18n}}
                         </a>
                     </div>
                 </div>
-                <div class="list-group list-group-flush">
-                    <a routerLink="exposed-passwords-report" class="list-group-item" routerLinkActive="active">
-                        {{'exposedPasswordsReport' | i18n}}
-                    </a>
-                    <a routerLink="reused-passwords-report" class="list-group-item" routerLinkActive="active">
-                        {{'reusedPasswordsReport' | i18n}}
-                    </a>
-                    <a routerLink="weak-passwords-report" class="list-group-item" routerLinkActive="active">
-                        {{'weakPasswordsReport' | i18n}}
-                    </a>
-                    <a routerLink="unsecured-websites-report" class="list-group-item" routerLinkActive="active">
-                        {{'unsecuredWebsitesReport' | i18n}}
-                    </a>
-                    <a routerLink="inactive-two-factor-report" class="list-group-item" routerLinkActive="active">
-                        {{'inactive2faReport' | i18n}}
-                    </a>
+                <div class="card" *ngIf="organization.canAccessReports">
+                    <div class="card-header d-flex">
+                        {{'reports' | i18n}}
+                        <div class="ml-auto">
+                            <a href="#" appStopClick class="badge badge-primary" *ngIf="!accessReports"
+                                (click)="upgradeOrganization()">
+                                {{'upgrade' | i18n}}
+                            </a>
+                        </div>
+                    </div>
+                    <div class="list-group list-group-flush">
+                        <a routerLink="exposed-passwords-report" class="list-group-item" routerLinkActive="active">
+                            {{'exposedPasswordsReport' | i18n}}
+                        </a>
+                        <a routerLink="reused-passwords-report" class="list-group-item" routerLinkActive="active">
+                            {{'reusedPasswordsReport' | i18n}}
+                        </a>
+                        <a routerLink="weak-passwords-report" class="list-group-item" routerLinkActive="active">
+                            {{'weakPasswordsReport' | i18n}}
+                        </a>
+                        <a routerLink="unsecured-websites-report" class="list-group-item" routerLinkActive="active">
+                            {{'unsecuredWebsitesReport' | i18n}}
+                        </a>
+                        <a routerLink="inactive-two-factor-report" class="list-group-item" routerLinkActive="active">
+                            {{'inactive2faReport' | i18n}}
+                        </a>
+                    </div>
                 </div>
             </div>
+            <div class="col-9">
+                <router-outlet></router-outlet>
+            </div>
         </div>
-        <div class="col-9">
-            <router-outlet></router-outlet>
-        </div>
-    </div>
+    </ng-container>
 </div>

--- a/src/app/organizations/tools/tools.component.ts
+++ b/src/app/organizations/tools/tools.component.ts
@@ -13,6 +13,7 @@ import { UserService } from 'jslib/abstractions/user.service';
 export class ToolsComponent {
     organization: Organization;
     accessReports = false;
+    loading = true;
 
     constructor(private route: ActivatedRoute, private userService: UserService,
         private messagingService: MessagingService) { }
@@ -23,6 +24,7 @@ export class ToolsComponent {
             // TODO: Maybe we want to just make sure they are not on a free plan? Just compare useTotp for now
             // since all paid plans include useTotp
             this.accessReports = this.organization.useTotp;
+            this.loading = false;
         });
     }
 

--- a/src/app/organizations/tools/weak-passwords-report.component.ts
+++ b/src/app/organizations/tools/weak-passwords-report.component.ts
@@ -9,6 +9,8 @@ import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { PasswordGenerationService } from 'jslib/abstractions/passwordGeneration.service';
 import { UserService } from 'jslib/abstractions/user.service';
 
+import { Cipher } from 'jslib/models/domain/cipher';
+
 import { CipherView } from 'jslib/models/view/cipherView';
 
 import {
@@ -20,6 +22,8 @@ import {
     templateUrl: '../../tools/weak-passwords-report.component.html',
 })
 export class WeakPasswordsReportComponent extends BaseWeakPasswordsReportComponent {
+    manageableCiphers: Cipher[];
+
     constructor(cipherService: CipherService, passwordGenerationService: PasswordGenerationService,
         componentFactoryResolver: ComponentFactoryResolver, messagingService: MessagingService,
         userService: UserService, private route: ActivatedRoute) {
@@ -29,11 +33,16 @@ export class WeakPasswordsReportComponent extends BaseWeakPasswordsReportCompone
     async ngOnInit() {
         this.route.parent.parent.params.subscribe(async (params) => {
             this.organization = await this.userService.getOrganization(params.organizationId);
+            this.manageableCiphers = await this.cipherService.getAll();
             await super.ngOnInit();
         });
     }
 
     getAllCiphers(): Promise<CipherView[]> {
         return this.cipherService.getAllFromApiForOrganization(this.organization.id);
+    }
+
+    canManageCipher(c: CipherView): boolean {
+        return this.manageableCiphers.some(x => x.id === c.id);
     }
 }

--- a/src/app/organizations/vault/add-edit.component.ts
+++ b/src/app/organizations/vault/add-edit.component.ts
@@ -46,7 +46,7 @@ export class AddEditComponent extends BaseAddEditComponent {
     protected allowOwnershipAssignment() {
         if (this.ownershipOptions != null && (this.ownershipOptions.length > 1 || !this.allowPersonal)) {
             if (this.organization != null) {
-                return this.cloneMode && this.organization.isAdmin;
+                return this.cloneMode && this.organization.canManageAllCollections;
             } else {
                 return !this.editMode || this.cloneMode;
             }
@@ -55,14 +55,14 @@ export class AddEditComponent extends BaseAddEditComponent {
     }
 
     protected loadCollections() {
-        if (!this.organization.isAdmin) {
+        if (!this.organization.canManageAllCollections) {
             return super.loadCollections();
         }
         return Promise.resolve(this.collections);
     }
 
     protected async loadCipher() {
-        if (!this.organization.isAdmin) {
+        if (!this.organization.canManageAllCollections) {
             return await super.loadCipher();
         }
         const response = await this.apiService.getCipherAdmin(this.cipherId);
@@ -72,14 +72,14 @@ export class AddEditComponent extends BaseAddEditComponent {
     }
 
     protected encryptCipher() {
-        if (!this.organization.isAdmin) {
+        if (!this.organization.canManageAllCollections) {
             return super.encryptCipher();
         }
         return this.cipherService.encrypt(this.cipher, null, this.originalCipher);
     }
 
     protected async saveCipher(cipher: Cipher) {
-        if (!this.organization.isAdmin || cipher.organizationId == null) {
+        if (!this.organization.canManageAllCollections || cipher.organizationId == null) {
             return super.saveCipher(cipher);
         }
         if (this.editMode && !this.cloneMode) {
@@ -92,7 +92,7 @@ export class AddEditComponent extends BaseAddEditComponent {
     }
 
     protected async deleteCipher() {
-        if (!this.organization.isAdmin) {
+        if (!this.organization.canManageAllCollections) {
             return super.deleteCipher();
         }
         return this.cipher.isDeleted ? this.apiService.deleteCipherAdmin(this.cipherId)

--- a/src/app/organizations/vault/attachments.component.ts
+++ b/src/app/organizations/vault/attachments.component.ts
@@ -29,13 +29,13 @@ export class AttachmentsComponent extends BaseAttachmentsComponent {
     }
 
     protected async reupload(attachment: AttachmentView) {
-        if (this.organization.isAdmin && this.showFixOldAttachments(attachment)) {
+        if (this.organization.canManageAllCollections && this.showFixOldAttachments(attachment)) {
             await super.reuploadCipherAttachment(attachment, true);
         }
     }
 
     protected async loadCipher() {
-        if (!this.organization.isAdmin) {
+        if (!this.organization.canManageAllCollections) {
             return await super.loadCipher();
         }
         const response = await this.apiService.getCipherAdmin(this.cipherId);
@@ -43,17 +43,17 @@ export class AttachmentsComponent extends BaseAttachmentsComponent {
     }
 
     protected saveCipherAttachment(file: File) {
-        return this.cipherService.saveAttachmentWithServer(this.cipherDomain, file, this.organization.isAdmin);
+        return this.cipherService.saveAttachmentWithServer(this.cipherDomain, file, this.organization.canManageAllCollections);
     }
 
     protected deleteCipherAttachment(attachmentId: string) {
-        if (!this.organization.isAdmin) {
+        if (!this.organization.canManageAllCollections) {
             return super.deleteCipherAttachment(attachmentId);
         }
         return this.apiService.deleteCipherAttachmentAdmin(this.cipherId, attachmentId);
     }
 
     protected showFixOldAttachments(attachment: AttachmentView) {
-        return attachment.key == null && this.organization.isAdmin;
+        return attachment.key == null && this.organization.canManageAllCollections;
     }
 }

--- a/src/app/organizations/vault/ciphers.component.ts
+++ b/src/app/organizations/vault/ciphers.component.ts
@@ -40,7 +40,7 @@ export class CiphersComponent extends BaseCiphersComponent {
     }
 
     async load(filter: (cipher: CipherView) => boolean = null) {
-        if (!this.organization.isAdmin) {
+        if (!this.organization.canManageAllCollections) {
             await super.load(filter, this.deleted);
             return;
         }
@@ -51,7 +51,7 @@ export class CiphersComponent extends BaseCiphersComponent {
     }
 
     async applyFilter(filter: (cipher: CipherView) => boolean = null) {
-        if (this.organization.isAdmin) {
+        if (this.organization.canManageAllCollections) {
             await super.applyFilter(filter);
         } else {
             const f = (c: CipherView) => c.organizationId === this.organization.id && (filter == null || filter(c));
@@ -60,7 +60,7 @@ export class CiphersComponent extends BaseCiphersComponent {
     }
 
     async search(timeout: number = null) {
-        if (!this.organization.isAdmin) {
+        if (!this.organization.canManageAllCollections) {
             return super.search(timeout);
         }
         this.searchPending = false;
@@ -87,13 +87,13 @@ export class CiphersComponent extends BaseCiphersComponent {
     }
 
     protected deleteCipher(id: string) {
-        if (!this.organization.isAdmin) {
+        if (!this.organization.canManageAllCollections) {
             return super.deleteCipher(id, this.deleted);
         }
         return this.deleted ? this.apiService.deleteCipherAdmin(id) : this.apiService.putDeleteCipherAdmin(id);
     }
 
     protected showFixOldAttachments(c: CipherView) {
-        return this.organization.isAdmin && c.hasOldAttachments;
+        return this.organization.canManageAllCollections && c.hasOldAttachments;
     }
 }

--- a/src/app/organizations/vault/collections.component.ts
+++ b/src/app/organizations/vault/collections.component.ts
@@ -36,21 +36,21 @@ export class CollectionsComponent extends BaseCollectionsComponent {
     }
 
     protected loadCipherCollections() {
-        if (!this.organization.manageAllCollections) {
+        if (!this.organization.canManageAllCollections) {
             return super.loadCipherCollections();
         }
         return this.collectionIds;
     }
 
     protected loadCollections() {
-        if (!this.organization.manageAllCollections) {
+        if (!this.organization.canManageAllCollections) {
             return super.loadCollections();
         }
         return Promise.resolve(this.collections);
     }
 
     protected saveCollections() {
-        if (this.organization.manageAllCollections) {
+        if (this.organization.canManageAllCollections) {
             const request = new CipherCollectionsRequest(this.cipherDomain.collectionIds);
             return this.apiService.putCipherCollectionsAdmin(this.cipherId, request);
         } else {

--- a/src/app/organizations/vault/collections.component.ts
+++ b/src/app/organizations/vault/collections.component.ts
@@ -28,7 +28,7 @@ export class CollectionsComponent extends BaseCollectionsComponent {
     }
 
     protected async loadCipher() {
-        if (!this.organization.isAdmin) {
+        if (!this.organization.canManageAllCollections) {
             return await super.loadCipher();
         }
         const response = await this.apiService.getCipherAdmin(this.cipherId);
@@ -36,21 +36,21 @@ export class CollectionsComponent extends BaseCollectionsComponent {
     }
 
     protected loadCipherCollections() {
-        if (!this.organization.isAdmin) {
+        if (!this.organization.manageAllCollections) {
             return super.loadCipherCollections();
         }
         return this.collectionIds;
     }
 
     protected loadCollections() {
-        if (!this.organization.isAdmin) {
+        if (!this.organization.manageAllCollections) {
             return super.loadCollections();
         }
         return Promise.resolve(this.collections);
     }
 
     protected saveCollections() {
-        if (this.organization.isAdmin) {
+        if (this.organization.manageAllCollections) {
             const request = new CipherCollectionsRequest(this.cipherDomain.collectionIds);
             return this.apiService.putCipherCollectionsAdmin(this.cipherId, request);
         } else {

--- a/src/app/organizations/vault/groupings.component.ts
+++ b/src/app/organizations/vault/groupings.component.ts
@@ -29,7 +29,7 @@ export class GroupingsComponent extends BaseGroupingsComponent {
     }
 
     async loadCollections() {
-        if (!this.organization.manageAllCollections) {
+        if (!this.organization.canManageAllCollections) {
             await super.loadCollections(this.organization.id);
             return;
         }

--- a/src/app/organizations/vault/groupings.component.ts
+++ b/src/app/organizations/vault/groupings.component.ts
@@ -29,7 +29,7 @@ export class GroupingsComponent extends BaseGroupingsComponent {
     }
 
     async loadCollections() {
-        if (!this.organization.isAdmin) {
+        if (!this.organization.manageAllCollections) {
             await super.loadCollections(this.organization.id);
             return;
         }

--- a/src/app/organizations/vault/vault.component.ts
+++ b/src/app/organizations/vault/vault.component.ts
@@ -69,7 +69,7 @@ export class VaultComponent implements OnInit, OnDestroy {
 
             const queryParamsSub = this.route.queryParams.subscribe(async (qParams) => {
                 this.ciphersComponent.searchText = this.groupingsComponent.searchText = qParams.search;
-                if (!this.organization.isAdmin) {
+                if (!this.organization.canManageAllCollections) {
                     await this.syncService.fullSync(false);
                     this.broadcasterService.subscribe(BroadcasterSubscriptionId, (message: any) => {
                         this.ngZone.run(async () => {
@@ -233,7 +233,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         this.modal = this.collectionsModalRef.createComponent(factory).instance;
         const childComponent = this.modal.show<CollectionsComponent>(CollectionsComponent, this.collectionsModalRef);
 
-        if (this.organization.isAdmin) {
+        if (this.organization.canManageAllCollections) {
             childComponent.collectionIds = cipher.collectionIds;
             childComponent.collections = this.groupingsComponent.collections.filter((c) => !c.readOnly);
         }
@@ -253,7 +253,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         const component = this.editCipher(null);
         component.organizationId = this.organization.id;
         component.type = this.type;
-        if (this.organization.isAdmin) {
+        if (this.organization.canManageAllCollections) {
             component.collections = this.groupingsComponent.collections.filter((c) => !c.readOnly);
         }
         if (this.collectionId != null) {
@@ -296,7 +296,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         const component = this.editCipher(cipher);
         component.cloneMode = true;
         component.organizationId = this.organization.id;
-        if (this.organization.isAdmin) {
+        if (this.organization.canManageAllCollections) {
             component.collections = this.groupingsComponent.collections.filter((c) => !c.readOnly);
         }
         // Regardless of Admin state, the collection Ids need to passed manually as they are not assigned value

--- a/src/app/services/organization-type-guard.service.ts
+++ b/src/app/services/organization-type-guard.service.ts
@@ -7,20 +7,32 @@ import {
 
 import { UserService } from 'jslib/abstractions/user.service';
 
-import { OrganizationUserType } from 'jslib/enums/organizationUserType';
+import { Permissions } from 'jslib/enums/permissions';
 
 @Injectable()
 export class OrganizationTypeGuardService implements CanActivate {
     constructor(private userService: UserService, private router: Router) { }
 
     async canActivate(route: ActivatedRouteSnapshot) {
-        const org = await this.userService.getOrganization(route.parent.params.organizationId);
-        const allowedTypes = route.data == null ? null : route.data.allowedTypes as OrganizationUserType[];
-        if (allowedTypes == null || allowedTypes.indexOf(org.type) === -1) {
-            this.router.navigate(['/organizations', org.id]);
-            return false;
+        const org = await this.userService.getOrganization(route.params.organizationId);
+        const permissions = route.data == null ? null : route.data.permissions as Permissions[];
+
+        if (
+            (permissions.indexOf(Permissions.AccessBusinessPortal) !== -1 && org.canAccessBusinessPortal) ||
+            (permissions.indexOf(Permissions.AccessEventLogs) !== -1 && org.canAccessEventLogs) ||
+            (permissions.indexOf(Permissions.AccessImportExport) !== -1 && org.canAccessImportExport) ||
+            (permissions.indexOf(Permissions.AccessReports) !== -1 && org.canAccessReports) ||
+            (permissions.indexOf(Permissions.ManageAllCollections) !== -1 && org.canManageAllCollections) ||
+            (permissions.indexOf(Permissions.ManageAssignedCollections) !== -1 && org.canManageAssignedCollections) ||
+            (permissions.indexOf(Permissions.ManageGroups) !== -1 && org.canManageGroups) ||
+            (permissions.indexOf(Permissions.ManageOrganization) !== -1 && org.isOwner) ||
+            (permissions.indexOf(Permissions.ManagePolicies) !== -1 && org.canManagePolicies) ||
+            (permissions.indexOf(Permissions.ManageUsers) !== -1 && org.canManageUsers)
+        ) {
+            return true;
         }
 
-        return true;
+        this.router.navigate(['/organizations', org.id]);
+        return false;
     }
 }

--- a/src/app/settings/link-sso.component.ts
+++ b/src/app/settings/link-sso.component.ts
@@ -24,7 +24,7 @@ import { Organization } from 'jslib/models/domain/organization';
 })
 export class LinkSsoComponent extends SsoComponent implements AfterContentInit {
     @Input() organization: Organization;
-    returnUri: string = '/settings/organizations'
+    returnUri: string = '/settings/organizations';
 
     constructor(platformUtilsService: PlatformUtilsService, i18nService: I18nService,
         apiService: ApiService, authService: AuthService,

--- a/src/app/tools/exposed-passwords-report.component.html
+++ b/src/app/tools/exposed-passwords-report.component.html
@@ -21,7 +21,12 @@
                         <app-vault-icon [cipher]="c"></app-vault-icon>
                     </td>
                     <td class="reduced-lh wrap">
-                        <a href="#" appStopClick (click)="selectCipher(c)" title="{{'editItem' | i18n}}">{{c.name}}</a>
+                        <ng-container *ngIf="!organization || canManageCipher(c) ; else cantManage">
+                            <a href="#" appStopClick (click)="selectCipher(c)" title="{{'editItem' | i18n}}">{{c.name}}</a>
+                        </ng-container>
+                        <ng-template #cantManage>
+                            <span>{{c.name}}</span>
+                        </ng-template>
                         <ng-container *ngIf="!organization && c.organizationId">
                             <i class="fa fa-share-alt" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
                             <span class="sr-only">{{'shared' | i18n}}</span>

--- a/src/app/tools/exposed-passwords-report.component.ts
+++ b/src/app/tools/exposed-passwords-report.component.ts
@@ -47,6 +47,7 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
                 return;
             }
             const promise = this.auditService.passwordLeaked(c.login.password).then((exposedCount) => {
+                exposedCount += 1;
                 if (exposedCount > 0) {
                     exposedPasswordCiphers.push(c);
                     this.exposedPasswordMap.set(c.id, exposedCount);
@@ -60,5 +61,10 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
 
     protected getAllCiphers(): Promise<CipherView[]> {
         return this.cipherService.getAllDecrypted();
+    }
+
+    protected canManageCipher(c: CipherView): boolean {
+        // this will only ever be false from the org view;
+        return true;
     }
 }

--- a/src/app/tools/exposed-passwords-report.component.ts
+++ b/src/app/tools/exposed-passwords-report.component.ts
@@ -47,7 +47,6 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
                 return;
             }
             const promise = this.auditService.passwordLeaked(c.login.password).then((exposedCount) => {
-                exposedCount += 1;
                 if (exposedCount > 0) {
                     exposedPasswordCiphers.push(c);
                     this.exposedPasswordMap.set(c.id, exposedCount);

--- a/src/app/tools/reused-passwords-report.component.html
+++ b/src/app/tools/reused-passwords-report.component.html
@@ -27,7 +27,12 @@
                         <app-vault-icon [cipher]="c"></app-vault-icon>
                     </td>
                     <td class="reduced-lh wrap">
-                        <a href="#" appStopClick (click)="selectCipher(c)" title="{{'editItem' | i18n}}">{{c.name}}</a>
+                        <ng-container *ngIf="!organization || canManageCipher(c) ; else cantManage">
+                            <a href="#" appStopClick (click)="selectCipher(c)" title="{{'editItem' | i18n}}">{{c.name}}</a>
+                        </ng-container>
+                        <ng-template #cantManage>
+                            <span>{{c.name}}</span>
+                        </ng-template>
                         <ng-container *ngIf="!organization && c.organizationId">
                             <i class="fa fa-share-alt" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
                             <span class="sr-only">{{'shared' | i18n}}</span>

--- a/src/app/tools/reused-passwords-report.component.ts
+++ b/src/app/tools/reused-passwords-report.component.ts
@@ -55,4 +55,9 @@ export class ReusedPasswordsReportComponent extends CipherReportComponent implem
     protected getAllCiphers(): Promise<CipherView[]> {
         return this.cipherService.getAllDecrypted();
     }
+
+    protected canManageCipher(c: CipherView): boolean {
+        // this will only ever be false from an organization view
+        return true;
+    }
 }

--- a/src/app/tools/weak-passwords-report.component.html
+++ b/src/app/tools/weak-passwords-report.component.html
@@ -27,7 +27,12 @@
                         <app-vault-icon [cipher]="c"></app-vault-icon>
                     </td>
                     <td class="reduced-lh wrap">
-                        <a href="#" appStopClick (click)="selectCipher(c)" title="{{'editItem' | i18n}}">{{c.name}}</a>
+                        <ng-container *ngIf="!organization || canManageCipher(c) ; else cantManage">
+                            <a href="#" appStopClick (click)="selectCipher(c)" title="{{'editItem' | i18n}}">{{c.name}}</a>
+                        </ng-container>
+                        <ng-template #cantManage>
+                            <span>{{c.name}}</span>
+                        </ng-template>
                         <ng-container *ngIf="!organization && c.organizationId">
                             <i class="fa fa-share-alt" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
                             <span class="sr-only">{{'shared' | i18n}}</span>

--- a/src/app/tools/weak-passwords-report.component.ts
+++ b/src/app/tools/weak-passwords-report.component.ts
@@ -75,6 +75,11 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
         return this.cipherService.getAllDecrypted();
     }
 
+    protected canManageCipher(c: CipherView): boolean {
+        // this will only ever be false from the org view;
+        return true;
+    }
+
     private scoreKey(score: number): [string, string] {
         switch (score) {
             case 4:

--- a/src/app/vault/bulk-delete.component.ts
+++ b/src/app/vault/bulk-delete.component.ts
@@ -31,7 +31,7 @@ export class BulkDeleteComponent {
         private apiService: ApiService) { }
 
     async submit() {
-        if (!this.organization || !this.organization.isAdmin) {
+        if (!this.organization || !this.organization.canManageAllCollections) {
             await this.deleteCiphers();
         } else {
             await this.deleteCiphersAdmin();

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3416,19 +3416,13 @@
   "manageGroups": {
     "message": "Manage Groups"
   },
-  "manageOrganization": {
-    "message": "Manage Organization"
-  },
   "managePolicies": {
     "message": "Manage Policies"
   },
-  "manageSelf": {
-    "message": "Manage Self"
+  "manageSso": {
+    "message": "Manage Sso"
   },
   "manageUsers": {
     "message": "Manage Users"
-  },
-  "viewUsers": {
-    "message": "View Users"
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3578,7 +3578,7 @@
   },
   "manageUsers": {
     "message": "Manage Users"
-  }
+  },
   "disableRequireSsoError": {
     "message": "You must manually disable the Single Sign-On Authentication policy before this policy can be disabled."
   }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3385,5 +3385,50 @@
   },
   "estimatedTax": {
     "message": "Estimated tax"
+  },
+  "custom": {
+    "message": "Custom"
+  },
+  "customDesc": {
+    "message": "Allows more granular control of user permissions for advanced configurations."
+  },
+  "permissions": {
+    "message": "Permissions"
+  },
+  "accessBusinessPortal": {
+    "message": "Access Business Portal"
+  },
+  "accessEventLogs": {
+    "message": "Access Event Logs"
+  },
+  "accessImportExport": {
+    "message": "Access Import/Export"
+  },
+  "accessReports": {
+    "message": "Access Reports"
+  },
+  "manageAllCollections": {
+    "message": "Manage All Collections"
+  },
+  "manageAssignedCollections": {
+    "message": "Manage Assigned Collections"
+  },
+  "manageGroups": {
+    "message": "Manage Groups"
+  },
+  "manageOrganization": {
+    "message": "Manage Organization"
+  },
+  "managePolicies": {
+    "message": "Manage Policies"
+  },
+  "manageSelf": {
+    "message": "Manage Self"
+  },
+  "manageUsers": {
+    "message": "Manage Users"
+  },
+  "viewUsers": {
+    "message": "View Users"
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -53,6 +53,13 @@
     "semicolon": [
       true,
       "always"
+    ],
+    "trailing-comma": [
+      true,
+      {
+        "multiline": "always",
+        "singleline": "never"
+      }
     ]
   }
 }


### PR DESCRIPTION
https://app.asana.com/0/1195018406457675/1153292148278664
https://github.com/bitwarden/server/pull/1057
https://github.com/bitwarden/jslib/pull/237

### Narrative
As a user, I would like to be able to configure another user with access to manage user/group/collection assignment without being able to see organization passwords that are not directly assigned to them.

### Code Changes
1. Added a semicolon to a line in sso.component.ts for the linter
2. Reworked the organization route guard to check permissions and roles
3. Reworked the app router to add any new permissions blocks
4. Added a global inheritance strategy to route parameters so I could still access the organization ID from nested routes
5. Blocked showing the entire Organization menu bar or parts of the menu bar behind permissions
6. Toggled the routes for a the different Organization menu bar option based on available user permissions
7. Replaced any calls to isAdmin, isManager, etc. with permission checks where applicable. Some things, like owner checks for getting to settings tab, did not change.
8. Added an option to the user add-edit modal for the Custom role, and a new section for assigning permissions to the Custom role.
9. Added checks to the organization reports views to show all org ciphers that show up on a given report, but not let the user access any that they are not directly assigned.
     - This came from a request to do this by the Smithsonian, see linked Asana ticket.
10. Added new translation strings that are probably going to need to be revisited and made more user friendly

### Screenshots
![Screen Shot 2020-12-22 at 1 14 10 PM](https://user-images.githubusercontent.com/15897251/102919878-a0781580-4457-11eb-8782-232eab504023.png)