### PR TITLE
Fix typo in webAuthnAuthenticate

### DIFF
--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3832,7 +3832,7 @@
     "message": "To verify your 2FA please click the button below."
   },
   "webAuthnAuthenticate": {
-    "message": "Authenticate WebAutn"
+    "message": "Authenticate WebAuthn"
   },
   "webAuthnNotSupported": {
     "message": "WebAuthn is not supported in this browser."


### PR DESCRIPTION
As reported by a user in Crowdin (https://crowdin.com/translate/bitwarden-browser/26/en-de#4816), the source string had a small typo. This PR fixes it.