### PR TITLE
[Reset Password] Rotate encryption key

### DIFF
--- a/src/app/settings/change-password.component.ts
+++ b/src/app/settings/change-password.component.ts
@@ -201,10 +201,12 @@ export class ChangePasswordComponent extends BaseChangePasswordComponent {
         const orgs = await this.userService.getAllOrganizations();
 
         for (const org of orgs) {
-            const request = new OrganizationUserResetPasswordEnrollmentRequest();
-            request.resetPasswordKey = null;
+            if (org.isResetPasswordEnrolled) {
+                const request = new OrganizationUserResetPasswordEnrollmentRequest();
+                request.resetPasswordKey = null;
 
-            await this.apiService.putOrganizationUserResetPasswordEnrollment(org.id, org.userId, request);
+                await this.apiService.putOrganizationUserResetPasswordEnrollment(org.id, org.userId, request);
+            }
         }
     }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -2858,9 +2858,6 @@
   "updateEncryptionKeyExportWarning": {
     "message": "Any encrypted exports that you have saved will also become invalid."
   },
-  "updateEncryptionKeyResetPasswordWarning": {
-    "message": "Finally, you will need to re-enroll in Password Reset assistance for each desired organizaiton."
-  },
   "subscription": {
     "message": "Subscription"
   },

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -2858,6 +2858,9 @@
   "updateEncryptionKeyExportWarning": {
     "message": "Any encrypted exports that you have saved will also become invalid."
   },
+  "updateEncryptionKeyResetPasswordWarning": {
+    "message": "Finally, you will need to re-enroll in Password Reset assistance for each desired organizaiton."
+  },
   "subscription": {
     "message": "Subscription"
   },


### PR DESCRIPTION
## Objective
> When a user change's their password through the settings page, an option to rotate the user's encryption key is offered. When this happens, daisy-chain onto the process and re-enroll **all** `resetPasswordKey` from the calling `orgUser` for each organization.

## Code Changes
- **change-password.component.ts**: Added daisy-chained method to rotate encryption key. For all confirmed orgs, re-enroll the `resetPasswordKey` if necessary.
