### PR TITLE
Hide match uri overflow

### DIFF
--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -164,7 +164,7 @@
                                     </a>
                                 </div>
                                 <div class="d-flex">
-                                    <select class="form-control" id="loginUriMatch{{i}}" name="Login.Uris[{{i}}].Match"
+                                    <select class="form-control overflow-hidden" id="loginUriMatch{{i}}" name="Login.Uris[{{i}}].Match"
                                         [(ngModel)]="u.match" (change)="loginUriMatchChanged(u)" 
                                         [disabled]="cipher.isDeleted || viewOnly">
                                         <option *ngFor="let o of uriMatchOptions" [ngValue]="o.value">{{o.name}}


### PR DESCRIPTION
# Overview

Closes #531. Cipher view modal's URI match detection selector is not handling overflow properly and pushing the URI delete button off the modal.

This change handles overflow properly. Selecting the modal still displays the full text.

# Files Changed

# Screenshots

## pre change
![image](https://user-images.githubusercontent.com/18214891/103385309-74940a00-4abf-11eb-9176-02159a452d21.png)

## post change
![image](https://user-images.githubusercontent.com/18214891/103385333-8f667e80-4abf-11eb-834f-a598cea154f0.png)
