### PR TITLE
Update emergency access user-access link

### DIFF
--- a/src/app/settings/emergency-access-add-edit.component.html
+++ b/src/app/settings/emergency-access-add-edit.component.html
@@ -26,7 +26,7 @@
                 <h3>
                     {{'userAccess' | i18n}}
                     <a target="_blank" rel="noopener" appA11yTitle="{{'learnMore' | i18n}}"
-                        href="https://bitwarden.com/help/article/user-types-access-control/#user-types">
+                        href="https://bitwarden.com/help/article/emergency-access/#user-access">
                         <i class="fa fa-question-circle-o" aria-hidden="true"></i>
                     </a>
                 </h3>


### PR DESCRIPTION
The help link for user-access incorrectly linked to the wrong page. Changed to the correct link.