### PR TITLE
Set WebVaultUrl if dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9941,6 +9941,14 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -9963,14 +9971,6 @@
             "ansi-regex": "^3.0.0"
           }
         }
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -146,6 +146,7 @@ export function initFactory(): Function {
         if (!isDev && platformUtilsService.isSelfHost()) {
             environmentService.baseUrl = window.location.origin;
         } else {
+            environmentService.webVaultUrl = isDev ? 'https://localhost:8080' : null;
             environmentService.notificationsUrl = isDev ? 'http://localhost:61840' :
                 'https://notifications.bitwarden.com'; // window.location.origin + '/notifications';
             environmentService.enterpriseUrl = isDev ? 'http://localhost:52313' :


### PR DESCRIPTION
# Overview

While playing with Sends in web, they were giving the wrong webvault URL. This change fixes that issue and should only impact development environments.

# Files Changed

* **services.module.ts**: Uses the default dev webvault url as we do in `apiService.SetUrls` just below this change.

# Testing concerns

This should have a minimal impact, but please test SSO needs to be validated as webVaultUrl is used for the return address from sso.