### PR TITLE
Updated PL translation

### DIFF
--- a/src/locales/pl/messages.json
+++ b/src/locales/pl/messages.json
@@ -1864,7 +1864,7 @@
     "message": "To konto jest własnością firmy."
   },
   "billingEmail": {
-    "message": "Adres rozliczeniowy"
+    "message": "Adres email do rozliczeń"
   },
   "businessName": {
     "message": "Nazwa firmy"


### PR DESCRIPTION
"Adres rozliczeniowy" is misleading, because it usually means an official company address used by the accounting. In this field we expect an email address, so let's emphasize it.