### PR TITLE
[Reset Password] Manage Reset Password permission

### DIFF
--- a/src/app/organizations/manage/user-add-edit.component.html
+++ b/src/app/organizations/manage/user-add-edit.component.html
@@ -264,8 +264,9 @@
                     <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
                     <span>{{'save' | i18n}}</span>
                 </button>
-                <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">{{'cancel' |
-                    i18n}}</button>
+                <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">
+                    {{'cancel' | i18n}}
+                </button>
                 <div class="ml-auto">
                     <button #deleteBtn type="button" (click)="delete()" class="btn btn-outline-danger"
                         appA11yTitle="{{'delete' | i18n}}" *ngIf="editMode" [disabled]="deleteBtn.loading"

--- a/src/app/organizations/manage/user-add-edit.component.html
+++ b/src/app/organizations/manage/user-add-edit.component.html
@@ -178,6 +178,15 @@
                                         </label>
                                     </div>
                                 </div>
+                                <div class="form-group mb-0">
+                                    <div class="form-check mt-1 form-check-block">
+                                        <input class="form-check-input" type="checkbox" name="manageResetPassword"
+                                            id="manageResetPassword" [(ngModel)]="permissions.manageResetPassword">
+                                        <label class="form-check-label font-weight-normal" for="manageResetPassword">
+                                            {{'manageResetPassword' | i18n}}
+                                        </label>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -255,8 +264,8 @@
                     <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
                     <span>{{'save' | i18n}}</span>
                 </button>
-                <button type="button" class="btn btn-outline-secondary"
-                    data-dismiss="modal">{{'cancel' | i18n}}</button>
+                <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">{{'cancel' |
+                    i18n}}</button>
                 <div class="ml-auto">
                     <button #deleteBtn type="button" (click)="delete()" class="btn btn-outline-danger"
                         appA11yTitle="{{'delete' | i18n}}" *ngIf="editMode" [disabled]="deleteBtn.loading"

--- a/src/app/organizations/manage/user-add-edit.component.ts
+++ b/src/app/organizations/manage/user-add-edit.component.ts
@@ -138,6 +138,9 @@ export class UserAddEditComponent implements OnInit {
         p.manageUsers = clearPermissions ?
             false :
             this.permissions.manageUsers;
+        p.manageResetPassword = clearPermissions ?
+            false :
+            this.permissions.manageResetPassword;
         return p;
     }
 

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3714,6 +3714,9 @@
   "manageUsers": {
     "message": "Manage Users"
   },
+  "manageResetPassword": {
+    "message": "Manage Password Reset"
+  },
   "disableRequireSsoError": {
     "message": "You must manually disable the Single Sign-On Authentication policy before this policy can be disabled."
   },


### PR DESCRIPTION
## Objective
> Allow user's with the custom permission type to manage password resets

## Code Changes
- **user-add-edit.component.html**: Added checkbox input for toggling permission
- **user-add-edit.component.ts**: update `setRequestPermissions` function to set/update the `manageResetPassword` boolean based on the checkbox state
- **messages.json**: `manageResetPassword` checkbox label added

## Screenshots
![2-manage-permission](https://user-images.githubusercontent.com/26154748/113218768-b6128d80-9245-11eb-86c8-a2f0c07e98e9.png)

## Dependency
- [Jslib - Permissions API update](https://github.com/bitwarden/jslib/pull/317)