### PR TITLE
Fix emergency access grantee name

### DIFF
--- a/src/app/settings/emergency-access.component.ts
+++ b/src/app/settings/emergency-access.component.ts
@@ -197,7 +197,7 @@ export class EmergencyAccessComponent implements OnInit {
         const type = this.i18nService.t(details.type === EmergencyAccessType.View ? 'view' : 'takeover');
 
         const confirmed = await this.platformUtilsService.showDialog(
-            this.i18nService.t('approveAccessConfirmation', details.name, type),
+            this.i18nService.t('approveAccessConfirmation', details.name || details.email, type),
             details.name || details.email,
             this.i18nService.t('approve'),
             this.i18nService.t('no'),


### PR DESCRIPTION
## Objective
Fix #828: 
> Attempting to approve an Emergency Access request from a Bitwarden account that has nothing set in their Name field will show __$1__ as the name.

## Code changes
Evaluate `details.name || details.email` instead of just `details.name`. This is done everywhere else in this component but looks like it was just missed in this case.