### PR TITLE
fixes to plan/pricing page

### DIFF
--- a/src/app/settings/create-organization.component.ts
+++ b/src/app/settings/create-organization.component.ts
@@ -5,6 +5,9 @@ import {
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
+import { PlanType } from 'jslib/enums/planType';
+import { ProductType } from 'jslib/enums/productType';
+
 import { OrganizationPlansComponent } from './organization-plans.component';
 
 @Component({
@@ -18,8 +21,15 @@ export class CreateOrganizationComponent implements OnInit {
 
     ngOnInit() {
         const queryParamsSub = this.route.queryParams.subscribe(async (qParams) => {
-            if (qParams.plan === 'families' || qParams.plan === 'teams' || qParams.plan === 'enterprise') {
-                this.orgPlansComponent.plan = qParams.plan;
+            if (qParams.plan === 'families') {
+                this.orgPlansComponent.plan = PlanType.FamiliesAnnually;
+                this.orgPlansComponent.product = ProductType.Families;
+            } else if (qParams.plan === 'teams') {
+                this.orgPlansComponent.plan = PlanType.TeamsAnnually;
+                this.orgPlansComponent.product = ProductType.Teams;
+            } else if (qParams.plan === 'enterprise') {
+                this.orgPlansComponent.plan = PlanType.EnterpriseAnnually;
+                this.orgPlansComponent.product = ProductType.Enterprise;
             }
             if (queryParamsSub != null) {
                 queryParamsSub.unsubscribe();

--- a/src/app/settings/organization-plans.component.html
+++ b/src/app/settings/organization-plans.component.html
@@ -54,6 +54,9 @@
                 <small *ngIf="selectableProduct.hasSelfHost">• {{'onPremHostingOptional' | i18n}}</small>
                 <small *ngIf="selectableProduct.hasSso">• {{'includeSsoAuthentication' | i18n}}</small>
                 <small *ngIf="selectableProduct.hasPolicies">• {{'includeEnterprisePolicies' | i18n}}</small>
+                <small *ngIf="selectableProduct.trialPeriodDays">•
+                    {{'xDayFreeTrial' | i18n : selectableProduct.trialPeriodDays }}
+                </small>
             </ng-container>
             <ng-template #fullFeatureList>
                 <small *ngIf="selectableProduct.product == productTypes.Free">•

--- a/src/app/settings/organization-plans.component.ts
+++ b/src/app/settings/organization-plans.component.ts
@@ -74,6 +74,9 @@ export class OrganizationPlansComponent implements OnInit {
         if (!this.selfHosted) {
             const plans = await this.apiService.getPlans();
             this.plans = plans.data;
+            if (this.product === ProductType.Enterprise || this.product === ProductType.Teams) {
+                this.ownedBusiness = true;
+            }
         }
         this.loading = false;
     }
@@ -189,7 +192,8 @@ export class OrganizationPlansComponent implements OnInit {
         if (!this.ownedBusiness || this.selectedPlan.canBeUsedByBusiness) {
             return;
         }
-        this.plan = PlanType.TeamsMonthly;
+        this.product = ProductType.Teams;
+        this.plan = PlanType.TeamsAnnually;
     }
 
     changedCountry() {


### PR DESCRIPTION
This PR fixes a few regressions on the organization create page:

- Pre-select product/plan based on `plan=` query parameter.
- Add "7 days free trial" line to enterprise product bullet list
- Set product and plan from free/families to Teams whenever selecting "ownedBusiness" checkbox

Enhancement:

- Default "ownedBusiness" to true if `plan=teams` or `plan=enterprise`.