### PR TITLE
[Send] Hide identifier if unavailable

### DIFF
--- a/src/app/send/access.component.html
+++ b/src/app/send/access.component.html
@@ -3,7 +3,7 @@
         <div class="col-12">
             <p class="lead text-center mb-4">Bitwarden Send</p>
         </div>
-        <div class="col-12 text-center">
+        <div class="col-12 text-center" *ngIf="creatorIdentifier != null">
             <p>{{'sendCreatorIdentifier' | i18n: creatorIdentifier }}</p>
         </div>
         <div class="col-5">
@@ -63,15 +63,19 @@
                             <i class="fa fa-download" aria-hidden="true"></i>
                             {{'downloadFile' | i18n}} ({{send.file.sizeName}})</button>
                     </ng-container>
-                    <p *ngIf="expirationDate" class="text-center text-muted">Expires: {{expirationDate | date: 'medium'}}</p>
+                    <p *ngIf="expirationDate" class="text-center text-muted">Expires:
+                        {{expirationDate | date: 'medium'}}</p>
                 </div>
             </div>
         </div>
         <div class="col-12 text-center mt-5 text-muted">
             <p class="mb-0">{{'sendAccessTaglineProductDesc' | i18n}}<br>
-            {{'sendAccessTaglineLearnMore' | i18n}} <a href="https://www.bitwarden.com/products/send?source=web-vault">Bitwarden Send</a> {{'sendAccessTaglineOr' | i18n}} <a href="https://vault.bitwarden.com/#/register">{{'sendAccessTaglineSignUp' | i18n}}</a> {{'sendAccessTaglineTryToday' | i18n}}
+                {{'sendAccessTaglineLearnMore' | i18n}} <a
+                    href="https://www.bitwarden.com/products/send?source=web-vault">Bitwarden Send</a>
+                {{'sendAccessTaglineOr' | i18n}} <a
+                    href="https://vault.bitwarden.com/#/register">{{'sendAccessTaglineSignUp' | i18n}}</a>
+                {{'sendAccessTaglineTryToday' | i18n}}
             </p>
         </div>
     </div>
 </form>
-


### PR DESCRIPTION
## Objective
> Fix bug where formatted string didn't have necessary data by hiding the `div` when the `creatorIdentifier` is unavailable (send has expired, been disabled, password gated, deleted, etc)

## Code Changes
- **access.component.html**: Hide header div when `creatorIdentifier` is `null`

## Screenshot
![0-error](https://user-images.githubusercontent.com/26154748/109841584-ce739600-7c0e-11eb-8bc0-a6cb85f9eced.png)
![1-fixed](https://user-images.githubusercontent.com/26154748/109841588-cf0c2c80-7c0e-11eb-985e-bbe4c7e602c6.png)
