### PR TITLE
Resolve organisation confirm user sometimes not showing errors

### DIFF
--- a/src/app/organizations/manage/user-confirm.component.html
+++ b/src/app/organizations/manage/user-confirm.component.html
@@ -1,6 +1,6 @@
 <div class="modal fade" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="confirmUserTitle">
     <div class="modal-dialog" role="document">
-        <form class="modal-content" #form (ngSubmit)="submit()" [appApiAction]="formPromise">
+        <form class="modal-content" #form (ngSubmit)="submit()">
             <div class="modal-header">
                 <h2 class="modal-title" id="confirmUserTitle">
                     {{'confirmUser' | i18n}}

--- a/src/app/tools/weak-passwords-report.component.ts
+++ b/src/app/tools/weak-passwords-report.component.ts
@@ -42,10 +42,10 @@ export class WeakPasswordsReportComponent extends CipherReportComponent implemen
         const weakPasswordCiphers: CipherView[] = [];
         const isUserNameNotEmpty = (c: CipherView): boolean => {
             return c.login.username != null && c.login.username.trim() !== '';
-        }
-        const getCacheKey = (c:CipherView): string => {
+        };
+        const getCacheKey = (c: CipherView): string => {
             return c.login.password + '_____' + (isUserNameNotEmpty(c) ? c.login.username : '');
-        }
+        };
 
         allCiphers.forEach(c => {
             if (c.type !== CipherType.Login || c.login.password == null || c.login.password === '' || c.isDeleted) {


### PR DESCRIPTION
## Objective
If you activate the 2FA Policy on your organization, then invite a user which has 2FA activated on their account but they deactivate it after they accept the invitation, you would not be able to confirm them and if you ticked 'Don't ask to verify fingerprint phrase again' before, you would not be shown an error message explaining why.

### Code Changes
* **src/app/organizations/manage/people.component.ts**: Catch server errors and display them using the validation service. Now expects a publicKey from the `UserConfirmComponent` instead of delegating the user confirmation to it.
* **src/app/organizations/manage/user-confirm.component.ts**: Moved duplicate code to `people.component.ts`. The `UserConfirmComponent` is now dumber and only handles showing the fingerprint.
* **src/app/tools/weak-passwords-report.component.ts**: `lint:fix` fixes.

### Testing Considerations
Since I've refactored the logic for accepting org invites we should do some quick regression testing and verify confirmations and errors shows up (with and without the verify fingerprint dialog).

Resolves https://github.com/bitwarden/web/issues/827