### PR TITLE
Implement disable send policy

### DIFF
--- a/src/app/organizations/manage/policies.component.ts
+++ b/src/app/organizations/manage/policies.component.ts
@@ -102,6 +102,13 @@ export class PoliciesComponent implements OnInit {
                     enabled: false,
                     display: true,
                 },
+                {
+                    name: this.i18nService.t('disableSend'),
+                    description: this.i18nService.t('disableSendPolicyDesc'),
+                    type: PolicyType.DisableSend,
+                    enabled: false,
+                    display: true,
+                },
             ];
             await this.load();
 

--- a/src/app/organizations/manage/policy-edit.component.html
+++ b/src/app/organizations/manage/policy-edit.component.html
@@ -32,6 +32,9 @@
                 <app-callout type="warning" *ngIf="type === policyType.PersonalOwnership">
                     {{'personalOwnershipExemption' | i18n}}
                 </app-callout>
+                <app-callout type="warning" *ngIf="type === policyType.DisableSend">
+                    {{'disableSendExemption' | i18n}}
+                </app-callout>
                 <div class="form-group">
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="enabled" [(ngModel)]="enabled"

--- a/src/app/send/add-edit.component.html
+++ b/src/app/send/add-edit.component.html
@@ -9,6 +9,9 @@
                 </button>
             </div>
             <div class="modal-body" *ngIf="send">
+                <app-callout *ngIf="disableSend">
+                    <span>{{'sendDisabledWarning' | i18n}}</span>
+                </app-callout>
                 <div class="row" *ngIf="!editMode">
                     <div class="col-6 form-group">
                         <label for="type">{{'whatTypeOfSend' | i18n}}</label>
@@ -21,7 +24,7 @@
                 <div class="row">
                     <div class="col-6 form-group">
                         <label for="name">{{'name' | i18n}}</label>
-                        <input id="name" class="form-control" type="text" name="Name" [(ngModel)]="send.name" required>
+                        <input id="name" class="form-control" type="text" name="Name" [(ngModel)]="send.name" required [readOnly]="disableSend">
                     </div>
                 </div>
                 <!-- Text -->
@@ -29,12 +32,12 @@
                     <div class="form-group">
                         <label for="text">{{'sendTypeText' | i18n}}</label>
                         <textarea id="text" name="Text.Text" rows="6" [(ngModel)]="send.text.text"
-                            class="form-control"></textarea>
+                            class="form-control" [readOnly]="disableSend"></textarea>
                     </div>
                     <div class="form-group">
                         <div class="form-check">
                             <input class="form-check-input" type="checkbox" [(ngModel)]="send.text.hidden"
-                                id="text-hidden" name="Text.Hidden">
+                                id="text-hidden" name="Text.Hidden" [disabled]="disableSend">
                             <label class="form-check-label" for="text-hidden">{{'textHiddenByDefault' | i18n}}</label>
                         </div>
                     </div>
@@ -48,7 +51,7 @@
                         </div>
                         <div *ngIf="!editMode">
                             <label for="file">{{'file' | i18n}}</label>
-                            <input type="file" id="file" class="form-control-file" name="file" required>
+                            <input type="file" id="file" class="form-control-file" name="file" required [disabled]="disableSend">
                             <small class="form-text text-muted">{{'maxFileSize' | i18n}}</small>
                         </div>
                     </div>
@@ -64,11 +67,11 @@
                             </select>
                             <input id="deletionDateCustom" class="form-control mt-1" type="datetime-local"
                                 name="DeletionDate" [(ngModel)]="deletionDate" required *ngIf="deletionDateSelect === 0"
-                                placeholder="MM/DD/YYYY HH:MM AM/PM">
+                                placeholder="MM/DD/YYYY HH:MM AM/PM" [readOnly]="disableSend">
                         </div>
                         <div *ngIf="editMode">
                             <input id="deletionDate" class="form-control" type="datetime-local" name="DeletionDate"
-                                [(ngModel)]="deletionDate" required placeholder="MM/DD/YYYY HH:MM AM/PM">
+                                [(ngModel)]="deletionDate" required placeholder="MM/DD/YYYY HH:MM AM/PM" [readOnly]="disableSend">
                         </div>
                         <div class="form-text text-muted small">{{'deletionDateDesc' | i18n}}</div>
                     </div>
@@ -87,11 +90,11 @@
                             </select>
                             <input id="expirationDateCustom" class="form-control mt-1" type="datetime-local"
                                 name="ExpirationDate" [(ngModel)]="expirationDate" required
-                                *ngIf="expirationDateSelect === 0" placeholder="MM/DD/YYYY HH:MM AM/PM">
+                                *ngIf="expirationDateSelect === 0" placeholder="MM/DD/YYYY HH:MM AM/PM" [readOnly]="disableSend">
                         </div>
                         <div *ngIf="editMode">
                             <input id="expirationDate" class="form-control" type="datetime-local" name="ExpirationDate"
-                                [(ngModel)]="expirationDate" placeholder="MM/DD/YYYY HH:MM AM/PM">
+                                [(ngModel)]="expirationDate" placeholder="MM/DD/YYYY HH:MM AM/PM" [readOnly]="disableSend">
                         </div>
                         <div class="form-text text-muted small">{{'expirationDateDesc' | i18n}}</div>
                     </div>
@@ -100,7 +103,7 @@
                     <div class="col-6 form-group">
                         <label for="maxAccessCount">{{'maxAccessCount' | i18n}}</label>
                         <input id="maxAccessCount" class="form-control" type="number" name="MaxAccessCount"
-                            [(ngModel)]="send.maxAccessCount" min="1">
+                            [(ngModel)]="send.maxAccessCount" min="1" [readOnly]="disableSend">
                         <div class="form-text text-muted small">{{'maxAccessCountDesc' | i18n}}</div>
                     </div>
                     <div class="col-6 form-group" *ngIf="editMode">
@@ -114,19 +117,20 @@
                         <label for="password" *ngIf="!hasPassword">{{'password' | i18n}}</label>
                         <label for="password" *ngIf="hasPassword">{{'newPassword' | i18n}}</label>
                         <input id="password" class="form-control" type="password" name="Password"
-                            [(ngModel)]="password">
+                            [(ngModel)]="password" [readOnly]="disableSend">
                         <div class="form-text text-muted small">{{'sendPasswordDesc' | i18n}}</div>
                     </div>
                 </div>
                 <div class="form-group">
                     <label for="notes">{{'notes' | i18n}}</label>
-                    <textarea id="notes" name="Notes" rows="6" [(ngModel)]="send.notes" class="form-control"></textarea>
+                    <textarea id="notes" name="Notes" rows="6" [(ngModel)]="send.notes" class="form-control"
+                        [readOnly]="disableSend"></textarea>
                     <div class="form-text text-muted small">{{'sendNotesDesc' | i18n}}</div>
                 </div>
                 <div class="form-group">
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" [(ngModel)]="send.disabled" id="disabled"
-                            name="Disabled">
+                            name="Disabled" [disabled]="disableSend">
                         <label class="form-check-label" for="disabled">{{'disableThisSend' | i18n}}</label>
                     </div>
                 </div>
@@ -137,7 +141,10 @@
                 </div>
             </div>
             <div class="modal-footer">
-                <button type="submit" class="btn btn-primary btn-submit" [disabled]="form.loading">
+                <button class="btn btn-primary disabled" disabled=true *ngIf="disableSend">
+                    <span>{{'save' | i18n}}</span>
+                </button>
+                <button type="submit" class="btn btn-primary btn-submit" [disabled]="form.loading" *ngIf="!disableSend">
                     <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
                     <span>{{'save' | i18n}}</span>
                 </button>

--- a/src/app/send/add-edit.component.ts
+++ b/src/app/send/add-edit.component.ts
@@ -6,6 +6,7 @@ import { EnvironmentService } from 'jslib/abstractions/environment.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
 import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { PolicyService } from 'jslib/abstractions/policy.service';
 import { SendService } from 'jslib/abstractions/send.service';
 import { UserService } from 'jslib/abstractions/user.service';
 
@@ -19,7 +20,8 @@ export class AddEditComponent extends BaseAddEditComponent {
     constructor(i18nService: I18nService, platformUtilsService: PlatformUtilsService,
         environmentService: EnvironmentService, datePipe: DatePipe,
         sendService: SendService, userService: UserService,
-        messagingService: MessagingService) {
-        super(i18nService, platformUtilsService, environmentService, datePipe, sendService, userService, messagingService);
+        messagingService: MessagingService, policyService: PolicyService) {
+        super(i18nService, platformUtilsService, environmentService, datePipe, sendService, userService,
+            messagingService, policyService);
     }
 }

--- a/src/app/send/send.component.html
+++ b/src/app/send/send.component.html
@@ -1,4 +1,12 @@
 <div class="container page-content">
+    <div class="row card border-warning mb-4" *ngIf="disableSend">
+        <div class="card-header bg-warning text-white">
+            <i class="fa fa-warning fa-fw" aria-hidden="true"></i> {{'sendDisabled' | i18n}}
+        </div>
+        <div class="card-body">
+            <span>{{'sendDisabledWarning' | i18n}}</span>
+        </div>
+    </div>
     <div class="row">
         <div class="col-3 groupings">
             <div class="card vault-filters">
@@ -45,7 +53,7 @@
                     </small>
                 </h1>
                 <div class="ml-auto d-flex">
-                    <button type="button" class="btn btn-outline-primary btn-sm" (click)="addSend()">
+                    <button type="button" class="btn btn-outline-primary btn-sm" (click)="addSend()" [disabled]="disableSend">
                         <i class="fa fa-plus fa-fw" aria-hidden="true"></i>{{'createSend' | i18n}}
                     </button>
                 </div>

--- a/src/app/send/send.component.ts
+++ b/src/app/send/send.component.ts
@@ -33,7 +33,8 @@ export class SendComponent extends BaseSendComponent {
 
     constructor(sendService: SendService, i18nService: I18nService,
         platformUtilsService: PlatformUtilsService, environmentService: EnvironmentService,
-        broadcasterService: BroadcasterService, ngZone: NgZone, searchService: SearchService, policyService: PolicyService, userService: UserService,
+        broadcasterService: BroadcasterService, ngZone: NgZone, searchService: SearchService,
+        policyService: PolicyService, userService: UserService,
         private componentFactoryResolver: ComponentFactoryResolver) {
         super(sendService, i18nService, platformUtilsService, environmentService, broadcasterService, ngZone,
             searchService, policyService, userService);

--- a/src/app/send/send.component.ts
+++ b/src/app/send/send.component.ts
@@ -19,6 +19,8 @@ import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 import { SendService } from 'jslib/abstractions/send.service';
 
 import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
+import { PolicyService } from 'jslib/abstractions/policy.service';
+import { SearchService, UserService } from 'jslib/abstractions';
 
 @Component({
     selector: 'app-send',
@@ -31,12 +33,17 @@ export class SendComponent extends BaseSendComponent {
 
     constructor(sendService: SendService, i18nService: I18nService,
         platformUtilsService: PlatformUtilsService, environmentService: EnvironmentService,
-        broadcasterService: BroadcasterService, ngZone: NgZone,
+        broadcasterService: BroadcasterService, ngZone: NgZone, searchService: SearchService, policyService: PolicyService, userService: UserService,
         private componentFactoryResolver: ComponentFactoryResolver) {
-        super(sendService, i18nService, platformUtilsService, environmentService, broadcasterService, ngZone);
+        super(sendService, i18nService, platformUtilsService, environmentService, broadcasterService, ngZone,
+            searchService, policyService, userService);
     }
 
     addSend() {
+        if (this.disableSend) {
+            return;
+        }
+
         const component = this.editSend(null);
         component.type = this.type;
     }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3560,7 +3560,7 @@
     "message": "Organization Owners and Administrators are exempt from this policy's enforcement."
   },
   "personalOwnershipSubmitError": {
-    "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership option to an organization and choose from available Collections."
+    "message": "Due to an enterprise policy, you are restricted from saving items to your personal vault. Change the Ownership option to an organization and choose from available Collections."
   },
   "disableSend": {
     "message": "Disable Send"
@@ -3577,7 +3577,7 @@
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
   "sendDisabledWarning": {
-    "message": "Due to an Enterprise Policy, you are only able to delete an existing Send.",
+    "message": "Due to an enterprise policy, you are only able to delete an existing Send.",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
   "modifiedPolicyId": {

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3566,16 +3566,19 @@
     "message": "Disable Send"
   },
   "disableSendPolicyDesc": {
-    "message": "Do not allow users to create or edit Bitwarden Sends. Deleting existing Sends is still allowed."
+    "message": "Do not allow users to create or edit a Bitwarden Send. Deleting an existing Send is still allowed.",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
   "disableSendExemption": {
     "message": "Organization users that can manage the organization's policies are exempt from this policy's enforcement."
   },
   "sendDisabled": {
-    "message": "Send disabled"
+    "message": "Send disabled",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
   "sendDisabledWarning": {
-    "message": "Due to an Enterprise Policy, you are restricted to only Deleting Sends."
+    "message": "Due to an Enterprise Policy, you are only able to delete an existing Send.",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
   "modifiedPolicyId": {
     "message": "Modified policy $ID$.",

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3562,6 +3562,21 @@
   "personalOwnershipSubmitError": {
     "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership option to an organization and choose from available Collections."
   },
+  "disableSend": {
+    "message": "Disable Send"
+  },
+  "disableSendPolicyDesc": {
+    "message": "Do not allow users to create or edit Bitwarden Sends. Deleting existing Sends is still allowed."
+  },
+  "disableSendExemption": {
+    "message": "Organization users that can manage the organization's policies are exempt from this policy's enforcement."
+  },
+  "sendDisabled": {
+    "message": "Send disabled"
+  },
+  "sendDisabledWarning": {
+    "message": "Due to an Enterprise Policy, you are restricted to only Deleting Sends."
+  },
   "modifiedPolicyId": {
     "message": "Modified policy $ID$.",
     "placeholders": {


### PR DESCRIPTION
# Overview

Depends on bitwarden/jslib#259

Implements web policy editor enabling of `DisableSend` policy. This policy disallows users of an organization from creating or editing Bitwarden Sends. Delete is still allowed.

# Files Changed

* **policies.component/policy-edit.component**: add DisableSend policy to the list of policies
* **send/add-edit.component**:  make all inputs either disabled or readonly (prefer readonly) if disable send policy is in effect. Also display an app-callout at the top of the modal and disable the save button. This had to be done with a second button due to the loading effect on the first being tied to the button's disabled state.
* **Send.component**: Add banner warning about sends being disabled. Disable the create button
* **messages.json**: messages relating to disable send policy

# Testing Concerns

Need to validate the disable logic from bitwarden/jslib#259. Send should be disabled when:
  * **Any** organization a user belongs to disables them
  * unless that user can manage policies by being
     1. Admin
     2. Owner
     3. custom with manage policy permission

Ensure polish of experience that disabled reason is not vague nor are you ever mistakenly thinking you're work can be saved.

# Screenshots

![image](https://user-images.githubusercontent.com/18214891/106930794-8dee2e80-66db-11eb-9e91-a8e3f28cf4a4.png)

### Text send
![image](https://user-images.githubusercontent.com/18214891/106931088-d73e7e00-66db-11eb-96dd-9e2ca16636ef.png)
![image](https://user-images.githubusercontent.com/18214891/106931136-defe2280-66db-11eb-901e-1c6ab36bd005.png)

### File send
![image](https://user-images.githubusercontent.com/18214891/106931244-fb01c400-66db-11eb-9ccc-c8bfc3c2cef4.png)
