### PR TITLE
Do not show "free trial" wording if upgrading plan

### DIFF
--- a/src/app/settings/organization-plans.component.html
+++ b/src/app/settings/organization-plans.component.html
@@ -54,7 +54,7 @@
                 <small *ngIf="selectableProduct.hasSelfHost">• {{'onPremHostingOptional' | i18n}}</small>
                 <small *ngIf="selectableProduct.hasSso">• {{'includeSsoAuthentication' | i18n}}</small>
                 <small *ngIf="selectableProduct.hasPolicies">• {{'includeEnterprisePolicies' | i18n}}</small>
-                <small *ngIf="selectableProduct.trialPeriodDays">•
+                <small *ngIf="selectableProduct.trialPeriodDays && createOrganization">•
                     {{'xDayFreeTrial' | i18n : selectableProduct.trialPeriodDays }}
                 </small>
             </ng-container>
@@ -79,7 +79,7 @@
                 <small *ngIf="selectableProduct.usersGetPremium">• {{'usersGetPremium' | i18n}}</small>
                 <small *ngIf="selectableProduct.product != productTypes.Free">•
                     {{'priorityCustomerSupport' | i18n}}</small>
-                <small *ngIf="selectableProduct.trialPeriodDays">•
+                <small *ngIf="selectableProduct.trialPeriodDays && createOrganization">•
                     {{'xDayFreeTrial' | i18n : selectableProduct.trialPeriodDays }}
                 </small>
             </ng-template>
@@ -224,12 +224,17 @@
             <p class="text-lg"><strong>{{'total' | i18n}}:</strong>
                 {{total | currency:'USD $'}}/{{selectedPlanInterval | i18n}}</p>
         </div>
-        <small class="text-muted font-italic">{{'paymentChargedWithTrial' | i18n : (selectedPlanInterval | i18n) }}</small>
+        <small class="text-muted font-italic" *ngIf="freeTrial && createOrganization; else paymentChargedImmediately">
+            {{'paymentChargedWithTrial' | i18n : (selectedPlanInterval | i18n) }}
+        </small>
+        <ng-template  #paymentChargedImmediately>
+            <small class="text-muted font-italic mt-2 d-block">
+                {{'paymentCharged' | i18n : (selectedPlanInterval | i18n) }}
+            </small>
+        </ng-template>
         <ng-container *ngIf="!createOrganization">
             <app-payment [showMethods]="false"></app-payment>
         </ng-container>
-        <small class="text-muted font-italic mt-2 d-block" *ngIf="!createOrganization">
-            {{'paymentCharged' | i18n : (selectedPlanInterval | i18n) }}</small>
     </div>
     <div *ngIf="singleOrgPolicyBlock" class="mt-4">
         <app-callout [type]="'error'">{{'singleOrgBlockCreateMessage' | i18n}}</app-callout>

--- a/src/app/settings/organization-plans.component.ts
+++ b/src/app/settings/organization-plans.component.ts
@@ -61,6 +61,7 @@ export class OrganizationPlansComponent implements OnInit {
     productTypes = ProductType;
     formPromise: Promise<any>;
     singleOrgPolicyBlock: boolean = false;
+    freeTrial: boolean = false;
 
     plans: PlanResponse[];
 
@@ -187,6 +188,7 @@ export class OrganizationPlansComponent implements OnInit {
             this.selectedPlan.hasAdditionalSeatsOption) {
             this.additionalSeats = 1;
         }
+        this.freeTrial = this.selectedPlan.trialPeriodDays != null;
     }
 
     changedOwnedBusiness() {


### PR DESCRIPTION
## Objective

The 7 day free trial is only available for new organizations, but we incorrectly state that it is also available when upgrading an existing organization. The template logic is also broken when upgrading, as it displays wording stating that the payment method will be charged after 7 days, but also immediately.

We have discussed extending free trials to existing organizations, but in the meantime I'm pushing this as a quick fix so at least the wording is accurate for the current business logic.