### PR TITLE
Fix "copy link to clipboard" for large file Sends

### DIFF
--- a/src/app/send/add-edit.component.ts
+++ b/src/app/send/add-edit.component.ts
@@ -26,12 +26,12 @@ export class AddEditComponent extends BaseAddEditComponent {
             messagingService, policyService);
     }
 
-    async showSuccessMessage() {
-        if (!this.editMode && this.send.type === SendType.File) {
-            this.platformUtilsService.showDialog(this.i18nService.t('createdSend'), null,
+    async showSuccessMessage(inactive: boolean) {
+        if (inactive && this.copyLink && this.send.type === SendType.File) {
+            await this.platformUtilsService.showDialog(this.i18nService.t('createdSend'), null,
                 this.i18nService.t('ok'), null, 'success', null);
         } else {
-            await super.showSuccessMessage();
+            await super.showSuccessMessage(inactive);
         }
     }
 

--- a/src/app/send/add-edit.component.ts
+++ b/src/app/send/add-edit.component.ts
@@ -11,6 +11,7 @@ import { SendService } from 'jslib/abstractions/send.service';
 import { UserService } from 'jslib/abstractions/user.service';
 
 import { AddEditComponent as BaseAddEditComponent } from 'jslib/angular/components/send/add-edit.component';
+
 import { SendType } from 'jslib/enums/sendType';
 
 @Component({

--- a/src/app/send/add-edit.component.ts
+++ b/src/app/send/add-edit.component.ts
@@ -11,6 +11,7 @@ import { SendService } from 'jslib/abstractions/send.service';
 import { UserService } from 'jslib/abstractions/user.service';
 
 import { AddEditComponent as BaseAddEditComponent } from 'jslib/angular/components/send/add-edit.component';
+import { SendType } from 'jslib/enums/sendType';
 
 @Component({
     selector: 'app-send-add-edit',
@@ -23,6 +24,15 @@ export class AddEditComponent extends BaseAddEditComponent {
         messagingService: MessagingService, policyService: PolicyService) {
         super(i18nService, platformUtilsService, environmentService, datePipe, sendService, userService,
             messagingService, policyService);
+    }
+
+    async showSuccessMessage() {
+        if (!this.editMode && this.send.type === SendType.File) {
+            this.platformUtilsService.showDialog(this.i18nService.t('createdSend'), null,
+                this.i18nService.t('ok'), null, 'success', null);
+        } else {
+            await super.showSuccessMessage();
+        }
     }
 
     copyLinkToClipboard(link: string) {

--- a/src/services/webPlatformUtils.service.ts
+++ b/src/services/webPlatformUtils.service.ts
@@ -245,7 +245,10 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
             textarea.select();
             try {
                 // Security exception may be thrown by some browsers.
-                doc.execCommand('copy');
+                const copyEnabled = doc.execCommand('copy');
+                if (!copyEnabled) {
+                    throw new Error('Command unsupported or disabled');
+                }
             } catch (e) {
                 // tslint:disable-next-line
                 console.warn('Copy to clipboard failed.', e);


### PR DESCRIPTION
## Objective

If a file Send takes more than ~5 seconds to upload, and the user does not interact with the page during this time, then the "copy link to clipboard" functionality does not work. This is because Firefox and Chrome consider the page to be inactive and will not let it access the clipboard (presumably to protect users from unexpected page behaviour).

## Code changes

We now show a popup modal if the Send is a file Send; the user wants to copy the link to clipboard; and the upload has taken longer than 4500ms. Unfortunately this does mean that the behaviour will appear different to the user for no particular reason (i.e. whether they get a toast or popup modal with the success message). However, the alternative would be to use the modal more frequently even if it is not required, which is probably a worse UX impact.

Other notes:

* this issue only affects the web repo, so changes are designed to not impact the other Angular clients.
* `execCommand('copy')` returns `false` if that command is unsupported or disabled. I made this `throw` (within the existing `try/catch` block) to assist any future debugging in this area. Otherwise it just fails silently.
* jslib must be merged first: https://github.com/bitwarden/jslib/pull/362/