### PR TITLE
Fix WebAuthn dialog not resetting on success

### DIFF
--- a/src/connectors/webauthn-fallback.ts
+++ b/src/connectors/webauthn-fallback.ts
@@ -103,6 +103,7 @@ async function initWebAuthn(obj: any) {
 
 function error(message: string) {
     const el = document.getElementById('msg');
+    resetMsgBox(el);
     el.innerHTML = message;
     el.classList.add('alert');
     el.classList.add('alert-danger');
@@ -112,7 +113,14 @@ function success(message: string) {
     (document.getElementById('webauthn-button') as HTMLButtonElement).disabled = true;
 
     const el = document.getElementById('msg');
+    resetMsgBox(el);
     el.innerHTML = message;
     el.classList.add('alert');
     el.classList.add('alert-success');
+}
+
+function resetMsgBox(el: HTMLElement) {
+    el.classList.remove('alert');
+    el.classList.remove('alert-danger');
+    el.classList.remove('alert-success');
 }


### PR DESCRIPTION
## Overview
The WebAuthn fallback for Firefox incorrectly kept the alert-danger style when initially failing the request and later succeeding. Resolved by resetting the styles.