### PR TITLE
make inline buttons accessible with tab button

### DIFF
--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -47,7 +47,7 @@
                                 <div class="input-group-append" *ngIf="!cipher.isDeleted">
                                     <button type="button" class="btn btn-outline-secondary"
                                         appA11yTitle="{{'copyUsername' | i18n}}"
-                                        (click)="copy(cipher.login.username, 'username', 'Username')" tabindex="-1">
+                                        (click)="copy(cipher.login.username, 'username', 'Username')">
                                         <i class="fa fa-lg fa-clone" aria-hidden="true"></i>
                                     </button>
                                 </div>
@@ -80,13 +80,13 @@
                                 <div class="input-group-append">
                                     <button type="button" class="btn btn-outline-secondary"
                                         appA11yTitle="{{'toggleVisibility' | i18n}}" (click)="togglePassword()"
-                                        tabindex="-1" [disabled]="!cipher.viewPassword">
+                                        [disabled]="!cipher.viewPassword">
                                         <i class="fa fa-lg" aria-hidden="true"
                                             [ngClass]="{'fa-eye': !showPassword, 'fa-eye-slash': showPassword}"></i>
                                     </button>
                                     <button type="button" class="btn btn-outline-secondary"
                                         appA11yTitle="{{'copyPassword' | i18n}}"
-                                        (click)="copy(cipher.login.password, 'password', 'Password')" tabindex="-1"
+                                        (click)="copy(cipher.login.password, 'password', 'Password')"
                                         [disabled]="!cipher.viewPassword">
                                         <i class="fa fa-lg fa-clone" aria-hidden="true"></i>
                                     </button>
@@ -148,12 +148,11 @@
                                     <div class="input-group-append">
                                         <button type="button" class="btn btn-outline-secondary"
                                             appA11yTitle="{{'launch' | i18n}}" (click)="launch(u)"
-                                            [disabled]="!u.canLaunch" tabindex="-1">
+                                            [disabled]="!u.canLaunch">
                                             <i class="fa fa-lg fa-share" aria-hidden="true"></i>
                                         </button>
                                         <button type="button" class="btn btn-outline-secondary"
-                                            appA11yTitle="{{'copyUri' | i18n}}" (click)="copy(u.uri, 'uri', 'URI')"
-                                            tabindex="-1">
+                                            appA11yTitle="{{'copyUri' | i18n}}" (click)="copy(u.uri, 'uri', 'URI')">
                                             <i class="fa fa-lg fa-clone" aria-hidden="true"></i>
                                         </button>
                                     </div>
@@ -216,7 +215,7 @@
                                 <div class="input-group-append">
                                     <button type="button" class="btn btn-outline-secondary"
                                         appA11yTitle="{{'copyNumber' | i18n}}"
-                                        (click)="copy(cipher.card.number, 'number', 'Number')" tabindex="-1">
+                                        (click)="copy(cipher.card.number, 'number', 'Number')">
                                         <i class="fa fa-lg fa-clone" aria-hidden="true"></i>
                                     </button>
                                 </div>
@@ -246,14 +245,13 @@
                                     [disabled]="cipher.isDeleted || viewOnly">
                                 <div class="input-group-append">
                                     <button type="button" class="btn btn-outline-secondary"
-                                        appA11yTitle="{{'toggleVisibility' | i18n}}" (click)="toggleCardCode()"
-                                        tabindex="-1">
+                                        appA11yTitle="{{'toggleVisibility' | i18n}}" (click)="toggleCardCode()">
                                         <i class="fa fa-lg" aria-hidden="true"
                                             [ngClass]="{'fa-eye': !showCardCode, 'fa-eye-slash': showCardCode}"></i>
                                     </button>
                                     <button type="button" class="btn btn-outline-secondary"
                                         appA11yTitle="{{'securityCode' | i18n}}"
-                                        (click)="copy(cipher.card.code, 'securityCode', 'Security Code')" tabindex="-1">
+                                        (click)="copy(cipher.card.code, 'securityCode', 'Security Code')">
                                         <i class="fa fa-lg fa-clone" aria-hidden="true"></i>
                                     </button>
                                 </div>
@@ -408,7 +406,7 @@
                                     <div class="input-group-append">
                                         <button type="button" class="btn btn-outline-secondary"
                                             appA11yTitle="{{'copyValue' | i18n}}"
-                                            (click)="copy(f.value, 'value', 'Field')" tabindex="-1">
+                                            (click)="copy(f.value, 'value', 'Field')">
                                             <i class="fa fa-lg fa-clone" aria-hidden="true"></i>
                                         </button>
                                     </div>
@@ -421,7 +419,7 @@
                                     <div class="input-group-append">
                                         <button type="button" class="btn btn-outline-secondary"
                                             appA11yTitle="{{'toggleVisibility' | i18n}}" (click)="toggleFieldValue(f)"
-                                            tabindex="-1" [disabled]="!cipher.viewPassword && !f.newField">
+                                            [disabled]="!cipher.viewPassword && !f.newField">
                                             <i class="fa fa-lg" aria-hidden="true"
                                                 [ngClass]="{'fa-eye': !f.showValue, 'fa-eye-slash': f.showValue}">
                                             </i>
@@ -429,7 +427,7 @@
                                         <button type="button" class="btn btn-outline-secondary"
                                             appA11yTitle="{{'copyValue' | i18n}}"
                                             (click)="copy(f.value, 'value', f.type === fieldType.Hidden ? 'H_Field' : 'Field')"
-                                            tabindex="-1" [disabled]="!cipher.viewPassword && !f.newField">
+                                            [disabled]="!cipher.viewPassword && !f.newField">
                                             <i class="fa fa-lg fa-clone" aria-hidden="true"></i>
                                         </button>
                                     </div>


### PR DESCRIPTION
## Objective

Fix #712 - some buttons on the add-edit page were not accessible when tabbing through elements. The issue correctly identified that this is required by web accessibility guidelines. (See issue for relevant links)

## Code changes
Remove `tabindex=-1` from the relevant elements.

## Screenshots

I have tested this in Chrome and all elements now appear to be accessible via tab, including those that were raised in the issue report.

![tab a11y](https://user-images.githubusercontent.com/31796059/104860312-907c2480-5976-11eb-9b00-123ee877f617.png)