### PR TITLE
Show spinner when downloading file for Send Accesses

### DIFF
--- a/src/app/send/access.component.html
+++ b/src/app/send/access.component.html
@@ -59,9 +59,12 @@
                     <!-- File -->
                     <ng-container *ngIf="send.type === sendType.File">
                         <p>{{send.file.fileName}}</p>
-                        <button class="btn btn-primary btn-block" type="button" (click)="download()">
+                        <button class="btn btn-primary btn-block" type="button" (click)="download()" *ngIf="!downloading">
                             <i class="fa fa-download" aria-hidden="true"></i>
                             {{'downloadFile' | i18n}} ({{send.file.sizeName}})</button>
+                        <button class="btn btn-primary btn-block" type="button" *ngIf="downloading" disabled="true">
+                            <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
+                        </button>
                     </ng-container>
                     <p *ngIf="expirationDate" class="text-center text-muted">Expires:
                         {{expirationDate | date: 'medium'}}</p>


### PR DESCRIPTION
# Overview

Baby QOL PR I noticed while testing large File type Sends. There's currently no feedback that you're actually downloading anything.

This changes the download button to a spinner to match current BW UI practices. 

We can't use typical download mechanisms currently because we have to decrypt the file stream prior to saving to disk.

# Files Changed:
* **access.component.html**: