### PR TITLE
Open pdf in same tab for Safari

### DIFF
--- a/src/services/webPlatformUtils.service.ts
+++ b/src/services/webPlatformUtils.service.ts
@@ -143,7 +143,7 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
             const a = win.document.createElement('a');
             if (doDownload) {
                 a.download = fileName;
-            } else {
+            } else if (!this.isSafari()) {
                 a.target = '_blank';
             }
             a.href = URL.createObjectURL(blob);


### PR DESCRIPTION
Safari blocks sharing objectURL data between tabs.
Just use the same tab.

# Overview
Downloads of PDFs in web should pop open a new tab with the browser's pdf viewer. However, Safari blocks objectURL blob data between tabs. The solution is to just remove the `target="_blank"` attribute from the appended `<a>` tag.

>Note: This code is shared between attachments and Send. This will cause PDF attachments to navigate away from the web vault to display the PDF.

# Files Changed
* **webPlatformUtils.service.ts**: Don't append _blank on the `<a>` tag in Safari, it doesn't work.