### PR TITLE
Fix Send Hide Email QA defects

### DIFF
--- a/src/app/send/access.component.html
+++ b/src/app/send/access.component.html
@@ -6,9 +6,10 @@
         <div class="col-12 text-center" *ngIf="creatorIdentifier != null">
             <p>{{'sendCreatorIdentifier' | i18n: creatorIdentifier }}</p>
         </div>
-        <div class="col-8" *ngIf="creatorIdentifier == null && !loading && !unavailable">
+        <div class="col-8" *ngIf="hideEmail">
             <app-callout type="warning" title="{{'warning' | i18n}}">
-                {{'viewSendHiddenEmailWarning' | i18n }} <a href="https://bitwarden.com/help/article/receive-send/">{{'learnMore' | i18n}}</a>.
+                {{'viewSendHiddenEmailWarning' | i18n }} 
+                <a href="https://bitwarden.com/help/article/receive-send/" target="_blank">{{'learnMore' | i18n}}</a>.
             </app-callout>
         </div>
     </div>

--- a/src/app/send/access.component.ts
+++ b/src/app/send/access.component.ts
@@ -39,6 +39,7 @@ export class AccessComponent implements OnInit {
     showText = false;
     unavailable = false;
     error = false;
+    hideEmail = false;
 
     private id: string;
     private key: string;
@@ -131,6 +132,7 @@ export class AccessComponent implements OnInit {
     async load() {
         this.unavailable = false;
         this.error = false;
+        this.hideEmail = false;
         const keyArray = Utils.fromUrlB64ToArray(this.key);
         this.accessRequest = new SendAccessRequest();
         if (this.password != null) {
@@ -162,5 +164,6 @@ export class AccessComponent implements OnInit {
             }
         }
         this.loading = false;
+        this.hideEmail = this.creatorIdentifier == null && !this.passwordRequired && !this.loading && !this.unavailable;
     }
 }


### PR DESCRIPTION
## Objective

Fix the following issues on the Send "Hide Email" feature, found during QA:

⚠️ A. When a user has added a password to a send, but has not opted to hide their email, the landing page of the Send will show the "hidden email" banner until the user inputs the password. The sender's email should, it seems, be shown on this page too. (Video Attached) 

⚠️ B. (This is more of a feedback item) When a user clicks the Learn More link in the landing page warning banner, it does not open as a new tab. This is inconsistent with the other links on the page and also could cause problems for access count.