### PR TITLE
Extend proxy work

### DIFF
--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -22,8 +22,6 @@ import { AuthGuardService } from 'jslib/angular/services/auth-guard.service';
 import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
 import { ValidationService } from 'jslib/angular/services/validation.service';
 
-import { Analytics } from 'jslib/misc/analytics';
-
 import { ApiService } from 'jslib/services/api.service';
 import { AppIdService } from 'jslib/services/appId.service';
 import { AuditService } from 'jslib/services/audit.service';
@@ -139,23 +137,20 @@ const environmentService = new EnvironmentService(apiService, storageService, no
 const auditService = new AuditService(cryptoFunctionService, apiService);
 const eventLoggingService = new EventLoggingService(storageService, apiService, userService, cipherService);
 
-const analytics = new Analytics(window, () => platformUtilsService.isDev() || platformUtilsService.isSelfHost(),
-    platformUtilsService, storageService, appIdService);
 containerService.attachToWindow(window);
 
 export function initFactory(): Function {
     return async () => {
         await (storageService as HtmlStorageService).init();
         const isDev = platformUtilsService.isDev();
-        if (!isDev && platformUtilsService.isSelfHost()) {
+
+        if (isDev || platformUtilsService.isSelfHost()) {
             environmentService.baseUrl = window.location.origin;
         } else {
-            environmentService.webVaultUrl = isDev ? 'https://localhost:8080' : null;
-            environmentService.notificationsUrl = isDev ? 'http://localhost:61840' :
-                'https://notifications.bitwarden.com'; // window.location.origin + '/notifications';
-            environmentService.enterpriseUrl = isDev ? 'http://localhost:52313' :
-                'https://portal.bitwarden.com'; // window.location.origin + '/portal';
+            environmentService.notificationsUrl = 'https://notifications.bitwarden.com';
+            environmentService.enterpriseUrl = 'https://portal.bitwarden.com';
         }
+
         apiService.setUrls({
             base: window.location.origin,
             api: null,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -160,41 +160,47 @@ const devServer = {
     proxy: {
         '/api': {
             target: 'http://localhost:4000',
-            pathRewrite: {'^/api' : ''}
-        },
-        '/identity': {
-            target: 'http://localhost:33656',
-            pathRewrite: {'^/identity' : ''}
-        },
-        '/events': {
-            target: 'http://localhost:46273',
-            pathRewrite: {'^/events' : ''}
-        }
-    },
-    hot: false,
-};
-
-if (ENV === "production") {
-    devServer.proxy = {
-        '/api': {
-            target: 'https://api.bitwarden.com',
             pathRewrite: {'^/api' : ''},
             secure: false,
             changeOrigin: true
         },
         '/identity': {
-            target: 'https://identity.bitwarden.com',
+            target: 'http://localhost:33656',
             pathRewrite: {'^/identity' : ''},
             secure: false,
             changeOrigin: true
         },
         '/events': {
-            target: 'https://events.bitwarden.com',
+            target: 'http://localhost:46273',
             pathRewrite: {'^/events' : ''},
             secure: false,
             changeOrigin: true
+        },
+        '/notifications': {
+            target: 'http://localhost:61840',
+            pathRewrite: {'^/notifications' : ''},
+            secure: false,
+            changeOrigin: true
+        },
+        '/portal': {
+            target: 'http://localhost:52313',
+            pathRewrite: {'^/portal' : ''},
+            secure: false,
+            changeOrigin: true
         }
-    };
+    },
+    hot: false,
+    allowedHosts: [
+        'bitwarden.test',
+    ],
+};
+
+if (ENV === "production") {
+    devServer.proxy['/api'].target = 'https://api.bitwarden.com';
+    devServer.proxy['/identity'].target = 'https://identity.bitwarden.com';
+    devServer.proxy['/events'].target = 'https://events.bitwarden.com';
+    devServer.proxy['/notifications'].target = 'https://notifications.bitwarden.com';
+    devServer.proxy['/portal'].target = 'https://portal.bitwarden.com';
 }
 
 const config = {


### PR DESCRIPTION
## Objective
While testing WebAuthn again I discovered that we hardcode the webvault to localhost:8080 in dev. This is undesired since WebAuthn requires a valid domain name to work. I continued the proxy work in #914 and converted the last services to also be behind the proxy.

### Code Changes
* **src/app/services/services.module.ts**: Simplify setting environment variables since dev behaves identical to self hosted.
* **webpack.config.js**: Proxy notifications and portal. Added an allowed host `bitwarden.test` since that's what I use as a test domain.