### PR TITLE
Inform send in vault

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -167,6 +167,7 @@ import { CiphersComponent } from './vault/ciphers.component';
 import { CollectionsComponent } from './vault/collections.component';
 import { FolderAddEditComponent } from './vault/folder-add-edit.component';
 import { GroupingsComponent } from './vault/groupings.component';
+import { SendInfoComponent } from './vault/send-info.component';
 import { ShareComponent } from './vault/share.component';
 import { VaultComponent } from './vault/vault.component';
 
@@ -382,6 +383,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         SelectCopyDirective,
         SendAddEditComponent,
         SendComponent,
+        SendInfoComponent,
         SettingsComponent,
         ShareComponent,
         SsoComponent,

--- a/src/app/send/access.component.html
+++ b/src/app/send/access.component.html
@@ -74,9 +74,9 @@
         <div class="col-12 text-center mt-5 text-muted">
             <p class="mb-0">{{'sendAccessTaglineProductDesc' | i18n}}<br>
                 {{'sendAccessTaglineLearnMore' | i18n}} <a
-                    href="https://www.bitwarden.com/products/send?source=web-vault">Bitwarden Send</a>
+                    href="https://www.bitwarden.com/products/send?source=web-vault" target="_blank">Bitwarden Send</a>
                 {{'sendAccessTaglineOr' | i18n}} <a
-                    href="https://vault.bitwarden.com/#/register">{{'sendAccessTaglineSignUp' | i18n}}</a>
+                    href="https://vault.bitwarden.com/#/register" target="_blank">{{'sendAccessTaglineSignUp' | i18n}}</a>
                 {{'sendAccessTaglineTryToday' | i18n}}
             </p>
         </div>

--- a/src/app/vault/send-info.component.html
+++ b/src/app/vault/send-info.component.html
@@ -8,6 +8,6 @@
             <a href="https://www.bitwarden.com/products/send?source=web-vault" target="_blank">{{'sendVaultCardLearnMore' |
                 i18n}}</a>
             {{'sendVaultCardAndSee' | i18n}}
-            <a href="https://vault.bitwarden.com/#/register" target="_blank">{{'sendVaultCardHowItWorks' | i18n}}</a>
+            <a href="https://vault.bitwarden.com/#/register" target="_blank">{{'sendVaultCardHowItWorks' | i18n}}</a>.
     </div>
 </div>

--- a/src/app/vault/send-info.component.html
+++ b/src/app/vault/send-info.component.html
@@ -1,0 +1,16 @@
+<div class="card border-primary">
+    <div class="card-header bg-primary text-white">
+        <i class="fa fa-paper-plane-o fa-fw" aria-hidden="true"></i> Bitwarden Send
+    </div>
+    <div class="card-body">
+        <p class="mb-0">{{'sendAccessTaglineProductDesc' | i18n}}<br>
+            {{'sendAccessTaglineLearnMore' | i18n}} <a
+                href="https://www.bitwarden.com/products/send?source=web-vault">Bitwarden
+                Send</a>
+            {{'sendAccessTaglineOr' | i18n}} <a
+                href="https://vault.bitwarden.com/#/register">{{'sendAccessTaglineSignUp' |
+                i18n}}</a>
+            {{'sendAccessTaglineTryToday' | i18n}}
+        </p>
+    </div>
+</div>

--- a/src/app/vault/send-info.component.html
+++ b/src/app/vault/send-info.component.html
@@ -1,15 +1,15 @@
 <div class="card border-primary">
     <div class="card-header bg-primary text-white">
-        <i class="fa fa-paper-plane-o fa-fw" aria-hidden="true"></i> Bitwarden Send
+        <i class="fa fa-paper-plane-o fa-fw" aria-hidden="true"></i>
+        <a class="text-white" href="https://www.bitwarden.com/products/send?source=web-vault">Bitwarden Send</a>
     </div>
     <div class="card-body">
-        <p class="mb-0">{{'sendAccessTaglineProductDesc' | i18n}}<br>
-            {{'sendAccessTaglineLearnMore' | i18n}} <a
-                href="https://www.bitwarden.com/products/send?source=web-vault">Bitwarden
-                Send</a>
-            {{'sendAccessTaglineOr' | i18n}} <a
-                href="https://vault.bitwarden.com/#/register">{{'sendAccessTaglineSignUp' |
-                i18n}}</a>
+        <p class="mb-0">{{'sendAccessTaglineProductDesc' | i18n}}
+            <br>
+            {{'sendAccessTaglineLearnMore' | i18n}}
+            <a href="https://www.bitwarden.com/products/send?source=web-vault">Bitwarden Send</a>
+            {{'sendAccessTaglineOr' | i18n}}
+            <a href="https://vault.bitwarden.com/#/register">{{'sendAccessTaglineSignUp' | i18n}}</a>
             {{'sendAccessTaglineTryToday' | i18n}}
         </p>
     </div>

--- a/src/app/vault/send-info.component.html
+++ b/src/app/vault/send-info.component.html
@@ -1,16 +1,13 @@
 <div class="card border-primary">
     <div class="card-header bg-primary text-white">
         <i class="fa fa-paper-plane-o fa-fw" aria-hidden="true"></i>
-        <a class="text-white" href="https://www.bitwarden.com/products/send?source=web-vault">Bitwarden Send</a>
+        <a class="text-white" href="https://www.bitwarden.com/products/send?source=web-vault" target="_blank">Bitwarden Send</a>
     </div>
     <div class="card-body">
-        <p class="mb-0">{{'sendAccessTaglineProductDesc' | i18n}}
-            <br>
-            {{'sendAccessTaglineLearnMore' | i18n}}
-            <a href="https://www.bitwarden.com/products/send?source=web-vault">Bitwarden Send</a>
-            {{'sendAccessTaglineOr' | i18n}}
-            <a href="https://vault.bitwarden.com/#/register">{{'sendAccessTaglineSignUp' | i18n}}</a>
-            {{'sendAccessTaglineTryToday' | i18n}}
-        </p>
+            {{'sendVaultCardProductDesc' | i18n}}
+            <a href="https://www.bitwarden.com/products/send?source=web-vault" target="_blank">{{'sendVaultCardLearnMore' |
+                i18n}}</a>
+            {{'sendVaultCardAndSee' | i18n}}
+            <a href="https://vault.bitwarden.com/#/register" target="_blank">{{'sendVaultCardHowItWorks' | i18n}}</a>
     </div>
 </div>

--- a/src/app/vault/send-info.component.html
+++ b/src/app/vault/send-info.component.html
@@ -1,13 +1,15 @@
 <div class="card border-primary">
     <div class="card-header bg-primary text-white">
         <i class="fa fa-paper-plane-o fa-fw" aria-hidden="true"></i>
-        <a class="text-white" href="https://www.bitwarden.com/products/send?source=web-vault" target="_blank">Bitwarden Send</a>
+        <a class="text-white" href="/#/sends">Bitwarden Send</a>
     </div>
     <div class="card-body">
             {{'sendVaultCardProductDesc' | i18n}}
             <a href="https://www.bitwarden.com/products/send?source=web-vault" target="_blank">{{'sendVaultCardLearnMore' |
-                i18n}}</a>
-            {{'sendVaultCardAndSee' | i18n}}
-            <a href="https://vault.bitwarden.com/#/register" target="_blank">{{'sendVaultCardHowItWorks' | i18n}}</a>.
+                i18n}}</a>,
+            {{'sendVaultCardSee' | i18n}}
+            <a href="https://vault.bitwarden.com/#/register" target="_blank">{{'sendVaultCardHowItWorks' | i18n}}</a>,
+            {{'sendVaultCardOr' | i18n}}
+            <a href="/#/sends">{{'sendVaultCardTryItNow' | i18n}}</a>.
     </div>
 </div>

--- a/src/app/vault/send-info.component.ts
+++ b/src/app/vault/send-info.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-send-info',
+    templateUrl: 'send-info.component.html',
+})
+export class SendInfoComponent { }

--- a/src/app/vault/vault.component.html
+++ b/src/app/vault/vault.component.html
@@ -47,6 +47,7 @@
                 </div>
             </div>
             <app-verify-email *ngIf="showVerifyEmail" class="d-block mb-4"></app-verify-email>
+            <app-send-info class="d-block mb-4"></app-send-info>
             <div class="card border-warning mb-4" *ngIf="showBrowserOutdated">
                 <div class="card-header bg-warning text-white">
                     <i class="fa fa-warning fa-fw" aria-hidden="true"></i> {{'updateBrowser' | i18n}}

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3705,19 +3705,27 @@
     "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read '**Learn more about** Bitwarden Send or sign up to try it today.'"
   },
   "sendVaultCardProductDesc": {
-    "message": "Sharing information just got easier with Bitwarden Send."
+    "message": "Share text or files directly with anyone."
   },
   "sendVaultCardLearnMore": {
     "message": "Learn more",
-    "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read '**Learn more** and see how it works."
+    "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read '**Learn more**, see how it works, or try it now. '"
   },
-  "sendVaultCardAndSee": {
-    "message": "and see",
-    "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Learn more **and see** how it works."
+  "sendVaultCardSee": {
+    "message": "see",
+    "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Learn more, **see** how it works, or try it now.'"
   },
   "sendVaultCardHowItWorks": {
     "message": "how it works",
-    "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Learn more and see **how it works**."
+    "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Learn more, see **how it works**, or try it now.'"
+  },
+  "sendVaultCardOr": {
+    "message": "or",
+    "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Learn more, see how it works, **or** try it now.'"
+  },
+  "sendVaultCardTryItNow": {
+    "message": "try it now",
+    "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Learn more, see how it works, or **try it now**.'"
   },
   "sendAccessTaglineOr": {
     "message": "or",

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3704,6 +3704,21 @@
     "message": "Learn more about",
     "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read '**Learn more about** Bitwarden Send or sign up to try it today.'"
   },
+  "sendVaultCardProductDesc": {
+    "message": "Sharing information just got easier with Bitwarden Send."
+  },
+  "sendVaultCardLearnMore": {
+    "message": "Learn more",
+    "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read '**Learn more** and see how it works."
+  },
+  "sendVaultCardAndSee": {
+    "message": "and see",
+    "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Learn more **and see** how it works."
+  },
+  "sendVaultCardHowItWorks": {
+    "message": "how it works",
+    "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Learn more and see **how it works**."
+  },
   "sendAccessTaglineOr": {
     "message": "or",
     "description": "This will be used as part of a larger sentence, broken up to include links. The full sentence will read 'Learn more about Bitwarden Send **or** sign up to try it today.'"


### PR DESCRIPTION
# Overview 

We should announce our new product loud and proud! This adds a card to the vault which will serve as a place to give a quick description of Send and link to a more info site.

I made this a component so we could show this in other locations if we choose. Right now just in vault

# Files Changed
* **app.module.ts**: Register the new angular component
* **send-info.component.html/ts**: Really minimalist angular component that just drops in a card with Send info in it.
* **vault.component.html**: Drop in send info after verify email card, which makes it third in priority (update key, verify email, BW Send)

# Draft Reason

Waiting on shorter copy from @elizabethbaier.

Looking for other drop-in locations to display this card.