### PR TITLE
Improve import error messages

### DIFF
--- a/src/app/organizations/tools/import.component.ts
+++ b/src/app/organizations/tools/import.component.ts
@@ -24,9 +24,9 @@ export class ImportComponent extends BaseImportComponent {
     constructor(i18nService: I18nService, analytics: Angulartics2,
         toasterService: ToasterService, importService: ImportService,
         router: Router, private route: ActivatedRoute,
-        private platformUtilsService: PlatformUtilsService,
+        platformUtilsService: PlatformUtilsService,
         private userService: UserService) {
-        super(i18nService, analytics, toasterService, importService, router);
+        super(i18nService, analytics, toasterService, importService, router, platformUtilsService);
     }
 
     async ngOnInit() {

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -128,7 +128,8 @@ const authService = new AuthService(cryptoService, apiService,
     userService, tokenService, appIdService, i18nService, platformUtilsService, messagingService, vaultTimeoutService,
     consoleLogService);
 const exportService = new ExportService(folderService, cipherService, apiService);
-const importService = new ImportService(cipherService, folderService, apiService, i18nService, collectionService);
+const importService = new ImportService(cipherService, folderService, apiService, i18nService, collectionService,
+    platformUtilsService);
 const notificationsService = new NotificationsService(userService, syncService, appIdService,
     apiService, vaultTimeoutService, async () => messagingService.send('logout', { expired: true }), consoleLogService);
 const environmentService = new EnvironmentService(apiService, storageService, notificationsService);

--- a/src/app/tools/import.component.html
+++ b/src/app/tools/import.component.html
@@ -248,7 +248,7 @@
         <label for="fileContents">{{'orCopyPasteFileContents' | i18n}}</label>
         <textarea id="fileContents" class="form-control" name="FileContents" [(ngModel)]="fileContents"></textarea>
     </div>
-    <button type="submit" class="btn btn-primary btn-submit" [disabled]="form.loading">
+    <button type="submit" class="btn btn-primary btn-submit" [disabled]="loading">
         <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
         <span>{{'importData' | i18n}}</span>
     </button>

--- a/src/app/tools/import.component.html
+++ b/src/app/tools/import.component.html
@@ -1,7 +1,7 @@
 <div class="page-header">
     <h1>{{'importData' | i18n}}</h1>
 </div>
-<form #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate>
+<form #form (ngSubmit)="submit()" ngNativeValidate>
     <div class="row">
         <div class="col-6">
             <div class="form-group">

--- a/src/app/tools/import.component.ts
+++ b/src/app/tools/import.component.ts
@@ -146,8 +146,8 @@ export class ImportComponent implements OnInit {
             text: this.i18nService.t('importErrorDesc'),
             showConfirmButton: true,
             confirmButtonText: this.i18nService.t('ok'),
-            onOpen: (popupEl) => { 
-                popupEl.querySelector(".swal2-textarea").scrollTo(0, 0);
+            onOpen: popupEl => {
+                popupEl.querySelector('.swal2-textarea').scrollTo(0, 0);
              },
         });
     }

--- a/src/app/tools/import.component.ts
+++ b/src/app/tools/import.component.ts
@@ -23,6 +23,7 @@ export class ImportComponent implements OnInit {
     format: string = null;
     fileContents: string;
     formPromise: Promise<Error>;
+    loading: boolean = false;
 
     protected organizationId: string = null;
     protected successNavigate: any[] = ['vault'];
@@ -50,10 +51,13 @@ export class ImportComponent implements OnInit {
     }
 
     async submit() {
+        this.loading = true;
+
         const importer = this.importService.getImporter(this.format, this.organizationId);
         if (importer === null) {
             this.toasterService.popAsync('error', this.i18nService.t('errorOccurred'),
                 this.i18nService.t('selectFormat'));
+            this.loading = false;
             return;
         }
 
@@ -62,6 +66,7 @@ export class ImportComponent implements OnInit {
         if ((files == null || files.length === 0) && (this.fileContents == null || this.fileContents === '')) {
             this.toasterService.popAsync('error', this.i18nService.t('errorOccurred'),
                 this.i18nService.t('selectFile'));
+            this.loading = false;
             return;
         }
 
@@ -78,6 +83,7 @@ export class ImportComponent implements OnInit {
         if (fileContents == null || fileContents === '') {
             this.toasterService.popAsync('error', this.i18nService.t('errorOccurred'),
                 this.i18nService.t('selectFile'));
+            this.loading = false;
             return;
         }
 
@@ -86,6 +92,7 @@ export class ImportComponent implements OnInit {
             const error = await this.formPromise;
             if (error != null) {
                 this.error(error);
+                this.loading = false;
                 return;
             }
             this.analytics.eventTrack.next({
@@ -95,6 +102,8 @@ export class ImportComponent implements OnInit {
             this.toasterService.popAsync('success', null, this.i18nService.t('importSuccess'));
             this.router.navigate(this.successNavigate);
         } catch { }
+
+        this.loading = false;
     }
 
     getFormatInstructionTitle() {

--- a/src/app/tools/import.component.ts
+++ b/src/app/tools/import.component.ts
@@ -9,6 +9,9 @@ import { Angulartics2 } from 'angulartics2';
 
 import { I18nService } from 'jslib/abstractions/i18n.service';
 import { ImportOption, ImportService } from 'jslib/abstractions/import.service';
+import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+
+import Swal, { SweetAlertIcon } from 'sweetalert2/dist/sweetalert2.js';
 
 @Component({
     selector: 'app-import',
@@ -26,7 +29,7 @@ export class ImportComponent implements OnInit {
 
     constructor(protected i18nService: I18nService, protected analytics: Angulartics2,
         protected toasterService: ToasterService, protected importService: ImportService,
-        protected router: Router) { }
+        protected router: Router, protected platformUtilsService: PlatformUtilsService) { }
 
     ngOnInit() {
         this.setImportOptions();
@@ -114,12 +117,26 @@ export class ImportComponent implements OnInit {
         this.importOptions = this.importService.regularImportOptions;
     }
 
-    private error(error: Error) {
+    private async error(error: Error) {
         this.analytics.eventTrack.next({
             action: 'Import Data Failed',
             properties: { label: this.format },
         });
-        this.toasterService.popAsync('error', this.i18nService.t('errorOccurred'), error.message);
+
+        await Swal.fire({
+            heightAuto: false,
+            buttonsStyling: false,
+            icon: 'fa-bolt text-danger' as SweetAlertIcon,
+            input: 'textarea',
+            inputValue: error.message,
+            inputAttributes: {
+                'readonly': 'true',
+            },
+            title: this.i18nService.t('importError'),
+            text: this.i18nService.t('importErrorDesc'),
+            showConfirmButton: true,
+            confirmButtonText: this.i18nService.t('ok'),
+        });
     }
 
     private getFileContents(file: File): Promise<string> {

--- a/src/app/tools/import.component.ts
+++ b/src/app/tools/import.component.ts
@@ -126,7 +126,8 @@ export class ImportComponent implements OnInit {
         await Swal.fire({
             heightAuto: false,
             buttonsStyling: false,
-            icon: 'fa-bolt text-danger' as SweetAlertIcon,
+            icon: 'error' as SweetAlertIcon,
+            iconHtml: `<i class="swal-custom-icon fa fa-bolt text-danger"></i>`,
             input: 'textarea',
             inputValue: error.message,
             inputAttributes: {
@@ -136,6 +137,9 @@ export class ImportComponent implements OnInit {
             text: this.i18nService.t('importErrorDesc'),
             showConfirmButton: true,
             confirmButtonText: this.i18nService.t('ok'),
+            onOpen: (popupEl) => { 
+                popupEl.querySelector(".swal2-textarea").scrollTo(0, 0);
+             },
         });
     }
 

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1004,7 +1004,7 @@
     "message": "Import Error"
   },
   "importErrorDesc": {
-    "message": "There was a problem with the data you tried to import. You can fix the errors below, or contact us if you need help."
+    "message": "There was a problem with the data you tried to import. Please resolve the errors listed below in your source file and try again."
   },
   "importSuccess": {
     "message": "Data has been successfully imported into your vault."

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1000,6 +1000,12 @@
   "importData": {
     "message": "Import Data"
   },
+  "importError": {
+    "message": "Import Error"
+  },
+  "importErrorDesc": {
+    "message": "There was a problem with the data you tried to import. You can fix the errors below, or contact us if you need help."
+  },
   "importSuccess": {
     "message": "Data has been successfully imported into your vault."
   },


### PR DESCRIPTION
## Objective

Improve import error messages so that users can identify problem items easier.

Errors are currently shown in the format below. 

![Screen Shot 2021-02-22 at 6 09 28 pm](https://user-images.githubusercontent.com/31796059/108680066-1f153000-7539-11eb-88a3-313772c9be4b.png)

We say that this index number refers to the index of the CSV. It actually refers to the index of the item in the `importResult.ciphers[]`, `importResult.folders[]` or `importResult.collections[]` arrays (as applicable). For ciphers this will mostly correspond to the CSV index number, with some adjustments, but not always.

## Solution

One suggestion was to provide the line number in the import file. However, I think it's better to show some actual item details so that users don't have to dig through the import file to identify it. (This is also easier than trying to match the item object with the unparsed import file.)

A user also requested that the error is more "permanent" so that it can be copy/pasted to assist with troubleshooting. This will also avoid excessively long toast messages.

The improved error format is below. It shows the index number, type of item, item name, and error message.

![Screen Shot 2021-02-22 at 6 14 22 pm](https://user-images.githubusercontent.com/31796059/108680624-d3af5180-7539-11eb-8d3c-6fc58b01126b.png)

Note: We discussed automatically converting overlong notes to attachments, but that is out of scope for this PR. I wanted to have a generic method for handling server-side model validation errors first. This PR should handle validation errors for all fields on ciphers, folders and collections, not just notes.

## Code changes

* disable default error handling by `appApiAction`
* change toast message to a modal (this might benefit from some tweaking to make the `textarea` bigger)

This requires the following PR for `jslib`: https://github.com/bitwarden/jslib/pull/280