### PR TITLE
[Reset Password] Enrollment actions

### DIFF
--- a/src/app/services/event.service.ts
+++ b/src/app/services/event.service.ts
@@ -155,6 +155,13 @@ export class EventService {
                 break;
             case EventType.OrganizationUser_UnlinkedSso:
                 msg = this.i18nService.t('unlinkedSsoUser', this.formatOrgUserId(ev));
+                break;
+            case EventType.OrganizationUser_ResetPassword_Enroll:
+                msg = this.i18nService.t('eventEnrollPasswordReset', this.formatOrgUserId(ev));
+                break;
+            case EventType.OrganizationUser_ResetPassword_Withdraw:
+                msg = this.i18nService.t('eventWithdrawPasswordReset', this.formatOrgUserId(ev));
+                break;
             // Org
             case EventType.Organization_Updated:
                 msg = this.i18nService.t('editedOrgSettings');

--- a/src/app/settings/organizations.component.html
+++ b/src/app/settings/organizations.component.html
@@ -74,6 +74,16 @@
                                 <i class="fa fa-cog fa-lg" aria-hidden="true"></i>
                             </button>
                             <div class="dropdown-menu dropdown-menu-right">
+                                <a *ngIf="!o.isResetPasswordEnrolled" class="dropdown-item" href="#" appStopClick
+                                    (click)="toggleResetPasswordEnrollment(o)">
+                                    <i class="fa fa-fw fa-key" aria-hidden="true"></i>
+                                    {{'enrollPasswordReset' | i18n}}
+                                </a>
+                                <a *ngIf="o.isResetPasswordEnrolled" class="dropdown-item" href="#" appStopClick
+                                    (click)="toggleResetPasswordEnrollment(o)">
+                                    <i class="fa fa-fw fa-undo" aria-hidden="true"></i>
+                                    {{'withdrawPasswordReset' | i18n}}
+                                </a>
                                 <ng-container *ngIf="o.useSso && o.identifier">
                                     <a *ngIf="o.ssoBound; else linkSso" class="dropdown-item" href="#" appStopClick
                                         (click)="unlinkSso(o)">

--- a/src/app/settings/organizations.component.html
+++ b/src/app/settings/organizations.component.html
@@ -65,6 +65,11 @@
                                 title="{{'organizationIsDisabled' | i18n}}" aria-hidden="true"></i>
                             <span class="sr-only">{{'organizationIsDisabled' | i18n}}</span>
                         </ng-container>
+                        <ng-container *ngIf="o.isResetPasswordEnrolled">
+                            <i class="fa fa-key" appStopProp title="{{'enrolledPasswordReset' | i18n}}"
+                                aria-hidden="true"></i>
+                            <span class="sr-only">{{'enrolledPasswordReset' | i18n}}</span>
+                        </ng-container>
                     </td>
                     <td class="table-list-options">
                         <div class="dropdown" appListDropdown>

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3837,6 +3837,9 @@
   "enrollPasswordReset": {
     "message": "Enroll in Password Reset"
   },
+  "enrolledPasswordReset": {
+    "message": "Enrolled in Password Reset"
+  },
   "withdrawPasswordReset": {
     "message": "Withdraw from Password Reset"
   },

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3804,5 +3804,35 @@
   },
   "hintEqualsPassword": {
     "message": "Your password hint cannot be the same as your password."
+  },
+  "enrollPasswordReset": {
+    "message": "Enroll in Password Reset"
+  },
+  "withdrawPasswordReset": {
+    "message": "Withdraw from Password Reset"
+  },
+  "enrollPasswordResetSuccess": {
+    "message": "Enrollment success!"
+  },
+  "withdrawPasswordResetSuccess": {
+    "message": "Withdrawal success!"
+  },
+  "eventEnrollPasswordReset": {
+    "message": "User $ID$ enrolled in password reset assistance.",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "John Smith"
+      }
+    }
+  },
+  "eventWithdrawPasswordReset": {
+    "message": "User $ID$ withdrew from password reset assistance.",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "John Smith"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Objective
> Allow user's to enroll/withdraw from the `Password Reset` within an organization.

## Code Changes
- **event.service**: Added message support for new event actions
- **organizations.component.html**: Added dropdown options based on the presence of the `ResetPasswordKey`. 
- **organizations.component.ts**: Added `CryptoService` import. Created `toggleResetPasswordEnrollment` function that will encrypt (if necessary) and set the user's `ResetPasswordKey`.  
- **messages.json**: Added necessary strings

## Screenshots
![0-enroll](https://user-images.githubusercontent.com/26154748/113214295-e1de4500-923e-11eb-9c4a-fd6bf327c35a.png)
![1-withdraw](https://user-images.githubusercontent.com/26154748/113586352-034e8080-95f3-11eb-8f50-875981386a59.png)

## Dependencies
- [Jslib Enrollment API](https://github.com/bitwarden/jslib/pull/315)