### PR TITLE
[Policy] Update Personal Ownership checkbox description

### DIFF
--- a/src/app/organizations/manage/policy-edit.component.html
+++ b/src/app/organizations/manage/policy-edit.component.html
@@ -36,7 +36,7 @@
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="enabled" [(ngModel)]="enabled"
                             name="Enabled">
-                        <label class="form-check-label" for="enabled">{{'enabled' | i18n}}</label>
+                        <label class="form-check-label" for="enabled">{{getCheckboxDesc()}}</label>
                     </div>
                 </div>
                 <ng-container *ngIf="type === policyType.MasterPassword">

--- a/src/app/organizations/manage/policy-edit.component.html
+++ b/src/app/organizations/manage/policy-edit.component.html
@@ -36,7 +36,7 @@
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="enabled" [(ngModel)]="enabled"
                             name="Enabled">
-                        <label class="form-check-label" for="enabled">{{getCheckboxDesc()}}</label>
+                        <label class="form-check-label" for="enabled">{{checkboxDesc}}</label>
                     </div>
                 </div>
                 <ng-container *ngIf="type === policyType.MasterPassword">

--- a/src/app/organizations/manage/policy-edit.component.ts
+++ b/src/app/organizations/manage/policy-edit.component.ts
@@ -172,6 +172,11 @@ export class PolicyEditComponent implements OnInit {
         }
     }
 
+    getCheckboxDesc(): string {
+        return this.type === PolicyType.PersonalOwnership ? this.i18nService.t('personalOwnershipCheckboxDesc') :
+            this.i18nService.t('enabled');
+    }
+
     private preValidate(): boolean {
         switch (this.type) {
             case PolicyType.RequireSso:

--- a/src/app/organizations/manage/policy-edit.component.ts
+++ b/src/app/organizations/manage/policy-edit.component.ts
@@ -172,7 +172,7 @@ export class PolicyEditComponent implements OnInit {
         }
     }
 
-    getCheckboxDesc(): string {
+    get checkboxDesc(): string {
         return this.type === PolicyType.PersonalOwnership ? this.i18nService.t('personalOwnershipCheckboxDesc') :
             this.i18nService.t('enabled');
     }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3565,5 +3565,8 @@
   },
   "custom": {
     "message": "Custom"
+  },
+  "personalOwnershipCheckboxDesc": {
+    "message": "Disable personal ownership for organization users"
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3586,13 +3586,11 @@
   "custom": {
     "message": "Custom"
   },
-<<<<<<< HEAD
   "personalOwnershipCheckboxDesc": {
     "message": "Disable personal ownership for organization users"
-=======
+  },
   "textHiddenByDefault": {
     "message": "When accessing the Send, hide the text by default",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
->>>>>>> master
   }
 }


### PR DESCRIPTION
## Objective
> Bring some clarity to what is happening when enabling the `Personal Ownership` policy.  Adjust the checkbox description to describe the action being taken.

## Code Changes
- **policy-edit.component.html**: Use new `getCheckboxDesc` to properly retrieve the enable checkbox text based on the policy type being edited
- **policy-edit.component.ts**: Added `getCheckboxDesc` that will return a different string based on the Policy Type being edited
- **message.json**: Added new string

## Screenshot
<img width="511" alt="0-web-enabled-checkbox" src="https://user-images.githubusercontent.com/26154748/103910605-a3ffd380-50ca-11eb-988b-dba78c2f11c7.png">
