### PR TITLE
added expiration date time autopopulation and new messages

### DIFF
--- a/src/app/send/add-edit.component.html
+++ b/src/app/send/add-edit.component.html
@@ -141,7 +141,7 @@
                                 <div class="d-flex justify-content-around" *ngIf="!isDateTimeLocalSupported">
                                     <input id="expirationDateCustomFallback" class="form-control mt-1" type="date"
                                         name="ExpirationDateFallback" [(ngModel)]="expirationDateFallback" [required]="!editMode"
-                                        placeholder="MM/DD/YYYY" [readOnly]="disableSend" data-date-format="mm/dd/yyyy">
+                                        placeholder="MM/DD/YYYY" [readOnly]="disableSend" data-date-format="mm/dd/yyyy" (change)="expirationDateFallbackChanged()">
                                         <select *ngIf="isSafari" id="expirationTimeCustomFallback" class="form-control mt-1 ml-1" [required]="!editMode"
                                             [(ngModel)]="safariExpirationTime" name="SafariExpirationTime">
                                             <option *ngFor="let o of safariExpirationTimeOptions" [ngValue]="o.military">{{o.standard}}</option>

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3747,5 +3747,20 @@
         "example": "An email address"
       }
     }
+  },
+  "expirationDateIsInvalid": {
+    "message": "The expiration date provided is not valid."
+  },
+  "deletionDateIsInvalid": {
+    "message": "The deletion date provided is not valid."
+  },
+  "expirationDateAndTimeRequired": {
+    "message": "An expiration date and time are required."
+  },
+  "deletionDateAndTimeRequired": {
+    "message": "A deletion date and time are required."
+  },
+  "dateParsingError": {
+    "message": "There was an error saving your deletion and expiration dates."
   }
 }


### PR DESCRIPTION
Note: jslib updates will need to be merged before this can be.

QA requested a few fix ups to the send date fallbacks.

1. The calendar popup for `<input type="date">` doesn't work in the Firefox browser plugin. This is for the same reason `<input type="file">` popups don't work, and has been handled in a similar way by adding some subtext telling users to pop out the extension to use the picker. The text based date input works as expected regardless of being in a popup or not.
2. Better error messages for input validation. Placeholders were created for messages in jslib but they didn't get added to clients.
3. We should auto populate `expirationTime` if `expirationDate` is set and no time is already present. Not doing so was causing confusion when trying to just set a date and click submit.  

Changes made to `web`:
1. Hooked into the new jslib change method for expiration date to set expiration time
2. Added error messages