### PR TITLE
Expand encrypted export warning

### DIFF
--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -799,8 +799,11 @@
   "exportWarningDesc": {
     "message": "This export contains your vault data in an unencrypted format. You should not store or send the exported file over unsecure channels (such as email). Delete it immediately after you are done using it."
   },
-  "encExportWarningDesc": {
+  "encExportKeyWarningDesc": {
     "message": "This export encrypts your data using your account's encryption key. If you ever rotate your account's encryption key you should export again since you will not be able to decrypt this export file."
+  },
+  "encExportAccountWarningDesc": {
+    "message": "Account encryption keys are unique to each Bitwarden user account, so you can't import an encrypted export into a different account."
   },
   "exportMasterPassword": {
     "message": "Enter your master password to export your vault data."

--- a/src/services/webPlatformUtils.service.ts
+++ b/src/services/webPlatformUtils.service.ts
@@ -179,7 +179,8 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
         });
     }
 
-    async showDialog(text: string, title?: string, confirmText?: string, cancelText?: string, type?: string) {
+    async showDialog(body: string, title?: string, confirmText?: string, cancelText?: string, type?: string,
+        bodyIsHtml: boolean = false) {
         let iconClasses: string = null;
         if (type != null) {
             // If you add custom types to this part, the type to SweetAlertIcon cast below needs to be changed.
@@ -207,7 +208,8 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
             buttonsStyling: false,
             icon: type as SweetAlertIcon, // required to be any of the SweetAlertIcons to output the iconHtml.
             iconHtml: iconHtmlStr,
-            text: text,
+            text: bodyIsHtml ? null : body,
+            html: bodyIsHtml ? body : null,
             title: title,
             showCancelButton: (cancelText != null),
             cancelButtonText: cancelText,


### PR DESCRIPTION
## Objective
Add more information to the encrypted export warning, so that users know they can't import it into a different account.

This reflects our warning in the [help documentation](https://bitwarden.com/help/article/encrypted-export/).

## Code changes
Aside from the obvious changes in `messages.json`, I also tweaked our `platformUtils` `showDialog` method so that we have the option of using html markup in our modals. (required so that the warning wouldn't be a single blob of text)

Required changes in jslib: https://github.com/bitwarden/jslib/pull/294