### PR TITLE
Prevent extra clicking of emergency access save button

### DIFF
--- a/src/app/settings/emergency-access-add-edit.component.html
+++ b/src/app/settings/emergency-access-add-edit.component.html
@@ -55,9 +55,11 @@
                 </div>
             </div>
             <div class="modal-footer">
-                <button type="submit" class="btn btn-primary" [disabled]="loading || readOnly">
-                    <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true" *ngIf="loading"></i>
-                    <span *ngIf="!loading">{{'save' | i18n}}</span>
+                <button #submitBtn type="submit" class="btn btn-primary" 
+                    [disabled]="loading || submitBtn.loading || readOnly" [appApiAction]="formPromise">
+                    <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true" 
+                        *ngIf="loading || submitBtn.loading"></i>
+                    <span *ngIf="!loading && !submitBtn.loading">{{'save' | i18n}}</span>
                 </button>
                 <button type="button" class="btn btn-outline-secondary"
                     data-dismiss="modal">{{'cancel' | i18n}}</button>


### PR DESCRIPTION
## Objective
Currently the Save button in the `emergency-access-add-edit.component` does not show a spinner and disable itself after being clicked. This means the user can click it multiple times and fire off multiple requests to server.

## Code changes
Add `[appApiAction]` on this button and wire up the relevant attributes to `btn.loading`.