### PR TITLE
Allow U2F on Edge

### DIFF
--- a/src/services/webPlatformUtils.service.ts
+++ b/src/services/webPlatformUtils.service.ts
@@ -162,7 +162,7 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
         if (win != null && (win as any).u2f != null) {
             return true;
         }
-        return this.isChrome() || ((this.isOpera() || this.isVivaldi()) && !Utils.isMobileBrowser);
+        return this.isChrome() || ((this.isEdge() || this.isOpera() || this.isVivaldi()) && !Utils.isMobileBrowser);
     }
 
     supportsDuo(): boolean {


### PR DESCRIPTION
## Objective
Fix #703. Microsoft Edge has added U2F support but we still had it disallowed in our code.

## Code changes
Add Edge to the list of browsers that support U2F in `webPlatformUtils.service`.

I couldn't find any clear statement as to whether the Edge mobile app supports U2F - a quick test on my Android (using demo.yubico.com) suggests it doesn't. Therefore I have only enabled U2F support on the desktop Edge browser.

Incidentally, Chrome is the only mobile app that `webPlatformUtils` recognises as supporting U2F. However, in my testing, the `u2f.js` api we use rejects Chrome mobile immediately as not being supported. And it's not clear from our [help documentation](https://bitwarden.com/help/article/setup-two-step-login-u2f/) whether we support web vault U2F on mobile devices at all. I'm mentioning it for completeness, but I haven't looked into this further at this stage.