### PR TITLE
Fix how it works link Send Info Card in Vault

### DIFF
--- a/src/app/vault/send-info.component.html
+++ b/src/app/vault/send-info.component.html
@@ -8,7 +8,7 @@
             <a href="https://www.bitwarden.com/products/send?source=web-vault" target="_blank">{{'sendVaultCardLearnMore' |
                 i18n}}</a>,
             {{'sendVaultCardSee' | i18n}}
-            <a href="https://vault.bitwarden.com/#/register" target="_blank">{{'sendVaultCardHowItWorks' | i18n}}</a>,
+            <a href="https://www.youtube.com/watch?v=AFtPP9bcuYM" target="_blank">{{'sendVaultCardHowItWorks' | i18n}}</a>,
             {{'sendVaultCardOr' | i18n}}
             <a href="/#/sends">{{'sendVaultCardTryItNow' | i18n}}</a>.
     </div>


### PR DESCRIPTION
# Overview

I accidentally kept the wrong link address in the `how it works` link in Send info card.

This corrects that link to the YouTube how it works video.