### PR TITLE
add predefined time frames for delete and expire

### DIFF
--- a/src/app/send/add-edit.component.html
+++ b/src/app/send/add-edit.component.html
@@ -52,22 +52,45 @@
                         </div>
                     </div>
                 </ng-container>
-                <h3 class="mt-4">{{'options' | i18n}}</h3>
+                <h3 class="mt-5">{{'options' | i18n}}</h3>
                 <div class="row">
                     <div class="col-6 form-group">
                         <label for="deletionDate">{{'deletionDate' | i18n}}</label>
-                        <input id="deletionDate" class="form-control" type="datetime-local" name="DeletionDate"
-                            [(ngModel)]="deletionDate" required>
+                        <div *ngIf="!editMode">
+                            <select id="deletionDate" name="DeletionDateSelect" [(ngModel)]="deletionDateSelect"
+                                class="form-control" required>
+                                <option *ngFor="let o of deletionDateOptions" [ngValue]="o.value">{{o.name}}</option>
+                            </select>
+                            <input id="deletionDateCustom" class="form-control mt-1" type="datetime-local"
+                                name="DeletionDate" [(ngModel)]="deletionDate" required
+                                *ngIf="deletionDateSelect === 0">
+                        </div>
+                        <div *ngIf="editMode">
+                            <input id="deletionDate" class="form-control" type="datetime-local" name="DeletionDate"
+                                [(ngModel)]="deletionDate" required>
+                        </div>
                     </div>
                     <div class="col-6 form-group">
                         <div class="d-flex">
                             <label for="expirationDate">{{'expirationDate' | i18n}}</label>
-                            <a href="#" appStopClick (click)="clearExpiration()" class="ml-auto">
+                            <a href="#" appStopClick (click)="clearExpiration()" class="ml-auto" *ngIf="editMode">
                                 {{'clear' | i18n}}
                             </a>
                         </div>
-                        <input id="expirationDate" class="form-control" type="datetime-local" name="ExpirationDate"
-                            [(ngModel)]="expirationDate">
+                        <div *ngIf="!editMode">
+                            <select id="expirationDate" name="ExpirationDateSelect" [(ngModel)]="expirationDateSelect"
+                                class="form-control" required>
+                                <option *ngFor="let o of expirationDateOptions" [ngValue]="o.value">{{o.name}}
+                                </option>
+                            </select>
+                            <input id="expirationDateCustom" class="form-control mt-1" type="datetime-local"
+                                name="ExpirationDate" [(ngModel)]="expirationDate" required
+                                *ngIf="expirationDateSelect === 0">
+                        </div>
+                        <div *ngIf="editMode">
+                            <input id="expirationDate" class="form-control" type="datetime-local" name="ExpirationDate"
+                                [(ngModel)]="expirationDate">
+                        </div>
                     </div>
                 </div>
                 <div class="row">

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3443,10 +3443,10 @@
     "message": "Time required before automatically granting access."
   },
   "oneDay": {
-    "message": "1 Day"
+    "message": "1 day"
   },
   "days": {
-    "message": "$DAYS$ Days",
+    "message": "$DAYS$ days",
     "placeholders": {
       "days": {
         "content": "$1",
@@ -3559,5 +3559,8 @@
   },
   "disableRequireSsoError": {
     "message": "You must manually disable the Single Sign-On Authentication policy before this policy can be disabled."
+  },
+  "custom": {
+    "message": "Custom"
   }
 }


### PR DESCRIPTION
When creating new sends, it can be bad UX to have to use a date picker to pick a specific date and time. This PR adds a select menu of some pre-defined timespans (1 hour, 1 day, etc) that a user can select from. The user can still select a "Custom" option which will make the date picker available again.

Also fix some old direct-api references in add-edit component to use send service properly.