### PR TITLE
Fix emergency access confirm not working with two-factor enabled

### DIFF
--- a/src/app/accounts/two-factor.component.ts
+++ b/src/app/accounts/two-factor.component.ts
@@ -60,9 +60,12 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
     }
 
     async goAfterLogIn() {
-        const invite = await this.stateService.get<any>('orgInvitation');
-        if (invite != null) {
-            this.router.navigate(['accept-organization'], { queryParams: invite });
+        const orgInvite = await this.stateService.get<any>('orgInvitation');
+        const emergencyInvite = await this.stateService.get<any>('emergencyInvitation');
+        if (orgInvite != null) {
+            this.router.navigate(['accept-organization'], { queryParams: orgInvite });
+        } else if (emergencyInvite != null) {
+            this.router.navigate(['accept-emergency'], { queryParams: emergencyInvite });
         } else {
             const loginRedirect = await this.stateService.get<any>('loginRedirect');
             if (loginRedirect != null) {


### PR DESCRIPTION
When two-factor authentication is enabled, and you are not "remembered" from a previous session, we don't handle the `emergencyInvitation` token properly.

When I added the handler for the `login.component.ts` in https://github.com/bitwarden/web/pull/707, I forgot to do the same changes to `two-factor.component.ts`.

Resolves https://github.com/bitwarden/web/issues/789.