### PR TITLE
Require user to verify email to use file Send

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -139,6 +139,15 @@ export class AppComponent implements OnDestroy, OnInit {
                             this.router.navigate(['settings/premium']);
                         }
                         break;
+                    case 'emailVerificationRequired':
+                        const emailVerificationConfirmed = await this.platformUtilsService.showDialog(
+                            this.i18nService.t('emailVerificationRequiredDesc'),
+                            this.i18nService.t('emailVerificationRequired'),
+                            this.i18nService.t('learnMore'), this.i18nService.t('cancel'));
+                        if (emailVerificationConfirmed) {
+                            this.platformUtilsService.launchUri('https://bitwarden.com/help/article/create-bitwarden-account/');
+                        }
+                        break;
                     case 'showToast':
                         this.showToast(message);
                         break;

--- a/src/app/send/add-edit.component.ts
+++ b/src/app/send/add-edit.component.ts
@@ -8,6 +8,7 @@ import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 import { PolicyService } from 'jslib/abstractions/policy.service';
 import { SendService } from 'jslib/abstractions/send.service';
+import { TokenService } from 'jslib/abstractions/token.service';
 import { UserService } from 'jslib/abstractions/user.service';
 
 import { AddEditComponent as BaseAddEditComponent } from 'jslib/angular/components/send/add-edit.component';
@@ -20,9 +21,9 @@ export class AddEditComponent extends BaseAddEditComponent {
     constructor(i18nService: I18nService, platformUtilsService: PlatformUtilsService,
         environmentService: EnvironmentService, datePipe: DatePipe,
         sendService: SendService, userService: UserService,
-        messagingService: MessagingService, policyService: PolicyService) {
+        messagingService: MessagingService, policyService: PolicyService, tokenService: TokenService) {
         super(i18nService, platformUtilsService, environmentService, datePipe, sendService, userService,
-            messagingService, policyService);
+            messagingService, policyService, tokenService);
     }
 
     copyLinkToClipboard(link: string) {

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -2636,6 +2636,12 @@
   "emailVerifiedFailed": {
     "message": "Unable to verify your email. Try sending a new verification email."
   },
+  "emailVerificationRequired": {
+    "message": "Email Verification Required"
+  },
+  "emailVerificationRequiredDesc": {
+    "message": "You must verify your email to use this feature."
+  },
   "updateBrowser": {
     "message": "Update Browser"
   },


### PR DESCRIPTION
## Objective

Require a user to have verified their email address before being able to create a file Send.

## Code changes

Repos affected:
* server - https://github.com/bitwarden/server/pull/1262
* jslib - https://github.com/bitwarden/jslib/pull/331
* web
* browser - https://github.com/bitwarden/browser/pull/1774
* desktop - https://github.com/bitwarden/desktop/pull/829
* mobile - https://github.com/bitwarden/mobile/pull/1360

I followed the current behaviour for the "premium required" gate. i.e.
* web and desktop - if the user tries to change the Send type to file, create an alert popup with a "learn more" button. After that, the user can go ahead and change the Send type, but will receive the server error message on submit.
* browser - no alert popup, just rely on the server error message
* mobile - alert popup only, do not let the user change the Send type at all

Note this depends on jslib update. Build is failing for this reason.