### PR TITLE
Adds folder word-wrap

### DIFF
--- a/src/app/vault/groupings.component.html
+++ b/src/app/vault/groupings.component.html
@@ -70,7 +70,7 @@
                                 <i *ngIf="f.children.length" class="fa-li fa" title="{{'toggleCollapse' | i18n}}"
                                     [ngClass]="{'fa-caret-right': isCollapsed(f.node), 'fa-caret-down': !isCollapsed(f.node)}"
                                     (click)="collapse(f.node)"></i>
-                                <a href="#" appStopClick (click)="selectFolder(f.node)">
+                                <a href="#" class="text-break" appStopClick (click)="selectFolder(f.node)">
                                     <i *ngIf="f.children.length === 0" class="fa-li fa fa-folder-o" aria-hidden="true"></i>{{f.node.name}}
                                 </a>
                                 <a href="#" class="text-muted ml-auto show-active" appStopClick
@@ -97,7 +97,7 @@
                             <i *ngIf="c.children.length" class="fa-li fa" title="{{'toggleCollapse' | i18n}}"
                                 [ngClass]="{'fa-caret-right': isCollapsed(c.node), 'fa-caret-down': !isCollapsed(c.node)}"
                                 (click)="collapse(c.node)"></i>
-                            <a href="#" appStopClick (click)="selectCollection(c.node)">
+                            <a href="#" class="text-break" appStopClick (click)="selectCollection(c.node)">
                                 <i *ngIf="c.children.length === 0" class="fa-li fa fa-cube" aria-hidden="true"></i>{{c.node.name}}
                             </a>
                             <ul class="fa-ul card-ul carets" *ngIf="c.children.length && !isCollapsed(c.node)">


### PR DESCRIPTION
Uses spaces and dashes as preferred separator in folder names
(instead of just breaking wherever the max width is encountered)

**Current behavior:**
![Folder names without word wrap](https://user-images.githubusercontent.com/18367627/110496230-94fec700-80f5-11eb-800c-075dde0ab388.JPG)

**New behavior:**
![Folder names with word wrap](https://user-images.githubusercontent.com/18367627/110496311-a5af3d00-80f5-11eb-990d-089213a15177.JPG)

**Tested on:**
- Chrome
- Firefox
- Edge