### PR TITLE
Change modal-dialog for add-edit cipher to be scrollable

### DIFF
--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -1,5 +1,5 @@
 <div class="modal fade" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="cipherAddEditTitle">
-    <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-dialog modal-dialog-scrollable modal-lg" role="document">
         <form class="modal-content" #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate
             autocomplete="off">
             <div class="modal-header">


### PR DESCRIPTION
## Objective
When an organization has many collections the add-edit page can get out of hand, which results in the save button disappearing from view. To improve the UX I changed the modal-dialog to be scrollable which better informs the user there is more context as well as keeping the save button always visible.

### Code Changes
- **src/app/vault/add-edit.component.html**: Add `modal-dialog-scrollable` to make the modal scrollable.

### Testing Considerations
We should verify it still works nicely on mobile.

### Screenshots
https://user-images.githubusercontent.com/137855/117331549-26d94500-ae97-11eb-9401-ef94e03c3e3e.mp4

