### PR TITLE
Use v2 of 2fa.directory API

### DIFF
--- a/src/app/tools/inactive-two-factor-report.component.ts
+++ b/src/app/tools/inactive-two-factor-report.component.ts
@@ -77,7 +77,7 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
         if (this.services.size > 0) {
             return;
         }
-        const response = await fetch(new Request('https://2fa.directory/api/v1/data.json'));
+        const response = await fetch(new Request('https://2fa.directory/api/v2/totp.json'));
         if (response.status !== 200) {
             throw new Error();
         }
@@ -88,7 +88,7 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
                 for (const serviceName in category) {
                     if (category.hasOwnProperty(serviceName)) {
                         const service = category[serviceName];
-                        if (service.tfa && service.software && service.url != null) {
+                        if (service.url != null) {
                             const hostname = Utils.getHostname(service.url);
                             if (hostname != null) {
                                 this.services.set(hostname, service.doc);


### PR DESCRIPTION
Version 1 of 2fa.directory API is [deprecated](https://github.com/2factorauth/twofactorauth/blob/master/API.md#version-1-deprecated-warning).

[Version 2](https://github.com/2factorauth/twofactorauth/blob/master/API.md#version-2) provides an endpoint which only returns services with TOTP.

The result should be much more accurate because the result only contains services that provide TOTP (and not only software 2FA).