### PR TITLE
changed send access creator identifier string

### DIFF
--- a/src/app/send/access.component.html
+++ b/src/app/send/access.component.html
@@ -4,7 +4,7 @@
             <p class="lead text-center mb-4">Bitwarden Send</p>
         </div>
         <div class="col-12 text-center">
-            <p>A Bitwarden user {{creatorIdentifier}} shared the following with you.</p>
+            <p>{{'sendCreatorIdentifier' | i18n: creatorIdentifier }}</p>
         </div>
         <div class="col-5">
             <div class="card d-block">

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3712,5 +3712,14 @@
   "sendAccessTaglineTryToday": {
     "message": "to try it today.",
     "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Learn more about Bitwarden Send or sign up to **try it today.**'"
+  },
+  "sendCreatorIdentifier": {
+    "message": "Bitwarden user $USER_IDENTIFIER$ shared the following with you",
+    "placeholders": {
+      "user_identifier": {
+        "content": "$1",
+        "example": "An email address"
+      }
+    }
   }
 }


### PR DESCRIPTION
Clayton asked (& marketing agreed) to remove the 'A' from a Send's creator identifier blurb. 
I also moved that string to messages.json (whoops)