### PR TITLE
Attachment azure upload blobs

### DIFF
--- a/src/app/organizations/vault/attachments.component.ts
+++ b/src/app/organizations/vault/attachments.component.ts
@@ -25,8 +25,8 @@ export class AttachmentsComponent extends BaseAttachmentsComponent {
 
     constructor(cipherService: CipherService, i18nService: I18nService,
         cryptoService: CryptoService, userService: UserService,
-        platformUtilsService: PlatformUtilsService, private apiService: ApiService) {
-        super(cipherService, i18nService, cryptoService, userService, platformUtilsService);
+        platformUtilsService: PlatformUtilsService, apiService: ApiService) {
+        super(cipherService, i18nService, cryptoService, userService, platformUtilsService, apiService);
     }
 
     protected async reupload(attachment: AttachmentView) {

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -108,8 +108,9 @@ const apiService = new ApiService(tokenService, platformUtilsService,
 const userService = new UserService(tokenService, storageService);
 const settingsService = new SettingsService(userService, storageService);
 export let searchService: SearchService = null;
+const azureStorageService = new AzureStorageService(consoleLogService);
 const cipherService = new CipherService(cryptoService, userService, settingsService,
-    apiService, storageService, i18nService, () => searchService);
+    apiService, storageService, i18nService, azureStorageService, () => searchService);
 const folderService = new FolderService(cryptoService, userService, apiService, storageService,
     i18nService, cipherService);
 const collectionService = new CollectionService(cryptoService, userService, storageService, i18nService);

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -108,15 +108,14 @@ const apiService = new ApiService(tokenService, platformUtilsService,
 const userService = new UserService(tokenService, storageService);
 const settingsService = new SettingsService(userService, storageService);
 export let searchService: SearchService = null;
-const azureStorageService = new AzureStorageService(consoleLogService);
+const fileUploadService = new FileUploadService(consoleLogService, apiService);
 const cipherService = new CipherService(cryptoService, userService, settingsService,
-    apiService, storageService, i18nService, azureStorageService, () => searchService);
+    apiService, fileUploadService, storageService, i18nService, () => searchService);
 const folderService = new FolderService(cryptoService, userService, apiService, storageService,
     i18nService, cipherService);
 const collectionService = new CollectionService(cryptoService, userService, storageService, i18nService);
 searchService = new SearchService(cipherService, consoleLogService);
 const policyService = new PolicyService(userService, storageService);
-const fileUploadService = new FileUploadService(consoleLogService, apiService);
 const sendService = new SendService(cryptoService, userService, apiService, fileUploadService, storageService,
     i18nService, cryptoFunctionService);
 const vaultTimeoutService = new VaultTimeoutService(cipherService, folderService, collectionService,

--- a/src/app/settings/emergency-access-attachments.component.ts
+++ b/src/app/settings/emergency-access-attachments.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 
+import { ApiService } from 'jslib/abstractions/api.service';
 import { CipherService } from 'jslib/abstractions/cipher.service';
 import { CryptoService } from 'jslib/abstractions/crypto.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
@@ -20,8 +21,8 @@ export class EmergencyAccessAttachmentsComponent extends BaseAttachmentsComponen
 
     constructor(cipherService: CipherService, i18nService: I18nService,
         cryptoService: CryptoService, userService: UserService,
-        platformUtilsService: PlatformUtilsService) {
-        super(cipherService, i18nService, cryptoService, userService, platformUtilsService, window);
+        platformUtilsService: PlatformUtilsService, apiService: ApiService) {
+        super(cipherService, i18nService, cryptoService, userService, platformUtilsService, apiService, window);
     }
 
     protected async init() {

--- a/src/app/settings/emergency-access-view.component.ts
+++ b/src/app/settings/emergency-access-view.component.ts
@@ -84,6 +84,7 @@ export class EmergencyAccessViewComponent implements OnInit {
         const childComponent = this.modal.show<EmergencyAccessAttachmentsComponent>(EmergencyAccessAttachmentsComponent, this.attachmentsModalRef);
 
         childComponent.cipher = cipher;
+        childComponent.emergencyAccessId = this.id;
 
         this.modal.onClosed.subscribe(async () => {
             this.modal = null;

--- a/src/app/vault/attachments.component.ts
+++ b/src/app/vault/attachments.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 
+import { ApiService } from 'jslib/abstractions/api.service';
 import { CipherService } from 'jslib/abstractions/cipher.service';
 import { CryptoService } from 'jslib/abstractions/crypto.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
@@ -19,8 +20,8 @@ export class AttachmentsComponent extends BaseAttachmentsComponent {
 
     constructor(cipherService: CipherService, i18nService: I18nService,
         cryptoService: CryptoService, userService: UserService,
-        platformUtilsService: PlatformUtilsService) {
-        super(cipherService, i18nService, cryptoService, userService, platformUtilsService, window);
+        platformUtilsService: PlatformUtilsService, apiService: ApiService) {
+        super(cipherService, i18nService, cryptoService, userService, platformUtilsService, apiService, window);
     }
 
     protected async reupload(attachment: AttachmentView) {

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -437,7 +437,7 @@
     "message": "Select a file."
   },
   "maxFileSize": {
-    "message": "Maximum file size is 100 MB."
+    "message": "Maximum file size is 500 MB."
   },
   "updateKey": {
     "message": "You cannot use this feature until you update your encryption key."


### PR DESCRIPTION
# Overview

Enable uploading of cipher attachments direct to Azure. Similar PR to #875. Allows for use of new ability to upload directly to Azure or Bitwarden.

# Files Changed
* **attachments.component.ts/emergency-access-attachments.component.ts**: Update component DI requirements
* **services.module.ts**: Add file upload service to cipher service
* **emergency-access-view.component.ts**: Set emergency access id. This will be used by the base attachment component to request download using emergency access rather than typical attachment download 
* **messages.json**: update size limit to 500MB