### PR TITLE
Create index of cipher orgs and use advanced search with org ciphers

### DIFF
--- a/src/app/organizations/vault/ciphers.component.ts
+++ b/src/app/organizations/vault/ciphers.component.ts
@@ -48,7 +48,8 @@ export class CiphersComponent extends BaseCiphersComponent {
         }
         this.accessEvents = this.organization.useEvents;
         this.allCiphers = await this.cipherService.getAllFromApiForOrganization(this.organization.id);
-        this.applyFilter(filter);
+        await this.searchService.indexCiphers(this.allCiphers);
+        await this.applyFilter(filter);
         this.loaded = true;
     }
 
@@ -62,28 +63,8 @@ export class CiphersComponent extends BaseCiphersComponent {
     }
 
     async search(timeout: number = null) {
-        if (!this.organization.canManageAllCollections) {
-            return super.search(timeout);
-        }
-        this.searchPending = false;
-        let filteredCiphers = this.allCiphers;
-
-        if (this.searchText == null || this.searchText.trim().length < 2) {
-            this.ciphers = filteredCiphers.filter(c => {
-                if (c.isDeleted !== this.deleted) {
-                    return false;
-                }
-                return this.filter == null || this.filter(c);
-            });
-        } else {
-            if (this.filter != null) {
-                filteredCiphers = filteredCiphers.filter(this.filter);
-            }
-            this.ciphers = this.searchService.searchCiphersBasic(filteredCiphers, this.searchText, this.deleted);
-        }
-        await this.resetPaging();
+        super.search(timeout, this.allCiphers);
     }
-
     events(c: CipherView) {
         this.onEventsClicked.emit(c);
     }


### PR DESCRIPTION
# Overview

web client changes for: https://app.asana.com/0/1169444489336079/1183168049159854/f

related to bitwarden/jslib#318. Alters Organization cipher view to index and search organization ciphers using the default cipher search algorithm.

# Files Changed
* **organizations/vault/ciphers.component.ts**: On load, index the organization ciphers and apply a null filter. Also update Search method to search only organization ciphers.