### PR TITLE
Add warning when importing data to organization

### DIFF
--- a/src/app/organizations/tools/import.component.ts
+++ b/src/app/organizations/tools/import.component.ts
@@ -9,6 +9,8 @@ import { Angulartics2 } from 'angulartics2';
 
 import { I18nService } from 'jslib/abstractions/i18n.service';
 import { ImportService } from 'jslib/abstractions/import.service';
+import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { UserService } from 'jslib/abstractions/user.service';
 
 import { ImportComponent as BaseImportComponent } from '../../tools/import.component';
 
@@ -17,17 +19,33 @@ import { ImportComponent as BaseImportComponent } from '../../tools/import.compo
     templateUrl: '../../tools/import.component.html',
 })
 export class ImportComponent extends BaseImportComponent {
+    organizationName: string;
+
     constructor(i18nService: I18nService, analytics: Angulartics2,
         toasterService: ToasterService, importService: ImportService,
-        router: Router, private route: ActivatedRoute) {
+        router: Router, private route: ActivatedRoute,
+        private platformUtilsService: PlatformUtilsService,
+        private userService: UserService) {
         super(i18nService, analytics, toasterService, importService, router);
     }
 
-    ngOnInit() {
+    async ngOnInit() {
         this.route.parent.parent.params.subscribe(async params => {
             this.organizationId = params.organizationId;
             this.successNavigate = ['organizations', this.organizationId, 'vault'];
             super.ngOnInit();
         });
+        const organization = await this.userService.getOrganization(this.organizationId);
+        this.organizationName = organization.name;
+    }
+
+    async submit() {
+        const confirmed = await this.platformUtilsService.showDialog(
+            this.i18nService.t('importWarning', this.organizationName),
+            this.i18nService.t('warning'), this.i18nService.t('yes'), this.i18nService.t('no'), 'warning');
+        if (!confirmed) {
+            return;
+        }
+        super.submit();
     }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1003,6 +1003,15 @@
   "importSuccess": {
     "message": "Data has been successfully imported into your vault."
   },
+  "importWarning": {
+    "message": "You are importing data to $ORGANIZATION$. Your data may be shared with members of this organization. Do you want to proceed?",
+    "placeholders": {
+      "organization": {
+        "content": "$1",
+        "example": "My Org Name"
+      }
+    }
+  },
   "importFormatError": {
     "message": "Data is not formatted correctly. Please check your import file and try again."
   },


### PR DESCRIPTION
## Objective
Fix #824:
> Organization import is not visually distinct from personal import and it easy to accidentally import personal items into an organization.

## Code changes

Add a confirmation dialog when importing data to an organization.

## Screenshots

![Screen Shot 2021-02-11 at 4 11 13 pm](https://user-images.githubusercontent.com/31796059/107607488-1b55f380-6c85-11eb-87f8-6fc4eb6a33ef.png)