### PR TITLE
Fix glob processing in npm. Ban single param parens

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "dist:selfhost": "npm run build:selfhost:prod && gulp postdist",
     "deploy": "npm run dist && gh-pages -d build",
     "deploy:dev": "npm run dist && gh-pages -d build -r git@github.com:kspearrin/bitwarden-web-dev.git",
-    "lint": "tslint src/**/*.ts || true",
-    "lint:fix": "tslint src/**/*.ts --fix"
+    "lint": "tslint 'src/**/*.ts' || true",
+    "lint:fix": "tslint 'src/**/*.ts' --fix"
   },
   "devDependencies": {
     "@angular/compiler-cli": "^9.1.12",

--- a/src/app/accounts/accept-emergency.component.ts
+++ b/src/app/accounts/accept-emergency.component.ts
@@ -36,7 +36,7 @@ export class AcceptEmergencyComponent implements OnInit {
 
     ngOnInit() {
         let fired = false;
-        this.route.queryParams.subscribe(async (qParams) => {
+        this.route.queryParams.subscribe(async qParams => {
             if (fired) {
                 return;
             }

--- a/src/app/accounts/accept-organization.component.ts
+++ b/src/app/accounts/accept-organization.component.ts
@@ -37,7 +37,7 @@ export class AcceptOrganizationComponent implements OnInit {
 
     ngOnInit() {
         let fired = false;
-        this.route.queryParams.subscribe(async (qParams) => {
+        this.route.queryParams.subscribe(async qParams => {
             if (fired) {
                 return;
             }

--- a/src/app/accounts/login.component.ts
+++ b/src/app/accounts/login.component.ts
@@ -34,7 +34,7 @@ export class LoginComponent extends BaseLoginComponent {
     }
 
     async ngOnInit() {
-        const queryParamsSub = this.route.queryParams.subscribe(async (qParams) => {
+        const queryParamsSub = this.route.queryParams.subscribe(async qParams => {
             if (qParams.email != null && qParams.email.indexOf('@') > -1) {
                 this.email = qParams.email;
             }

--- a/src/app/accounts/register.component.ts
+++ b/src/app/accounts/register.component.ts
@@ -62,7 +62,7 @@ export class RegisterComponent extends BaseRegisterComponent {
     }
 
     async ngOnInit() {
-        const queryParamsSub = this.route.queryParams.subscribe((qParams) => {
+        const queryParamsSub = this.route.queryParams.subscribe(qParams => {
             this.referenceData = new ReferenceEventRequest();
             if (qParams.email != null && qParams.email.indexOf('@') > -1) {
                 this.email = qParams.email;
@@ -96,8 +96,8 @@ export class RegisterComponent extends BaseRegisterComponent {
                 const policies = await this.apiService.getPoliciesByToken(invite.organizationId, invite.token,
                     invite.email, invite.organizationUserId);
                 if (policies.data != null) {
-                    const policiesData = policies.data.map((p) => new PolicyData(p));
-                    this.policies = policiesData.map((p) => new Policy(p));
+                    const policiesData = policies.data.map(p => new PolicyData(p));
+                    this.policies = policiesData.map(p => new Policy(p));
                 }
             } catch { }
         }

--- a/src/app/accounts/sso.component.ts
+++ b/src/app/accounts/sso.component.ts
@@ -36,7 +36,7 @@ export class SsoComponent extends BaseSsoComponent {
 
     async ngOnInit() {
         super.ngOnInit();
-        const queryParamsSub = this.route.queryParams.subscribe(async (qParams) => {
+        const queryParamsSub = this.route.queryParams.subscribe(async qParams => {
             if (qParams.identifier != null) {
                 this.identifier = qParams.identifier;
             } else {

--- a/src/app/accounts/verify-email-token.component.ts
+++ b/src/app/accounts/verify-email-token.component.ts
@@ -26,7 +26,7 @@ export class VerifyEmailTokenComponent implements OnInit {
 
     ngOnInit() {
         let fired = false;
-        this.route.queryParams.subscribe(async (qParams) => {
+        this.route.queryParams.subscribe(async qParams => {
             if (fired) {
                 return;
             }

--- a/src/app/accounts/verify-recover-delete.component.ts
+++ b/src/app/accounts/verify-recover-delete.component.ts
@@ -33,7 +33,7 @@ export class VerifyRecoverDeleteComponent implements OnInit {
 
     ngOnInit() {
         let fired = false;
-        this.route.queryParams.subscribe(async (qParams) => {
+        this.route.queryParams.subscribe(async qParams => {
             if (fired) {
                 return;
             }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -157,7 +157,7 @@ export class AppComponent implements OnDestroy, OnInit {
             });
         });
 
-        this.router.events.subscribe((event) => {
+        this.router.events.subscribe(event => {
             if (event instanceof NavigationEnd) {
                 const modals = Array.from(document.querySelectorAll('.modal'));
                 for (const modal of modals) {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -115,10 +115,10 @@ import { DeleteAccountComponent } from './settings/delete-account.component';
 import { DomainRulesComponent } from './settings/domain-rules.component';
 import { EmergencyAccessAddEditComponent } from './settings/emergency-access-add-edit.component';
 import { EmergencyAccessAttachmentsComponent } from './settings/emergency-access-attachments.component';
-import { EmergencyAccessComponent } from './settings/emergency-access.component';
 import { EmergencyAccessConfirmComponent } from './settings/emergency-access-confirm.component';
 import { EmergencyAccessTakeoverComponent } from './settings/emergency-access-takeover.component';
 import { EmergencyAccessViewComponent } from './settings/emergency-access-view.component';
+import { EmergencyAccessComponent } from './settings/emergency-access.component';
 import { EmergencyAddEditComponent } from './settings/emergency-add-edit.component';
 import { LinkSsoComponent } from './settings/link-sso.component';
 import { OptionsComponent } from './settings/options.component';
@@ -191,8 +191,8 @@ import { SearchCiphersPipe } from 'jslib/angular/pipes/search-ciphers.pipe';
 import { SearchPipe } from 'jslib/angular/pipes/search.pipe';
 
 import {
-    registerLocaleData,
     DatePipe,
+    registerLocaleData,
 } from '@angular/common';
 import localeCa from '@angular/common/locales/ca';
 import localeCs from '@angular/common/locales/cs';

--- a/src/app/layouts/organization-layout.component.ts
+++ b/src/app/layouts/organization-layout.component.ts
@@ -42,7 +42,7 @@ export class OrganizationLayoutComponent implements OnInit, OnDestroy {
         }
 
         document.body.classList.remove('layout_frontend');
-        this.route.params.subscribe(async (params) => {
+        this.route.params.subscribe(async params => {
             this.organizationId = params.organizationId;
             await this.load();
         });

--- a/src/app/organizations/manage/collection-add-edit.component.ts
+++ b/src/app/organizations/manage/collection-add-edit.component.ts
@@ -56,7 +56,7 @@ export class CollectionAddEditComponent implements OnInit {
         this.editMode = this.loading = this.collectionId != null;
         if (this.accessGroups) {
             const groupsResponse = await this.apiService.getGroups(this.organizationId);
-            this.groups = groupsResponse.data.map((r) => r).sort(Utils.getSortFunction(this.i18nService, 'name'));
+            this.groups = groupsResponse.data.map(r => r).sort(Utils.getSortFunction(this.i18nService, 'name'));
         }
         this.orgKey = await this.cryptoService.getOrgKey(this.organizationId);
 
@@ -68,8 +68,8 @@ export class CollectionAddEditComponent implements OnInit {
                 this.name = await this.cryptoService.decryptToUtf8(new CipherString(collection.name), this.orgKey);
                 this.externalId = collection.externalId;
                 if (collection.groups != null && this.groups.length > 0) {
-                    collection.groups.forEach((s) => {
-                        const group = this.groups.filter((g) => !g.accessAll && g.id === s.id);
+                    collection.groups.forEach(s => {
+                        const group = this.groups.filter(g => !g.accessAll && g.id === s.id);
                         if (group != null && group.length > 0) {
                             (group[0] as any).checked = true;
                             (group[0] as any).readOnly = s.readOnly;
@@ -82,7 +82,7 @@ export class CollectionAddEditComponent implements OnInit {
             this.title = this.i18nService.t('addCollection');
         }
 
-        this.groups.forEach((g) => {
+        this.groups.forEach(g => {
             if (g.accessAll) {
                 (g as any).checked = true;
             }
@@ -103,7 +103,7 @@ export class CollectionAddEditComponent implements OnInit {
     }
 
     selectAll(select: boolean) {
-        this.groups.forEach((g) => this.check(g, select));
+        this.groups.forEach(g => this.check(g, select));
     }
 
     async submit() {
@@ -114,8 +114,8 @@ export class CollectionAddEditComponent implements OnInit {
         const request = new CollectionRequest();
         request.name = (await this.cryptoService.encrypt(this.name, this.orgKey)).encryptedString;
         request.externalId = this.externalId;
-        request.groups = this.groups.filter((g) => (g as any).checked && !g.accessAll)
-            .map((g) => new SelectionReadOnlyRequest(g.id, !!(g as any).readOnly, !!(g as any).hidePasswords));
+        request.groups = this.groups.filter(g => (g as any).checked && !g.accessAll)
+            .map(g => new SelectionReadOnlyRequest(g.id, !!(g as any).readOnly, !!(g as any).hidePasswords));
 
         try {
             if (this.editMode) {

--- a/src/app/organizations/manage/collections.component.ts
+++ b/src/app/organizations/manage/collections.component.ts
@@ -57,10 +57,10 @@ export class CollectionsComponent implements OnInit {
         private userService: UserService, private searchService: SearchService) { }
 
     async ngOnInit() {
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organizationId = params.organizationId;
             await this.load();
-            const queryParamsSub = this.route.queryParams.subscribe(async (qParams) => {
+            const queryParamsSub = this.route.queryParams.subscribe(async qParams => {
                 this.searchText = qParams.search;
                 if (queryParamsSub != null) {
                     queryParamsSub.unsubscribe();
@@ -77,7 +77,7 @@ export class CollectionsComponent implements OnInit {
         } else {
             response = await this.apiService.getUserCollections();
         }
-        const collections = response.data.filter((c) => c.organizationId === this.organizationId).map((r) =>
+        const collections = response.data.filter(c => c.organizationId === this.organizationId).map(r =>
             new Collection(new CollectionData(r as CollectionDetailsResponse)));
         this.collections = await this.collectionService.decryptMany(collections);
         this.resetPaging();

--- a/src/app/organizations/manage/entity-events.component.ts
+++ b/src/app/organizations/manage/entity-events.component.ts
@@ -50,7 +50,7 @@ export class EntityEventsComponent implements OnInit {
     async load() {
         if (this.showUser) {
             const response = await this.apiService.getOrganizationUsers(this.organizationId);
-            response.data.forEach((u) => {
+            response.data.forEach(u => {
                 const name = u.name == null || u.name.trim() === '' ? u.email : u.name;
                 this.orgUsersIdMap.set(u.id, { name: name, email: u.email });
                 this.orgUsersUserIdMap.set(u.userId, { name: name, email: u.email });
@@ -94,7 +94,7 @@ export class EntityEventsComponent implements OnInit {
         } catch { }
 
         this.continuationToken = response.continuationToken;
-        const events = response.data.map((r) => {
+        const events = response.data.map(r => {
             const userId = r.actingUserId == null ? r.userId : r.actingUserId;
             const eventInfo = this.eventService.getEventInfo(r);
             const user = this.showUser && userId != null && this.orgUsersUserIdMap.has(userId) ?

--- a/src/app/organizations/manage/entity-users.component.ts
+++ b/src/app/organizations/manage/entity-users.component.ts
@@ -51,7 +51,7 @@ export class EntityUsersComponent implements OnInit {
 
     get users() {
         if (this.showSelected) {
-            return this.allUsers.filter((u) => (u as any).checked);
+            return this.allUsers.filter(u => (u as any).checked);
         } else {
             return this.allUsers;
         }
@@ -59,12 +59,12 @@ export class EntityUsersComponent implements OnInit {
 
     async loadUsers() {
         const users = await this.apiService.getOrganizationUsers(this.organizationId);
-        this.allUsers = users.data.map((r) => r).sort(Utils.getSortFunction(this.i18nService, 'email'));
+        this.allUsers = users.data.map(r => r).sort(Utils.getSortFunction(this.i18nService, 'email'));
         if (this.entity === 'group') {
             const response = await this.apiService.getGroupUsers(this.organizationId, this.entityId);
             if (response != null && users.data.length > 0) {
-                response.forEach((s) => {
-                    const user = users.data.filter((u) => u.id === s);
+                response.forEach(s => {
+                    const user = users.data.filter(u => u.id === s);
                     if (user != null && user.length > 0) {
                         (user[0] as any).checked = true;
                     }
@@ -73,8 +73,8 @@ export class EntityUsersComponent implements OnInit {
         } else if (this.entity === 'collection') {
             const response = await this.apiService.getCollectionUsers(this.organizationId, this.entityId);
             if (response != null && users.data.length > 0) {
-                response.forEach((s) => {
-                    const user = users.data.filter((u) => !u.accessAll && u.id === s.id);
+                response.forEach(s => {
+                    const user = users.data.filter(u => !u.accessAll && u.id === s.id);
                     if (user != null && user.length > 0) {
                         (user[0] as any).checked = true;
                         (user[0] as any).readOnly = s.readOnly;
@@ -84,7 +84,7 @@ export class EntityUsersComponent implements OnInit {
             }
         }
 
-        this.allUsers.forEach((u) => {
+        this.allUsers.forEach(u => {
             if (this.entity === 'collection' && u.accessAll) {
                 (u as any).checked = true;
             }
@@ -121,11 +121,11 @@ export class EntityUsersComponent implements OnInit {
     async submit() {
         try {
             if (this.entity === 'group') {
-                const selections = this.users.filter((u) => (u as any).checked).map((u) => u.id);
+                const selections = this.users.filter(u => (u as any).checked).map(u => u.id);
                 this.formPromise = this.apiService.putGroupUsers(this.organizationId, this.entityId, selections);
             } else {
-                const selections = this.users.filter((u) => (u as any).checked && !u.accessAll)
-                    .map((u) => new SelectionReadOnlyRequest(u.id, !!(u as any).readOnly, !!(u as any).hidePasswords));
+                const selections = this.users.filter(u => (u as any).checked && !u.accessAll)
+                    .map(u => new SelectionReadOnlyRequest(u.id, !!(u as any).readOnly, !!(u as any).hidePasswords));
                 this.formPromise = this.apiService.putCollectionUsers(this.organizationId, this.entityId, selections);
             }
             await this.formPromise;

--- a/src/app/organizations/manage/events.component.ts
+++ b/src/app/organizations/manage/events.component.ts
@@ -39,7 +39,7 @@ export class EventsComponent implements OnInit {
         private router: Router) { }
 
     async ngOnInit() {
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organizationId = params.organizationId;
             const organization = await this.userService.getOrganization(this.organizationId);
             if (organization == null || !organization.useEvents) {
@@ -55,7 +55,7 @@ export class EventsComponent implements OnInit {
 
     async load() {
         const response = await this.apiService.getOrganizationUsers(this.organizationId);
-        response.data.forEach((u) => {
+        response.data.forEach(u => {
             const name = u.name == null || u.name.trim() === '' ? u.email : u.name;
             this.orgUsersIdMap.set(u.id, { name: name, email: u.email });
             this.orgUsersUserIdMap.set(u.userId, { name: name, email: u.email });
@@ -92,7 +92,7 @@ export class EventsComponent implements OnInit {
         } catch { }
 
         this.continuationToken = response.continuationToken;
-        const events = response.data.map((r) => {
+        const events = response.data.map(r => {
             const userId = r.actingUserId == null ? r.userId : r.actingUserId;
             const eventInfo = this.eventService.getEventInfo(r);
             const user = userId != null && this.orgUsersUserIdMap.has(userId) ?

--- a/src/app/organizations/manage/group-add-edit.component.ts
+++ b/src/app/organizations/manage/group-add-edit.component.ts
@@ -58,8 +58,8 @@ export class GroupAddEditComponent implements OnInit {
                 this.name = group.name;
                 this.externalId = group.externalId;
                 if (group.collections != null && this.collections != null) {
-                    group.collections.forEach((s) => {
-                        const collection = this.collections.filter((c) => c.id === s.id);
+                    group.collections.forEach(s => {
+                        const collection = this.collections.filter(c => c.id === s.id);
                         if (collection != null && collection.length > 0) {
                             (collection[0] as any).checked = true;
                             collection[0].readOnly = s.readOnly;
@@ -77,7 +77,7 @@ export class GroupAddEditComponent implements OnInit {
 
     async loadCollections() {
         const response = await this.apiService.getCollections(this.organizationId);
-        const collections = response.data.map((r) =>
+        const collections = response.data.map(r =>
             new Collection(new CollectionData(r as CollectionDetailsResponse)));
         this.collections = await this.collectionService.decryptMany(collections);
     }
@@ -90,7 +90,7 @@ export class GroupAddEditComponent implements OnInit {
     }
 
     selectAll(select: boolean) {
-        this.collections.forEach((c) => this.check(c, select));
+        this.collections.forEach(c => this.check(c, select));
     }
 
     async submit() {
@@ -99,8 +99,8 @@ export class GroupAddEditComponent implements OnInit {
         request.externalId = this.externalId;
         request.accessAll = this.access === 'all';
         if (!request.accessAll) {
-            request.collections = this.collections.filter((c) => (c as any).checked)
-                .map((c) => new SelectionReadOnlyRequest(c.id, !!c.readOnly, !!c.hidePasswords));
+            request.collections = this.collections.filter(c => (c as any).checked)
+                .map(c => new SelectionReadOnlyRequest(c.id, !!c.readOnly, !!c.hidePasswords));
         }
 
         try {

--- a/src/app/organizations/manage/groups.component.ts
+++ b/src/app/organizations/manage/groups.component.ts
@@ -54,7 +54,7 @@ export class GroupsComponent implements OnInit {
         private router: Router, private searchService: SearchService) { }
 
     async ngOnInit() {
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organizationId = params.organizationId;
             const organization = await this.userService.getOrganization(this.organizationId);
             if (organization == null || !organization.useGroups) {
@@ -62,7 +62,7 @@ export class GroupsComponent implements OnInit {
                 return;
             }
             await this.load();
-            const queryParamsSub = this.route.queryParams.subscribe(async (qParams) => {
+            const queryParamsSub = this.route.queryParams.subscribe(async qParams => {
                 this.searchText = qParams.search;
                 if (queryParamsSub != null) {
                     queryParamsSub.unsubscribe();

--- a/src/app/organizations/manage/manage.component.ts
+++ b/src/app/organizations/manage/manage.component.ts
@@ -21,7 +21,7 @@ export class ManageComponent implements OnInit {
     constructor(private route: ActivatedRoute, private userService: UserService) { }
 
     ngOnInit() {
-        this.route.parent.params.subscribe(async (params) => {
+        this.route.parent.params.subscribe(async params => {
             this.organization = await this.userService.getOrganization(params.organizationId);
             this.accessPolicies = this.organization.usePolicies;
             this.accessEvents = this.organization.useEvents;

--- a/src/app/organizations/manage/people.component.ts
+++ b/src/app/organizations/manage/people.component.ts
@@ -76,7 +76,7 @@ export class PeopleComponent implements OnInit {
         private storageService: StorageService, private searchService: SearchService) { }
 
     async ngOnInit() {
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organizationId = params.organizationId;
             const organization = await this.userService.getOrganization(this.organizationId);
             if (!organization.canManageUsers) {
@@ -87,10 +87,10 @@ export class PeopleComponent implements OnInit {
             this.accessGroups = organization.useGroups;
             await this.load();
 
-            const queryParamsSub = this.route.queryParams.subscribe(async (qParams) => {
+            const queryParamsSub = this.route.queryParams.subscribe(async qParams => {
                 this.searchText = qParams.search;
                 if (qParams.viewEvents != null) {
-                    const user = this.users.filter((u) => u.id === qParams.viewEvents);
+                    const user = this.users.filter(u => u.id === qParams.viewEvents);
                     if (user.length > 0 && user[0].status === OrganizationUserStatusType.Confirmed) {
                         this.events(user[0]);
                     }
@@ -107,7 +107,7 @@ export class PeopleComponent implements OnInit {
         this.statusMap.clear();
         this.allUsers = response.data != null && response.data.length > 0 ? response.data : [];
         this.allUsers.sort(Utils.getSortFunction(this.i18nService, 'email'));
-        this.allUsers.forEach((u) => {
+        this.allUsers.forEach(u => {
             if (!this.statusMap.has(u.status)) {
                 this.statusMap.set(u.status, [u]);
             } else {

--- a/src/app/organizations/manage/policies.component.ts
+++ b/src/app/organizations/manage/policies.component.ts
@@ -12,8 +12,8 @@ import {
 
 import { PolicyType } from 'jslib/enums/policyType';
 
-import { ApiService } from 'jslib/abstractions/api.service';
 import { EnvironmentService } from 'jslib/abstractions';
+import { ApiService } from 'jslib/abstractions/api.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 import { UserService } from 'jslib/abstractions/user.service';
@@ -51,7 +51,7 @@ export class PoliciesComponent implements OnInit {
         private router: Router, private environmentService: EnvironmentService) { }
 
     async ngOnInit() {
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organizationId = params.organizationId;
             const organization = await this.userService.getOrganization(this.organizationId);
             if (organization == null || !organization.usePolicies) {
@@ -106,7 +106,7 @@ export class PoliciesComponent implements OnInit {
             await this.load();
 
             // Handle policies component launch from Event message
-            const queryParamsSub = this.route.queryParams.subscribe(async (qParams) => {
+            const queryParamsSub = this.route.queryParams.subscribe(async qParams => {
                 if (qParams.policyId != null) {
                     const policyIdFromEvents: string = qParams.policyId;
                     for (const orgPolicy of this.orgPolicies) {
@@ -140,10 +140,10 @@ export class PoliciesComponent implements OnInit {
     async load() {
         const response = await this.apiService.getPolicies(this.organizationId);
         this.orgPolicies = response.data != null && response.data.length > 0 ? response.data : [];
-        this.orgPolicies.forEach((op) => {
+        this.orgPolicies.forEach(op => {
             this.policiesEnabledMap.set(op.type, op.enabled);
         });
-        this.policies.forEach((p) => {
+        this.policies.forEach(p => {
             p.enabled = this.policiesEnabledMap.has(p.type) && this.policiesEnabledMap.get(p.type);
         });
         this.loading = false;

--- a/src/app/organizations/manage/user-add-edit.component.ts
+++ b/src/app/organizations/manage/user-add-edit.component.ts
@@ -72,8 +72,8 @@ export class UserAddEditComponent implements OnInit {
                     this.permissions = user.permissions;
                 }
                 if (user.collections != null && this.collections != null) {
-                    user.collections.forEach((s) => {
-                        const collection = this.collections.filter((c) => c.id === s.id);
+                    user.collections.forEach(s => {
+                        const collection = this.collections.filter(c => c.id === s.id);
                         if (collection != null && collection.length > 0) {
                             (collection[0] as any).checked = true;
                             collection[0].readOnly = s.readOnly;
@@ -91,7 +91,7 @@ export class UserAddEditComponent implements OnInit {
 
     async loadCollections() {
         const response = await this.apiService.getCollections(this.organizationId);
-        const collections = response.data.map((r) =>
+        const collections = response.data.map(r =>
             new Collection(new CollectionData(r as CollectionDetailsResponse)));
         this.collections = await this.collectionService.decryptMany(collections);
     }
@@ -104,7 +104,7 @@ export class UserAddEditComponent implements OnInit {
     }
 
     selectAll(select: boolean) {
-        this.collections.forEach((c) => this.check(c, select));
+        this.collections.forEach(c => this.check(c, select));
     }
 
     setRequestPermissions(p: PermissionsApi, clearPermissions: boolean) {
@@ -144,8 +144,8 @@ export class UserAddEditComponent implements OnInit {
     async submit() {
         let collections: SelectionReadOnlyRequest[] = null;
         if (this.access !== 'all') {
-            collections = this.collections.filter((c) => (c as any).checked)
-                .map((c) => new SelectionReadOnlyRequest(c.id, !!c.readOnly, !!c.hidePasswords));
+            collections = this.collections.filter(c => (c as any).checked)
+                .map(c => new SelectionReadOnlyRequest(c.id, !!c.readOnly, !!c.hidePasswords));
         }
 
         try {

--- a/src/app/organizations/manage/user-groups.component.ts
+++ b/src/app/organizations/manage/user-groups.component.ts
@@ -36,7 +36,7 @@ export class UserGroupsComponent implements OnInit {
 
     async ngOnInit() {
         const groupsResponse = await this.apiService.getGroups(this.organizationId);
-        const groups = groupsResponse.data.map((r) => r);
+        const groups = groupsResponse.data.map(r => r);
         groups.sort(Utils.getSortFunction(this.i18nService, 'name'));
         this.groups = groups;
 
@@ -44,8 +44,8 @@ export class UserGroupsComponent implements OnInit {
             const userGroups = await this.apiService.getOrganizationUserGroups(
                 this.organizationId, this.organizationUserId);
             if (userGroups != null && this.groups != null) {
-                userGroups.forEach((ug) => {
-                    const group = this.groups.filter((g) => g.id === ug);
+                userGroups.forEach(ug => {
+                    const group = this.groups.filter(g => g.id === ug);
                     if (group != null && group.length > 0) {
                         (group[0] as any).checked = true;
                     }
@@ -64,12 +64,12 @@ export class UserGroupsComponent implements OnInit {
     }
 
     selectAll(select: boolean) {
-        this.groups.forEach((g) => this.check(g, select));
+        this.groups.forEach(g => this.check(g, select));
     }
 
     async submit() {
         const request = new OrganizationUserUpdateGroupsRequest();
-        request.groupIds = this.groups.filter((g) => (g as any).checked).map((g) => g.id);
+        request.groupIds = this.groups.filter(g => (g as any).checked).map(g => g.id);
 
         try {
             this.formPromise = this.apiService.putOrganizationUserGroups(this.organizationId, this.organizationUserId,

--- a/src/app/organizations/settings/account.component.ts
+++ b/src/app/organizations/settings/account.component.ts
@@ -52,7 +52,7 @@ export class AccountComponent {
 
     async ngOnInit() {
         this.selfHosted = this.platformUtilsService.isSelfHost();
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organizationId = params.organizationId;
             try {
                 this.org = await this.apiService.getOrganization(this.organizationId);

--- a/src/app/organizations/settings/organization-billing.component.ts
+++ b/src/app/organizations/settings/organization-billing.component.ts
@@ -25,7 +25,7 @@ export class OrganizationBillingComponent extends UserBillingComponent implement
     }
 
     async ngOnInit() {
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organizationId = params.organizationId;
             await this.load();
             this.firstLoaded = true;

--- a/src/app/organizations/settings/organization-subscription.component.ts
+++ b/src/app/organizations/settings/organization-subscription.component.ts
@@ -45,7 +45,7 @@ export class OrganizationSubscriptionComponent implements OnInit {
     }
 
     async ngOnInit() {
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organizationId = params.organizationId;
             await this.load();
             this.firstLoaded = true;

--- a/src/app/organizations/settings/settings.component.ts
+++ b/src/app/organizations/settings/settings.component.ts
@@ -16,7 +16,7 @@ export class SettingsComponent {
         private platformUtilsService: PlatformUtilsService) { }
 
     ngOnInit() {
-        this.route.parent.params.subscribe(async (params) => {
+        this.route.parent.params.subscribe(async params => {
             this.selfHosted = await this.platformUtilsService.isSelfHost();
             const organization = await this.userService.getOrganization(params.organizationId);
             this.access2fa = organization.use2fa;

--- a/src/app/organizations/settings/two-factor-setup.component.ts
+++ b/src/app/organizations/settings/two-factor-setup.component.ts
@@ -26,7 +26,7 @@ export class TwoFactorSetupComponent extends BaseTwoFactorSetupComponent {
     }
 
     async ngOnInit() {
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organizationId = params.organizationId;
             await super.ngOnInit();
         });

--- a/src/app/organizations/tools/export.component.ts
+++ b/src/app/organizations/tools/export.component.ts
@@ -23,7 +23,7 @@ export class ExportComponent extends BaseExportComponent {
     }
 
     ngOnInit() {
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organizationId = params.organizationId;
         });
     }

--- a/src/app/organizations/tools/exposed-passwords-report.component.ts
+++ b/src/app/organizations/tools/exposed-passwords-report.component.ts
@@ -13,8 +13,8 @@ import {
     ExposedPasswordsReportComponent as BaseExposedPasswordsReportComponent,
 } from '../../tools/exposed-passwords-report.component';
 
-import { CipherView } from 'jslib/models/view/cipherView';
 import { Cipher } from 'jslib/models/domain/cipher';
+import { CipherView } from 'jslib/models/view/cipherView';
 
 @Component({
     selector: 'app-exposed-passwords-report',
@@ -30,7 +30,7 @@ export class ExposedPasswordsReportComponent extends BaseExposedPasswordsReportC
     }
 
     ngOnInit() {
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organization = await this.userService.getOrganization(params.organizationId);
             this.manageableCiphers = await this.cipherService.getAll();
             super.ngOnInit();

--- a/src/app/organizations/tools/import.component.ts
+++ b/src/app/organizations/tools/import.component.ts
@@ -24,7 +24,7 @@ export class ImportComponent extends BaseImportComponent {
     }
 
     ngOnInit() {
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organizationId = params.organizationId;
             this.successNavigate = ['organizations', this.organizationId, 'vault'];
             super.ngOnInit();

--- a/src/app/organizations/tools/inactive-two-factor-report.component.ts
+++ b/src/app/organizations/tools/inactive-two-factor-report.component.ts
@@ -26,7 +26,7 @@ export class InactiveTwoFactorReportComponent extends BaseInactiveTwoFactorRepor
     }
 
     async ngOnInit() {
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organization = await this.userService.getOrganization(params.organizationId);
             await super.ngOnInit();
         });

--- a/src/app/organizations/tools/reused-passwords-report.component.ts
+++ b/src/app/organizations/tools/reused-passwords-report.component.ts
@@ -30,7 +30,7 @@ export class ReusedPasswordsReportComponent extends BaseReusedPasswordsReportCom
     }
 
     async ngOnInit() {
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organization = await this.userService.getOrganization(params.organizationId);
             this.manageableCiphers = await this.cipherService.getAll();
             await super.ngOnInit();

--- a/src/app/organizations/tools/tools.component.ts
+++ b/src/app/organizations/tools/tools.component.ts
@@ -19,7 +19,7 @@ export class ToolsComponent {
         private messagingService: MessagingService) { }
 
     ngOnInit() {
-        this.route.parent.params.subscribe(async (params) => {
+        this.route.parent.params.subscribe(async params => {
             this.organization = await this.userService.getOrganization(params.organizationId);
             // TODO: Maybe we want to just make sure they are not on a free plan? Just compare useTotp for now
             // since all paid plans include useTotp

--- a/src/app/organizations/tools/unsecured-websites-report.component.ts
+++ b/src/app/organizations/tools/unsecured-websites-report.component.ts
@@ -26,7 +26,7 @@ export class UnsecuredWebsitesReportComponent extends BaseUnsecuredWebsitesRepor
     }
 
     async ngOnInit() {
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organization = await this.userService.getOrganization(params.organizationId);
             await super.ngOnInit();
         });

--- a/src/app/organizations/tools/weak-passwords-report.component.ts
+++ b/src/app/organizations/tools/weak-passwords-report.component.ts
@@ -31,7 +31,7 @@ export class WeakPasswordsReportComponent extends BaseWeakPasswordsReportCompone
     }
 
     async ngOnInit() {
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organization = await this.userService.getOrganization(params.organizationId);
             this.manageableCiphers = await this.cipherService.getAll();
             await super.ngOnInit();

--- a/src/app/organizations/vault/ciphers.component.ts
+++ b/src/app/organizations/vault/ciphers.component.ts
@@ -69,7 +69,7 @@ export class CiphersComponent extends BaseCiphersComponent {
         let filteredCiphers = this.allCiphers;
 
         if (this.searchText == null || this.searchText.trim().length < 2) {
-            this.ciphers = filteredCiphers.filter((c) => {
+            this.ciphers = filteredCiphers.filter(c => {
                 if (c.isDeleted !== this.deleted) {
                     return false;
                 }

--- a/src/app/organizations/vault/groupings.component.ts
+++ b/src/app/organizations/vault/groupings.component.ts
@@ -36,7 +36,7 @@ export class GroupingsComponent extends BaseGroupingsComponent {
 
         const collections = await this.apiService.getCollections(this.organization.id);
         if (collections != null && collections.data != null && collections.data.length) {
-            const collectionDomains = collections.data.map((r) =>
+            const collectionDomains = collections.data.map(r =>
                 new Collection(new CollectionData(r as CollectionDetailsResponse)));
             this.collections = await this.collectionService.decryptMany(collectionDomains);
         } else {

--- a/src/app/organizations/vault/vault.component.ts
+++ b/src/app/organizations/vault/vault.component.ts
@@ -62,12 +62,12 @@ export class VaultComponent implements OnInit, OnDestroy {
         private broadcasterService: BroadcasterService, private ngZone: NgZone) { }
 
     ngOnInit() {
-        const queryParams = this.route.parent.params.subscribe(async (params) => {
+        const queryParams = this.route.parent.params.subscribe(async params => {
             this.organization = await this.userService.getOrganization(params.organizationId);
             this.groupingsComponent.organization = this.organization;
             this.ciphersComponent.organization = this.organization;
 
-            const queryParamsSub = this.route.queryParams.subscribe(async (qParams) => {
+            const queryParamsSub = this.route.queryParams.subscribe(async qParams => {
                 this.ciphersComponent.searchText = this.groupingsComponent.searchText = qParams.search;
                 if (!this.organization.canManageAllCollections) {
                     await this.syncService.fullSync(false);
@@ -110,7 +110,7 @@ export class VaultComponent implements OnInit, OnDestroy {
                 }
 
                 if (qParams.viewEvents != null) {
-                    const cipher = this.ciphersComponent.ciphers.filter((c) => c.id === qParams.viewEvents);
+                    const cipher = this.ciphersComponent.ciphers.filter(c => c.id === qParams.viewEvents);
                     if (cipher.length > 0) {
                         this.viewEvents(cipher[0]);
                     }
@@ -235,7 +235,7 @@ export class VaultComponent implements OnInit, OnDestroy {
 
         if (this.organization.canManageAllCollections) {
             childComponent.collectionIds = cipher.collectionIds;
-            childComponent.collections = this.groupingsComponent.collections.filter((c) => !c.readOnly);
+            childComponent.collections = this.groupingsComponent.collections.filter(c => !c.readOnly);
         }
         childComponent.organization = this.organization;
         childComponent.cipherId = cipher.id;
@@ -254,7 +254,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         component.organizationId = this.organization.id;
         component.type = this.type;
         if (this.organization.canManageAllCollections) {
-            component.collections = this.groupingsComponent.collections.filter((c) => !c.readOnly);
+            component.collections = this.groupingsComponent.collections.filter(c => !c.readOnly);
         }
         if (this.collectionId != null) {
             component.collectionIds = [this.collectionId];
@@ -297,7 +297,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         component.cloneMode = true;
         component.organizationId = this.organization.id;
         if (this.organization.canManageAllCollections) {
-            component.collections = this.groupingsComponent.collections.filter((c) => !c.readOnly);
+            component.collections = this.groupingsComponent.collections.filter(c => !c.readOnly);
         }
         // Regardless of Admin state, the collection Ids need to passed manually as they are not assigned value
         // in the add-edit componenet

--- a/src/app/send/access.component.ts
+++ b/src/app/send/access.component.ts
@@ -13,8 +13,8 @@ import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 
 import { Utils } from 'jslib/misc/utils';
 
-import { SymmetricCryptoKey } from 'jslib/models/domain/symmetricCryptoKey';
 import { SendAccess } from 'jslib/models/domain/sendAccess';
+import { SymmetricCryptoKey } from 'jslib/models/domain/symmetricCryptoKey';
 
 import { SendAccessView } from 'jslib/models/view/sendAccessView';
 
@@ -57,7 +57,7 @@ export class AccessComponent implements OnInit {
     }
 
     ngOnInit() {
-        this.route.params.subscribe(async (params) => {
+        this.route.params.subscribe(async params => {
             this.id = params.sendId;
             this.key = params.key;
             if (this.key == null || this.id == null) {

--- a/src/app/send/send.component.ts
+++ b/src/app/send/send.component.ts
@@ -8,8 +8,8 @@ import {
 
 import { SendView } from 'jslib/models/view/sendView';
 
-import { AddEditComponent } from './add-edit.component';
 import { SendComponent as BaseSendComponent } from 'jslib/angular/components/send/send.component';
+import { AddEditComponent } from './add-edit.component';
 
 import { ModalComponent } from '../modal.component';
 

--- a/src/app/services/router.service.ts
+++ b/src/app/services/router.service.ts
@@ -16,7 +16,7 @@ export class RouterService {
     constructor(private router: Router, private activatedRoute: ActivatedRoute,
         private titleService: Title, i18nService: I18nService) {
         this.currentUrl = this.router.url;
-        router.events.subscribe((event) => {
+        router.events.subscribe(event => {
             if (event instanceof NavigationEnd) {
                 this.previousUrl = this.currentUrl;
                 this.currentUrl = event.url;

--- a/src/app/settings/adjust-payment.component.ts
+++ b/src/app/settings/adjust-payment.component.ts
@@ -41,7 +41,7 @@ export class AdjustPaymentComponent {
     async submit() {
         try {
             const request = new PaymentRequest();
-            this.formPromise = this.paymentComponent.createPaymentToken().then((result) => {
+            this.formPromise = this.paymentComponent.createPaymentToken().then(result => {
                 request.paymentToken = result[0];
                 request.paymentMethodType = result[1];
                 request.postalCode = this.taxInfoComponent.taxInfo.postalCode;

--- a/src/app/settings/create-organization.component.ts
+++ b/src/app/settings/create-organization.component.ts
@@ -20,7 +20,7 @@ export class CreateOrganizationComponent implements OnInit {
     constructor(private route: ActivatedRoute) { }
 
     ngOnInit() {
-        const queryParamsSub = this.route.queryParams.subscribe(async (qParams) => {
+        const queryParamsSub = this.route.queryParams.subscribe(async qParams => {
             if (qParams.plan === 'families') {
                 this.orgPlansComponent.plan = PlanType.FamiliesAnnually;
                 this.orgPlansComponent.product = ProductType.Families;

--- a/src/app/settings/domain-rules.component.ts
+++ b/src/app/settings/domain-rules.component.ts
@@ -28,10 +28,10 @@ export class DomainRulesComponent implements OnInit {
         const response = await this.apiService.getSettingsDomains();
         this.loading = false;
         if (response.equivalentDomains != null) {
-            this.custom = response.equivalentDomains.map((d) => d.join(', '));
+            this.custom = response.equivalentDomains.map(d => d.join(', '));
         }
         if (response.globalEquivalentDomains != null) {
-            this.global = response.globalEquivalentDomains.map((d) => {
+            this.global = response.globalEquivalentDomains.map(d => {
                 return {
                     domains: d.domains.join(', '),
                     excluded: d.excluded,
@@ -60,13 +60,13 @@ export class DomainRulesComponent implements OnInit {
 
     async submit() {
         const request = new UpdateDomainsRequest();
-        request.excludedGlobalEquivalentDomains = this.global.filter((d) => d.excluded)
-            .map((d) => d.key);
+        request.excludedGlobalEquivalentDomains = this.global.filter(d => d.excluded)
+            .map(d => d.key);
         if (request.excludedGlobalEquivalentDomains.length === 0) {
             request.excludedGlobalEquivalentDomains = null;
         }
-        request.equivalentDomains = this.custom.filter((d) => d != null && d.trim() !== '')
-            .map((d) => d.split(',').map((d2) => d2.trim()));
+        request.equivalentDomains = this.custom.filter(d => d != null && d.trim() !== '')
+            .map(d => d.split(',').map(d2 => d2.trim()));
         if (request.equivalentDomains.length === 0) {
             request.equivalentDomains = null;
         }

--- a/src/app/settings/emergency-access-view.component.ts
+++ b/src/app/settings/emergency-access-view.component.ts
@@ -39,7 +39,7 @@ export class EmergencyAccessViewComponent implements OnInit {
         private route: ActivatedRoute, private apiService: ApiService) { }
 
     ngOnInit() {
-        this.route.params.subscribe((qParams) => {
+        this.route.params.subscribe(qParams => {
             if (qParams.id == null) {
                 return this.router.navigate(['settings/emergency-access']);
             }
@@ -98,10 +98,10 @@ export class EmergencyAccessViewComponent implements OnInit {
         const oldEncKey = new SymmetricCryptoKey(oldKeyBuffer);
 
         const promises: any[] = [];
-        ciphers.forEach((cipherResponse) => {
+        ciphers.forEach(cipherResponse => {
             const cipherData = new CipherData(cipherResponse);
             const cipher = new Cipher(cipherData);
-            promises.push(cipher.decrypt(oldEncKey).then((c) => decCiphers.push(c)));
+            promises.push(cipher.decrypt(oldEncKey).then(c => decCiphers.push(c)));
         });
 
         await Promise.all(promises);

--- a/src/app/settings/options.component.ts
+++ b/src/app/settings/options.component.ts
@@ -51,7 +51,7 @@ export class OptionsComponent implements OnInit {
         }
 
         const localeOptions: any[] = [];
-        i18nService.supportedTranslationLocales.forEach((locale) => {
+        i18nService.supportedTranslationLocales.forEach(locale => {
             let name = locale;
             if (i18nService.localeNames.has(locale)) {
                 name += (' - ' + i18nService.localeNames.get(locale));

--- a/src/app/settings/organization-plans.component.ts
+++ b/src/app/settings/organization-plans.component.ts
@@ -86,7 +86,7 @@ export class OrganizationPlansComponent implements OnInit {
     }
 
     get selectedPlan() {
-        return this.plans.find((plan) => plan.type === this.plan);
+        return this.plans.find(plan => plan.type === this.plan);
     }
 
     get selectedPlanInterval() {
@@ -96,18 +96,18 @@ export class OrganizationPlansComponent implements OnInit {
     }
 
     get selectableProducts() {
-        let validPlans = this.plans.filter((plan) => plan.type !== PlanType.Custom);
+        let validPlans = this.plans.filter(plan => plan.type !== PlanType.Custom);
 
         if (this.ownedBusiness) {
-            validPlans = validPlans.filter((plan) => plan.canBeUsedByBusiness);
+            validPlans = validPlans.filter(plan => plan.canBeUsedByBusiness);
         }
 
         if (!this.showFree) {
-            validPlans = validPlans.filter((plan) => plan.product !== ProductType.Free);
+            validPlans = validPlans.filter(plan => plan.product !== ProductType.Free);
         }
 
         validPlans = validPlans
-            .filter((plan) => !plan.legacyYear
+            .filter(plan => !plan.legacyYear
                 && !plan.disabled
                 && (plan.isAnnual || plan.product === this.productTypes.Free));
 
@@ -115,7 +115,7 @@ export class OrganizationPlansComponent implements OnInit {
     }
 
     get selectablePlans() {
-        return this.plans.filter((plan) => !plan.legacyYear && !plan.disabled && plan.product === this.product);
+        return this.plans.filter(plan => !plan.legacyYear && !plan.disabled && plan.product === this.product);
     }
 
     additionalStoragePriceMonthly(selectedPlan: PlanResponse) {

--- a/src/app/settings/payment.component.ts
+++ b/src/app/settings/payment.component.ts
@@ -92,7 +92,7 @@ export class PaymentComponent implements OnInit {
     ngOnDestroy() {
         window.document.head.removeChild(this.stripeScript);
         window.setTimeout(() => {
-            Array.from(window.document.querySelectorAll('iframe')).forEach((el) => {
+            Array.from(window.document.querySelectorAll('iframe')).forEach(el => {
                 if (el.src != null && el.src.indexOf('stripe') > -1) {
                     try {
                         window.document.body.removeChild(el);
@@ -103,7 +103,7 @@ export class PaymentComponent implements OnInit {
         if (!this.hidePaypal) {
             window.document.head.removeChild(this.btScript);
             window.setTimeout(() => {
-                Array.from(window.document.head.querySelectorAll('script')).forEach((el) => {
+                Array.from(window.document.head.querySelectorAll('script')).forEach(el => {
                     if (el.src != null && el.src.indexOf('paypal') > -1) {
                         try {
                             window.document.head.removeChild(el);
@@ -165,7 +165,7 @@ export class PaymentComponent implements OnInit {
                 });
             } else if (this.method === PaymentMethodType.Card || this.method === PaymentMethodType.BankAccount) {
                 if (this.method === PaymentMethodType.Card) {
-                    this.apiService.postSetupPayment().then((clientSecret) =>
+                    this.apiService.postSetupPayment().then(clientSecret =>
                         this.stripe.handleCardSetup(clientSecret, this.stripeCardNumberElement))
                         .then((result: any) => {
                             if (result.error) {

--- a/src/app/settings/premium.component.ts
+++ b/src/app/settings/premium.component.ts
@@ -78,7 +78,7 @@ export class PremiumComponent implements OnInit {
                     return this.finalizePremium();
                 });
             } else {
-                this.formPromise = this.paymentComponent.createPaymentToken().then((result) => {
+                this.formPromise = this.paymentComponent.createPaymentToken().then(result => {
                     const fd = new FormData();
                     fd.append('paymentMethodType', result[1].toString());
                     if (result[0] != null) {
@@ -88,7 +88,7 @@ export class PremiumComponent implements OnInit {
                     fd.append('country', this.taxInfoComponent.taxInfo.country);
                     fd.append('postalCode', this.taxInfoComponent.taxInfo.postalCode);
                     return this.apiService.postPremium(fd);
-                }).then((paymentResponse) => {
+                }).then(paymentResponse => {
                     if (!paymentResponse.success && paymentResponse.paymentIntentClientSecret != null) {
                         return this.paymentComponent.handleStripeCardPayment(paymentResponse.paymentIntentClientSecret,
                             () => this.finalizePremium());

--- a/src/app/settings/tax-info.component.ts
+++ b/src/app/settings/tax-info.component.ts
@@ -45,7 +45,7 @@ export class TaxInfoComponent {
     constructor(private apiService: ApiService, private route: ActivatedRoute) { }
 
     async ngOnInit() {
-        this.route.parent.parent.params.subscribe(async (params) => {
+        this.route.parent.parent.params.subscribe(async params => {
             this.organizationId = params.organizationId;
             if (this.organizationId) {
                 try {
@@ -118,7 +118,7 @@ export class TaxInfoComponent {
 
     submitTaxInfo(): Promise<any> {
         if (!this.hasChanged()) {
-            return new Promise((resolve) => { resolve(); });
+            return new Promise(resolve => { resolve(); });
         }
         const request = this.getTaxInfoRequest();
         return this.organizationId ? this.apiService.putOrganizationTaxInfo(this.organizationId,

--- a/src/app/settings/two-factor-setup.component.ts
+++ b/src/app/settings/two-factor-setup.component.ts
@@ -80,8 +80,8 @@ export class TwoFactorSetupComponent implements OnInit {
     async load() {
         this.loading = true;
         const providerList = await this.getTwoFactorProviders();
-        providerList.data.forEach((p) => {
-            this.providers.forEach((p2) => {
+        providerList.data.forEach(p => {
+            this.providers.forEach(p2 => {
                 if (p.type === p2.type) {
                     p2.enabled = p.enabled;
                 }
@@ -166,7 +166,7 @@ export class TwoFactorSetupComponent implements OnInit {
         if (!enabled && this.modal != null) {
             this.modal.close();
         }
-        this.providers.forEach((p) => {
+        this.providers.forEach(p => {
             if (p.type === type) {
                 p.enabled = enabled;
             }
@@ -175,9 +175,9 @@ export class TwoFactorSetupComponent implements OnInit {
     }
 
     private async evaluatePolicies() {
-        if (this.organizationId == null && this.providers.filter((p) => p.enabled).length === 1) {
+        if (this.organizationId == null && this.providers.filter(p => p.enabled).length === 1) {
             const policies = await this.policyService.getAll(PolicyType.TwoFactorAuthentication);
-            this.showPolicyWarning = policies != null && policies.some((p) => p.enabled);
+            this.showPolicyWarning = policies != null && policies.some(p => p.enabled);
         } else {
             this.showPolicyWarning = false;
         }

--- a/src/app/settings/two-factor-u2f.component.ts
+++ b/src/app/settings/two-factor-u2f.component.ts
@@ -156,7 +156,7 @@ export class TwoFactorU2fComponent extends TwoFactorBaseComponent implements OnI
         this.keysConfiguredCount = 0;
         for (let i = 1; i <= 5; i++) {
             if (response.keys != null) {
-                const key = response.keys.filter((k) => k.id === i);
+                const key = response.keys.filter(k => k.id === i);
                 if (key.length > 0) {
                     this.keysConfiguredCount++;
                     this.keys.push({

--- a/src/app/settings/update-key.component.ts
+++ b/src/app/settings/update-key.component.ts
@@ -47,7 +47,7 @@ export class UpdateKeyComponent {
         }
 
         try {
-            this.formPromise = this.makeRequest().then((request) => {
+            this.formPromise = this.makeRequest().then(request => {
                 return this.apiService.postAccountKey(request);
             });
             await this.formPromise;

--- a/src/app/tools/exposed-passwords-report.component.ts
+++ b/src/app/tools/exposed-passwords-report.component.ts
@@ -42,11 +42,11 @@ export class ExposedPasswordsReportComponent extends CipherReportComponent imple
         const allCiphers = await this.getAllCiphers();
         const exposedPasswordCiphers: CipherView[] = [];
         const promises: Promise<void>[] = [];
-        allCiphers.forEach((c) => {
+        allCiphers.forEach(c => {
             if (c.type !== CipherType.Login || c.login.password == null || c.login.password === '' || c.isDeleted) {
                 return;
             }
-            const promise = this.auditService.passwordLeaked(c.login.password).then((exposedCount) => {
+            const promise = this.auditService.passwordLeaked(c.login.password).then(exposedCount => {
                 if (exposedCount > 0) {
                     exposedPasswordCiphers.push(c);
                     this.exposedPasswordMap.set(c.id, exposedCount);

--- a/src/app/tools/import.component.ts
+++ b/src/app/tools/import.component.ts
@@ -99,7 +99,7 @@ export class ImportComponent implements OnInit {
             return null;
         }
 
-        const results = this.featuredImportOptions.concat(this.importOptions).filter((o) => o.id === this.format);
+        const results = this.featuredImportOptions.concat(this.importOptions).filter(o => o.id === this.format);
         if (results.length > 0) {
             return this.i18nService.t('instructionsFor', results[0].name);
         }
@@ -126,7 +126,7 @@ export class ImportComponent implements OnInit {
         return new Promise((resolve, reject) => {
             const reader = new FileReader();
             reader.readAsText(file, 'utf-8');
-            reader.onload = (evt) => {
+            reader.onload = evt => {
                 if (this.format === 'lastpasscsv' && file.type === 'text/html') {
                     const parser = new DOMParser();
                     const doc = parser.parseFromString((evt.target as any).result, 'text/html');

--- a/src/app/tools/inactive-two-factor-report.component.ts
+++ b/src/app/tools/inactive-two-factor-report.component.ts
@@ -44,7 +44,7 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
             const inactive2faCiphers: CipherView[] = [];
             const promises: Promise<void>[] = [];
             const docs = new Map<string, string>();
-            allCiphers.forEach((c) => {
+            allCiphers.forEach(c => {
                 if (c.type !== CipherType.Login || (c.login.totp != null && c.login.totp !== '') || !c.login.hasUris ||
                     c.isDeleted) {
                     return;

--- a/src/app/tools/reused-passwords-report.component.ts
+++ b/src/app/tools/reused-passwords-report.component.ts
@@ -36,7 +36,7 @@ export class ReusedPasswordsReportComponent extends CipherReportComponent implem
         const allCiphers = await this.getAllCiphers();
         const ciphersWithPasswords: CipherView[] = [];
         this.passwordUseMap = new Map<string, number>();
-        allCiphers.forEach((c) => {
+        allCiphers.forEach(c => {
             if (c.type !== CipherType.Login || c.login.password == null || c.login.password === '' || c.isDeleted) {
                 return;
             }
@@ -47,7 +47,7 @@ export class ReusedPasswordsReportComponent extends CipherReportComponent implem
                 this.passwordUseMap.set(c.login.password, 1);
             }
         });
-        const reusedPasswordCiphers = ciphersWithPasswords.filter((c) =>
+        const reusedPasswordCiphers = ciphersWithPasswords.filter(c =>
             this.passwordUseMap.has(c.login.password) && this.passwordUseMap.get(c.login.password) > 1);
         this.ciphers = reusedPasswordCiphers;
     }

--- a/src/app/tools/unsecured-websites-report.component.ts
+++ b/src/app/tools/unsecured-websites-report.component.ts
@@ -32,11 +32,11 @@ export class UnsecuredWebsitesReportComponent extends CipherReportComponent impl
 
     async setCiphers() {
         const allCiphers = await this.getAllCiphers();
-        const unsecuredCiphers = allCiphers.filter((c) => {
+        const unsecuredCiphers = allCiphers.filter(c => {
             if (c.type !== CipherType.Login || !c.login.hasUris || c.isDeleted) {
                 return false;
             }
-            return c.login.uris.some((u) => u.uri != null && u.uri.indexOf('http://') === 0);
+            return c.login.uris.some(u => u.uri != null && u.uri.indexOf('http://') === 0);
         });
         this.ciphers = unsecuredCiphers;
     }

--- a/src/app/tools/weak-passwords-report.component.ts
+++ b/src/app/tools/weak-passwords-report.component.ts
@@ -39,7 +39,7 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
     async setCiphers() {
         const allCiphers = await this.getAllCiphers();
         const weakPasswordCiphers: CipherView[] = [];
-        allCiphers.forEach((c) => {
+        allCiphers.forEach(c => {
             if (c.type !== CipherType.Login || c.login.password == null || c.login.password === '' || c.isDeleted) {
                 return;
             }
@@ -52,10 +52,10 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
                     if (atPosition > -1) {
                         userInput = userInput.concat(
                             c.login.username.substr(0, atPosition).trim().toLowerCase().split(/[^A-Za-z0-9]/))
-                            .filter((i) => i.length >= 3);
+                            .filter(i => i.length >= 3);
                     } else {
                         userInput = c.login.username.trim().toLowerCase().split(/[^A-Za-z0-9]/)
-                            .filter((i) => i.length >= 3);
+                            .filter(i => i.length >= 3);
                     }
                 }
                 const result = this.passwordGenerationService.passwordStrength(c.login.password,

--- a/src/app/vault/bulk-share.component.ts
+++ b/src/app/vault/bulk-share.component.ts
@@ -41,10 +41,10 @@ export class BulkShareComponent implements OnInit {
         private collectionService: CollectionService, private userService: UserService) { }
 
     async ngOnInit() {
-        this.shareableCiphers = this.ciphers.filter((c) => !c.hasOldAttachments && c.organizationId == null);
+        this.shareableCiphers = this.ciphers.filter(c => !c.hasOldAttachments && c.organizationId == null);
         this.nonShareableCount = this.ciphers.length - this.shareableCiphers.length;
         const allCollections = await this.collectionService.getAllDecrypted();
-        this.writeableCollections = allCollections.filter((c) => !c.readOnly);
+        this.writeableCollections = allCollections.filter(c => !c.readOnly);
         this.organizations = await this.userService.getAllOrganizations();
         if (this.organizationId == null && this.organizations.length > 0) {
             this.organizationId = this.organizations[0].id;
@@ -61,12 +61,12 @@ export class BulkShareComponent implements OnInit {
         if (this.organizationId == null || this.writeableCollections.length === 0) {
             this.collections = [];
         } else {
-            this.collections = this.writeableCollections.filter((c) => c.organizationId === this.organizationId);
+            this.collections = this.writeableCollections.filter(c => c.organizationId === this.organizationId);
         }
     }
 
     async submit() {
-        const checkedCollectionIds = this.collections.filter((c) => (c as any).checked).map((c) => c.id);
+        const checkedCollectionIds = this.collections.filter(c => (c as any).checked).map(c => c.id);
         try {
             this.formPromise = this.cipherService.shareManyWithServer(this.shareableCiphers, this.organizationId,
                 checkedCollectionIds);
@@ -83,7 +83,7 @@ export class BulkShareComponent implements OnInit {
 
     selectAll(select: boolean) {
         const collections = select ? this.collections : this.writeableCollections;
-        collections.forEach((c) => this.check(c, select));
+        collections.forEach(c => this.check(c, select));
     }
 
     get canSave() {

--- a/src/app/vault/ciphers.component.ts
+++ b/src/app/vault/ciphers.component.ts
@@ -163,11 +163,11 @@ export class CiphersComponent extends BaseCiphersComponent implements OnDestroy 
         if (this.ciphers == null) {
             return [];
         }
-        return this.ciphers.filter((c) => !!(c as any).checked);
+        return this.ciphers.filter(c => !!(c as any).checked);
     }
 
     getSelectedIds(): string[] {
-        return this.getSelected().map((c) => c.id);
+        return this.getSelected().map(c => c.id);
     }
 
     displayTotpCopyButton(cipher: CipherView) {

--- a/src/app/vault/collections.component.ts
+++ b/src/app/vault/collections.component.ts
@@ -31,6 +31,6 @@ export class CollectionsComponent extends BaseCollectionsComponent implements On
     }
 
     selectAll(select: boolean) {
-        this.collections.forEach((c) => this.check(c, select));
+        this.collections.forEach(c => this.check(c, select));
     }
 }

--- a/src/app/vault/share.component.ts
+++ b/src/app/vault/share.component.ts
@@ -34,6 +34,6 @@ export class ShareComponent extends BaseShareComponent implements OnDestroy {
 
     selectAll(select: boolean) {
         const collections = select ? this.collections : this.writeableCollections;
-        collections.forEach((c) => this.check(c, select));
+        collections.forEach(c => this.check(c, select));
     }
 }

--- a/src/app/vault/vault.component.ts
+++ b/src/app/vault/vault.component.ts
@@ -80,7 +80,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         this.showVerifyEmail = !(await this.tokenService.getEmailVerified());
         this.showBrowserOutdated = window.navigator.userAgent.indexOf('MSIE') !== -1;
 
-        const queryParamsSub = this.route.queryParams.subscribe(async (params) => {
+        const queryParamsSub = this.route.queryParams.subscribe(async params => {
             await this.syncService.fullSync(false);
 
             this.showUpdateKey = !(await this.cryptoService.hasEncKey());
@@ -158,7 +158,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     async filterFavorites() {
         this.ciphersComponent.showAddNew = true;
         this.groupingsComponent.searchPlaceholder = this.i18nService.t('searchFavorites');
-        await this.ciphersComponent.reload((c) => c.favorite);
+        await this.ciphersComponent.reload(c => c.favorite);
         this.clearFilters();
         this.favorites = true;
         this.go();
@@ -177,7 +177,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     async filterCipherType(type: CipherType) {
         this.ciphersComponent.showAddNew = true;
         this.groupingsComponent.searchPlaceholder = this.i18nService.t('searchType');
-        await this.ciphersComponent.reload((c) => c.type === type);
+        await this.ciphersComponent.reload(c => c.type === type);
         this.clearFilters();
         this.type = type;
         this.go();
@@ -187,7 +187,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         this.ciphersComponent.showAddNew = true;
         folderId = folderId === 'none' ? null : folderId;
         this.groupingsComponent.searchPlaceholder = this.i18nService.t('searchFolder');
-        await this.ciphersComponent.reload((c) => c.folderId === folderId);
+        await this.ciphersComponent.reload(c => c.folderId === folderId);
         this.clearFilters();
         this.folderId = folderId == null ? 'none' : folderId;
         this.go();
@@ -196,7 +196,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     async filterCollection(collectionId: string) {
         this.ciphersComponent.showAddNew = true;
         this.groupingsComponent.searchPlaceholder = this.i18nService.t('searchCollection');
-        await this.ciphersComponent.reload((c) => c.collectionIds != null &&
+        await this.ciphersComponent.reload(c => c.collectionIds != null &&
             c.collectionIds.indexOf(collectionId) > -1);
         this.clearFilters();
         this.collectionId = collectionId;
@@ -337,7 +337,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         component.type = this.type;
         component.folderId = this.folderId === 'none' ? null : this.folderId;
         if (this.collectionId != null) {
-            const collection = this.groupingsComponent.collections.filter((c) => c.id === this.collectionId);
+            const collection = this.groupingsComponent.collections.filter(c => c.id === this.collectionId);
             if (collection.length > 0) {
                 component.organizationId = collection[0].organizationId;
                 component.collectionIds = [this.collectionId];

--- a/src/connectors/duo.ts
+++ b/src/connectors/duo.ts
@@ -3,7 +3,7 @@
 // tslint:disable-next-line
 require('./duo.scss');
 
-document.addEventListener('DOMContentLoaded', (event) => {
+document.addEventListener('DOMContentLoaded', event => {
     const frameElement = document.createElement('iframe');
     frameElement.setAttribute('id', 'duo_iframe');
     setFrameHeight();

--- a/src/connectors/sso.ts
+++ b/src/connectors/sso.ts
@@ -1,7 +1,7 @@
 ﻿// tslint:disable-next-line
 require('./sso.scss');
 
-document.addEventListener('DOMContentLoaded', (event) => {
+document.addEventListener('DOMContentLoaded', event => {
     const code = getQsParam('code');
     const state = getQsParam('state');
 

--- a/tslint.json
+++ b/tslint.json
@@ -66,6 +66,10 @@
         "singleline": "never"
       }
     ],
-    "arrow-parens": false
+    "ordered-imports": true,
+    "arrow-parens": [
+      true,
+      "ban-single-arg-parens"
+    ]
   }
 }


### PR DESCRIPTION
# Overview

It turns out there was a bug in out npm linter script which allowed LOTS of lint violations through. This PR fixes that error.

It also attempts to standardize a lint ruleset across bitwarden typescript repositories. We'll likely need a little more work on this front, though.

# Files Changed
* **package.json**: single quotes around globs are resolved by shell rather than npm.
* **tslint.conf**: 
  * ordered imports is a big hassle for our review process (I'm sure you don't like having to do this manual @cscharf). This gets one step toward removing that burden. Eventually we will want to investigate the groups option and standardize how we group our imports as well.
  * do not allow parenthesis in arrow functions with single parameters otherwise parenthesis are required.

Other file changes are linter autofixes