### PR TITLE
Fixed trailing comma lint warnings

### DIFF
--- a/src/app/send/add-edit.component.ts
+++ b/src/app/send/add-edit.component.ts
@@ -17,9 +17,9 @@ import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 import { SendService } from 'jslib/abstractions/send.service';
 import { UserService } from 'jslib/abstractions/user.service';
 
-import { SendView } from 'jslib/models/view/sendView';
 import { SendFileView } from 'jslib/models/view/sendFileView';
 import { SendTextView } from 'jslib/models/view/sendTextView';
+import { SendView } from 'jslib/models/view/sendView';
 
 import { Send } from 'jslib/models/domain/send';
 
@@ -72,7 +72,7 @@ export class AddEditComponent {
             { name: i18nService.t('custom'), value: 0 },
         ];
         this.expirationDateOptions = [
-            { name: i18nService.t('never'), value: null }
+            { name: i18nService.t('never'), value: null },
         ].concat([...this.deletionDateOptions]);
     }
 
@@ -202,7 +202,7 @@ export class AddEditComponent {
     }
 
     typeChanged() {
-        if (!this.canAccessPremium && this.send.type == SendType.File && !this.premiumRequiredAlertShown) {
+        if (!this.canAccessPremium && this.send.type === SendType.File && !this.premiumRequiredAlertShown) {
             this.premiumRequiredAlertShown = true;
             this.messagingService.send('premiumRequired');
         }

--- a/src/app/settings/change-password.component.ts
+++ b/src/app/settings/change-password.component.ts
@@ -41,7 +41,7 @@ export class ChangePasswordComponent extends BaseChangePasswordComponent {
         userService: UserService, passwordGenerationService: PasswordGenerationService,
         platformUtilsService: PlatformUtilsService, policyService: PolicyService,
         private folderService: FolderService, private cipherService: CipherService,
-        private syncService: SyncService, private apiService: ApiService, ) {
+        private syncService: SyncService, private apiService: ApiService ) {
         super(i18nService, cryptoService, messagingService, userService, passwordGenerationService,
             platformUtilsService, policyService);
     }

--- a/src/app/settings/emergency-access.component.ts
+++ b/src/app/settings/emergency-access.component.ts
@@ -177,7 +177,7 @@ export class EmergencyAccessComponent implements OnInit {
             details.name || details.email,
             this.i18nService.t('requestAccess'),
             this.i18nService.t('no'),
-            'warning'
+            'warning',
         );
 
         if (!confirmed) {
@@ -198,7 +198,7 @@ export class EmergencyAccessComponent implements OnInit {
             details.name || details.email,
             this.i18nService.t('approve'),
             this.i18nService.t('no'),
-            'warning'
+            'warning',
         );
 
         if (!confirmed) {

--- a/src/app/settings/tax-info.component.ts
+++ b/src/app/settings/tax-info.component.ts
@@ -90,7 +90,7 @@ export class TaxInfoComponent {
         if (this.taxRates != null) {
             const localTaxRate = this.taxRates.find(x =>
                 x.country === this.taxInfo.country &&
-                x.postalCode === this.taxInfo.postalCode
+                x.postalCode === this.taxInfo.postalCode,
             );
             return localTaxRate?.rate ?? null;
         }

--- a/src/app/settings/tax-info.component.ts
+++ b/src/app/settings/tax-info.component.ts
@@ -90,7 +90,7 @@ export class TaxInfoComponent {
         if (this.taxRates != null) {
             const localTaxRate = this.taxRates.find(x =>
                 x.country === this.taxInfo.country &&
-                x.postalCode === this.taxInfo.postalCode,
+                x.postalCode === this.taxInfo.postalCode
             );
             return localTaxRate?.rate ?? null;
         }

--- a/tslint.json
+++ b/tslint.json
@@ -57,7 +57,12 @@
     "trailing-comma": [
       true,
       {
-        "multiline": "always",
+        "multiline": {
+          "objects": "always",
+          "arrays": "always",
+          "functions": "ignore",
+          "typeLiterals": "ignore"
+        },
         "singleline": "never"
       }
     ],

--- a/tslint.json
+++ b/tslint.json
@@ -60,6 +60,7 @@
         "multiline": "always",
         "singleline": "never"
       }
-    ]
+    ],
+    "arrow-parens": false
   }
 }


### PR DESCRIPTION
1. Ran the tslint fixer over a few files to remove new trailing comma warnings from the new linter rule specifying them
2. Added another tslint rule to keep the fixer from automatically wrapping single property lambda functions in parenthesis