### PR TITLE
fixed various Permissions UI issues

### DIFF
--- a/src/app/organizations/manage/entity-users.component.html
+++ b/src/app/organizations/manage/entity-users.component.html
@@ -86,6 +86,7 @@
                                     <span *ngIf="u.type === organizationUserType.Admin">{{'admin' | i18n}}</span>
                                     <span *ngIf="u.type === organizationUserType.Manager">{{'manager' | i18n}}</span>
                                     <span *ngIf="u.type === organizationUserType.User">{{'user' | i18n}}</span>
+                                    <span *ngIf="u.type === organizationUserType.Custom">{{'custom' | i18n}}</span>
                                 </td>
                                 <td class="text-center" *ngIf="entity === 'collection'">
                                     <input type="checkbox" [(ngModel)]="u.hidePasswords"

--- a/src/app/organizations/manage/policies.component.html
+++ b/src/app/organizations/manage/policies.component.html
@@ -1,4 +1,4 @@
-<app-callout [type]="'warning'">
+<app-callout *ngIf="userCanAccessBusinessPortal" [type]="'warning'">
     <p>{{'webPoliciesDeprecationWarning' | i18n}}</p>
     <button type="button" class="btn btn-outline-secondary"
         (click)="goToEnterprisePortal()">{{'businessPortal' | i18n}}</button>

--- a/src/app/organizations/manage/policies.component.ts
+++ b/src/app/organizations/manage/policies.component.ts
@@ -37,12 +37,13 @@ export class PoliciesComponent implements OnInit {
 
     // Remove when removing deprecation warning
     enterpriseTokenPromise: Promise<any>;
+    userCanAccessBusinessPortal = false;
+
     private enterpriseUrl: string;
 
     private modal: ModalComponent = null;
     private orgPolicies: PolicyResponse[];
     private policiesEnabledMap: Map<PolicyType, boolean> = new Map<PolicyType, boolean>();
-
 
     constructor(private apiService: ApiService, private route: ActivatedRoute,
         private i18nService: I18nService, private componentFactoryResolver: ComponentFactoryResolver,
@@ -57,6 +58,7 @@ export class PoliciesComponent implements OnInit {
                 this.router.navigate(['/organizations', this.organizationId]);
                 return;
             }
+            this.userCanAccessBusinessPortal = organization.canAccessBusinessPortal;
             this.policies = [
                 {
                     name: this.i18nService.t('twoStepLogin'),

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3611,7 +3611,7 @@
     "message": "Manage Policies"
   },
   "manageSso": {
-    "message": "Manage Sso"
+    "message": "Manage SSO"
   },
   "manageUsers": {
     "message": "Manage Users"


### PR DESCRIPTION
Fixed various UI issues with Permissions reported by @clayadams5226 during testing

1. If someone has a custom permission, when the admin goes to the user access screen (Manage > Collections > Users) Custom doesn't show up next to the user. It's just blank
2. If I have the policies permission, but not the portal permission, I'm still able to access the portal from the policies page (although I can't make any changes.)
3. The SSO permission is displayed as "Sso" should it all be caps?