### PR TITLE
Add show hide password to send

### DIFF
--- a/src/app/send/add-edit.component.html
+++ b/src/app/send/add-edit.component.html
@@ -116,8 +116,17 @@
                     <div class="col-6 form-group">
                         <label for="password" *ngIf="!hasPassword">{{'password' | i18n}}</label>
                         <label for="password" *ngIf="hasPassword">{{'newPassword' | i18n}}</label>
-                        <input id="password" class="form-control" type="password" name="Password"
-                            [(ngModel)]="password" [readOnly]="disableSend">
+                        <div class="input-group">
+                            <input id="password" class="form-control text-monospace" type="{{showPassword ? 'text' : 'password'}}"
+                                name="Password" [(ngModel)]="password" [readOnly]="disableSend">
+                            <div class="input-group-append">
+                                <button type="button" class="btn btn-outline-secondary" appA11yTitle="{{'toggleVisibility' | i18n}}"
+                                    (click)="togglePasswordVisible()">
+                                    <i class="fa fa-lg" aria-hidden="true"
+                                        [ngClass]="{'fa-eye': !showPassword, 'fa-eye-slash': showPassword}"></i>
+                                </button>
+                            </div>
+                        </div>
                         <div class="form-text text-muted small">{{'sendPasswordDesc' | i18n}}</div>
                     </div>
                 </div>

--- a/src/app/send/send.component.html
+++ b/src/app/send/send.component.html
@@ -107,7 +107,7 @@
                                         {{'copySendLink' | i18n}}
                                     </a>
                                     <a class="dropdown-item" href="#" appStopClick (click)="removePassword(s)"
-                                        *ngIf="s.password">
+                                        *ngIf="s.password && !disableSend">
                                         <i class="fa fa-fw fa-undo" aria-hidden="true"></i>
                                         {{'removePassword' | i18n}}
                                     </a>


### PR DESCRIPTION
# Overview

Add toggle password visibility to Send add-edit component.

This also fixes an oversight to DisableSend policy where disabled send environments still shows remove password link.

# Files Changed

* **add-edit.component.html**: add input-group for password and visibility toggle. wire it up to jslib toggler changes. Password formatting changes match existing Login cipher password element
* **send.component.html**: Do not show remove password link if DisableSend is in effect.

# Testing concerns

* can show/hide password for both new and existing sends for both has and does not have passwords.
  * note, we don't know the password (it's used for authentication) so the old password is not visible in edit mode
* The remove password link does not show up if send is disabled by a policy the user belongs to.

# Screenshots


### enabled
![image](https://user-images.githubusercontent.com/18214891/107070162-92344d80-67a8-11eb-879a-d247fb724a85.png)
![image](https://user-images.githubusercontent.com/18214891/107070180-98c2c500-67a8-11eb-9410-7ae16ca76be4.png)


### disabled and with password
![image](https://user-images.githubusercontent.com/18214891/107070114-7c268d00-67a8-11eb-9523-fbabb1fb4d15.png)
![image](https://user-images.githubusercontent.com/18214891/107070229-aa0bd180-67a8-11eb-8db5-5cc74149bfff.png)