### PR TITLE
Revert "Correct URL to emergency access doc (#805)"

### DIFF
--- a/src/app/settings/emergency-access-confirm.component.html
+++ b/src/app/settings/emergency-access-confirm.component.html
@@ -13,7 +13,7 @@
             <div class="modal-body">
                 <p>
                     {{'fingerprintEnsureIntegrityVerify' | i18n}}
-                    <a href="https://help.bitwarden.com/article/emergency-access/" target="_blank" rel="noopener">
+                    <a href="https://help.bitwarden.com/article/fingerprint-phrase/" target="_blank" rel="noopener">
                         {{'learnMore' | i18n}}</a>
                 </p>
                 <p><code>{{fingerprint}}</code></p>


### PR DESCRIPTION
This reverts commit 8449cdca75d3309995adc5a153f917a037eb034b.

This seems to actually have been the appropriate help link regarding the fingerprint phrase for verification which is used in several places including Org Invites, Emergency Access, etc.