### PR TITLE
[Send] Updated current access input type to text

### DIFF
--- a/src/app/send/add-edit.component.html
+++ b/src/app/send/add-edit.component.html
@@ -143,7 +143,7 @@
                         </div>
                         <div class="col-6 form-group" *ngIf="editMode">
                             <label for="accessCount">{{'currentAccessCount' | i18n}}</label>
-                            <input id="accessCount" class="form-control" type="number" name="AccessCount" readonly
+                            <input id="accessCount" class="form-control" type="text" name="AccessCount" readonly
                                 [(ngModel)]="send.accessCount">
                         </div>
                     </div>


### PR DESCRIPTION
## Objective
> `Current Access Count` input field gives the impression that the value (at some point) could be changed on Firefox and Safari because the action bars are not hidden when `readonly`. 

## Code Changes
- **send/add-edit.component.html**: Changed `accessCount` input type from `number` to `text`

## Screenshots
![0-firefox-readonly](https://user-images.githubusercontent.com/26154748/109513545-d5fa3a00-7a6a-11eb-85cf-3688d0540b2a.png)
