### PR TITLE
Remove grantee email from accept-emergency component

### DIFF
--- a/src/app/accounts/accept-emergency.component.html
+++ b/src/app/accounts/accept-emergency.component.html
@@ -15,7 +15,6 @@
                 <div class="card-body">
                     <p class="text-center">
                         {{name}}
-                        <strong class="d-block mt-2">{{email}}</strong>
                     </p>
                     <p>{{'acceptEmergencyAccess' | i18n}}</p>
                     <hr>


### PR DESCRIPTION
Remove the grantee's email from the accept emergency contact invite page to avoid confusion.

![image](https://user-images.githubusercontent.com/137855/104636939-655ab200-56a4-11eb-80ed-742f50352abc.png)
