### PR TITLE
Clearer keyboard focus on input elements

### DIFF
--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -57,12 +57,12 @@
                             <div class="d-flex">
                                 <label for="loginPassword">{{'password' | i18n}}</label>
                                 <div class="ml-auto d-flex" *ngIf="!cipher.isDeleted && !viewOnly">
-                                    <a href="#" class="d-block mr-2" appStopClick
+                                    <a href="#" class="d-block mr-2 fa-icon-above-input" appStopClick
                                         appA11yTitle="{{'generatePassword' | i18n}}" (click)="generatePassword()"
                                         *ngIf="cipher.viewPassword">
                                         <i class="fa fa-lg fa-fw fa-refresh" aria-hidden="true"></i>
                                     </a>
-                                    <a href="#" class="d-block" #checkPasswordBtn appStopClick
+                                    <a href="#" class="d-block fa-icon-above-input" #checkPasswordBtn appStopClick
                                         appA11yTitle="{{'checkPassword' | i18n}}" (click)="checkPassword()"
                                         [appApiAction]="checkPasswordPromise">
                                         <i class="fa fa-lg fa-fw fa-check-circle" [hidden]="checkPasswordBtn.loading"

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -315,6 +315,16 @@ input[type="search"]::-webkit-search-cancel-button {
     }
 }
 
+.btn-link {
+    &:focus,
+    &.focus {
+        outline-color: -webkit-focus-ring-color;
+        outline-offset: 1px;
+        outline-style: auto;
+        outline-width: 1px;
+    }
+}
+
 .btn-outline-secondary {
     color: $text-muted;
 
@@ -324,6 +334,11 @@ input[type="search"]::-webkit-search-cancel-button {
 
     &:disabled {
         opacity: 1;
+    }
+
+    &:focus,
+    &.focus {
+        box-shadow: 0 0 0 $btn-focus-width rgba(mix(color-yiq($primary), $primary, 15%), .5);
     }
 }
 

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -367,6 +367,17 @@ input[type="search"]::-webkit-search-cancel-button {
     }
 }
 
+.list-group-item {
+    &:focus,
+    &.focus {
+        z-index: 100;
+    }
+}
+
+.fa-icon-above-input {
+    height: 1.5em;
+}
+
 .table.table-list {
     thead th {
         border-top: none;


### PR DESCRIPTION
## Objective

Fix #713: when tabbing through elements, not all elements have a clear outline/shadow to indicate that they have focus. This is required by WCAG.

## Code changes

I inspected each of the elements identified in the issue and grouped them as follows:

* `.btn-outline-secondary`: sets `box-shadow` on focus, but uses a colour with poor visibility. Changed so that it uses the primary colour for `box-shadow`.
* `.btn-link`: does not set any `box-shadow` or `outline` on focus. Changed to set `outline` on focus.
* `.list-group-item`: sets `outline` on focus, but this is partially obscured by other `.list-group-item`s nearby. Changed to set `z-index` on focus so that it's always on top.
* `<a>` items above text input: sets `outline` on focus, but this is partially obscured by the nearby text `input`. Changed to reduce the height of the element so the outline doesn't overlap.

I went through Bootstrap 4's default variables and mixins, but I don't think they let us customise this behaviour. Therefore this is just done by applying our own scss to these elements.

## Screenshots

`.btn-outline-secondary`
![Screen Shot 2021-01-19 at 7 12 02 am](https://user-images.githubusercontent.com/31796059/104963421-3c307d80-5a26-11eb-97ac-3b84f53573f5.png)

`.btn-link`
![Screen Shot 2021-01-19 at 7 11 47 am](https://user-images.githubusercontent.com/31796059/104963441-46527c00-5a26-11eb-8de6-012baafb4bdc.png)

`.list-group-item`
![Screen Shot 2021-01-19 at 7 12 32 am](https://user-images.githubusercontent.com/31796059/104963478-5f5b2d00-5a26-11eb-943c-b9f41d01b8e3.png)

`<a>` items above text input
![Screen Shot 2021-01-19 at 7 12 54 am](https://user-images.githubusercontent.com/31796059/104963511-70a43980-5a26-11eb-8880-65e7b3958571.png)
