### PR TITLE
Add event export

### DIFF
--- a/src/app/organizations/manage/entity-events.component.ts
+++ b/src/app/organizations/manage/entity-events.component.ts
@@ -94,9 +94,9 @@ export class EntityEventsComponent implements OnInit {
         } catch { }
 
         this.continuationToken = response.continuationToken;
-        const events = response.data.map(r => {
+        const events = await Promise.all(response.data.map(async r => {
             const userId = r.actingUserId == null ? r.userId : r.actingUserId;
-            const eventInfo = this.eventService.getEventInfo(r);
+            const eventInfo = await this.eventService.getEventInfo(r);
             const user = this.showUser && userId != null && this.orgUsersUserIdMap.has(userId) ?
                 this.orgUsersUserIdMap.get(userId) : null;
             return {
@@ -110,7 +110,7 @@ export class EntityEventsComponent implements OnInit {
                 ip: r.ipAddress,
                 type: r.type,
             };
-        });
+        }));
 
         if (!clearExisting && this.events != null && this.events.length > 0) {
             this.events = this.events.concat(events);

--- a/src/app/organizations/manage/events.component.html
+++ b/src/app/organizations/manage/events.component.html
@@ -15,6 +15,10 @@
             <i class="fa fa-refresh fa-fw" aria-hidden="true" [ngClass]="{'fa-spin': loaded && refreshBtn.loading}"></i>
             {{'refresh' | i18n}}
         </button>
+        <button #exportBtn [appApiAction]="exportPromise" type="button" class="btn btn-sm btn-outline-primary ml-3"
+            (click)="exportEvents()" [disabled]="loaded && refreshBtn.loading">
+            {{'export' | i18n}}
+        </button>
     </div>
 </div>
 <ng-container *ngIf="!loaded">

--- a/src/app/organizations/manage/events.component.ts
+++ b/src/app/organizations/manage/events.component.ts
@@ -74,11 +74,12 @@ export class EventsComponent implements OnInit {
         }
 
         this.loading = true;
-        try {
-            this.exportPromise = this.exportService.getEventExport(this.events);
-            const data = await this.exportPromise;
+        this.exportPromise = this.exportService.getEventExport(this.events).then(data => {
             const fileName = this.exportService.getFileName('org-events', 'csv');
             this.platformUtilsService.saveFile(window, data, { type: 'text/plain' }, fileName);
+        });
+        try {
+            await this.exportPromise;
         } catch { }
 
         this.exportPromise = null;
@@ -144,9 +145,6 @@ export class EventsComponent implements OnInit {
     }
 
     private appApiPromiseUnfulfilled() {
-        if (this.refreshPromise != null || this.morePromise != null || this.exportPromise != null) {
-            return true;
-        }
-        return false;
+        return this.refreshPromise != null || this.morePromise != null || this.exportPromise != null;
     }
 }

--- a/src/app/services/event.service.ts
+++ b/src/app/services/event.service.ts
@@ -1,15 +1,17 @@
 import { Injectable } from '@angular/core';
 
 import { I18nService } from 'jslib/abstractions/i18n.service';
+import { PolicyService } from 'jslib/abstractions/policy.service';
 
 import { DeviceType } from 'jslib/enums/deviceType';
 import { EventType } from 'jslib/enums/eventType';
+import { PolicyType } from 'jslib/enums/policyType';
 
 import { EventResponse } from 'jslib/models/response/eventResponse';
 
 @Injectable()
 export class EventService {
-    constructor(private i18nService: I18nService) { }
+    constructor(private i18nService: I18nService, private policyService: PolicyService) { }
 
     getDefaultDateFilters() {
         const d = new Date();
@@ -28,146 +30,180 @@ export class EventService {
         return [start.toISOString(), end.toISOString()];
     }
 
-    getEventInfo(ev: EventResponse, options = new EventOptions()): EventInfo {
+    async getEventInfo(ev: EventResponse, options = new EventOptions()): Promise<EventInfo> {
         const appInfo = this.getAppInfo(ev.deviceType);
+        const { message, humanReadableMessage } = await this.getEventMessage(ev, options);
         return {
-            message: this.getEventMessage(ev, options),
+            message: message,
+            humanReadableMessage: humanReadableMessage,
             appIcon: appInfo[0],
             appName: appInfo[1],
         };
     }
 
-    private getEventMessage(ev: EventResponse, options: EventOptions) {
+    private async getEventMessage(ev: EventResponse, options: EventOptions) {
         let msg = '';
+        let humanReadableMsg = '';
         switch (ev.type) {
             // User
             case EventType.User_LoggedIn:
-                msg = this.i18nService.t('loggedIn');
+                msg = humanReadableMsg = this.i18nService.t('loggedIn');
                 break;
             case EventType.User_ChangedPassword:
-                msg = this.i18nService.t('changedPassword');
+                msg = humanReadableMsg = this.i18nService.t('changedPassword');
                 break;
             case EventType.User_Updated2fa:
-                msg = this.i18nService.t('enabledUpdated2fa');
+                msg = humanReadableMsg = this.i18nService.t('enabledUpdated2fa');
                 break;
             case EventType.User_Disabled2fa:
-                msg = this.i18nService.t('disabled2fa');
+                msg = humanReadableMsg = this.i18nService.t('disabled2fa');
                 break;
             case EventType.User_Recovered2fa:
-                msg = this.i18nService.t('recovered2fa');
+                msg = humanReadableMsg = this.i18nService.t('recovered2fa');
                 break;
             case EventType.User_FailedLogIn:
-                msg = this.i18nService.t('failedLogin');
+                msg = humanReadableMsg = this.i18nService.t('failedLogin');
                 break;
             case EventType.User_FailedLogIn2fa:
-                msg = this.i18nService.t('failedLogin2fa');
+                msg = humanReadableMsg = this.i18nService.t('failedLogin2fa');
                 break;
             case EventType.User_ClientExportedVault:
-                msg = this.i18nService.t('exportedVault');
+                msg = humanReadableMsg = this.i18nService.t('exportedVault');
                 break;
             // Cipher
             case EventType.Cipher_Created:
                 msg = this.i18nService.t('createdItemId', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('createdItemId', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_Updated:
                 msg = this.i18nService.t('editedItemId', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('editedItemId', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_Deleted:
                 msg = this.i18nService.t('permanentlyDeletedItemId', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('permanentlyDeletedItemId', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_SoftDeleted:
                 msg = this.i18nService.t('deletedItemId', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('deletedItemId', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_Restored:
                 msg = this.i18nService.t('restoredItemId', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('restoredItemId', this.formatCipherId(ev, options));
                 break;
             case EventType.Cipher_AttachmentCreated:
                 msg = this.i18nService.t('createdAttachmentForItem', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('createdAttachmentForItem', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_AttachmentDeleted:
                 msg = this.i18nService.t('deletedAttachmentForItem', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('deletedAttachmentForItem', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_Shared:
                 msg = this.i18nService.t('sharedItemId', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('sharedItemId', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_ClientViewed:
                 msg = this.i18nService.t('viewedItemId', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('viewedItemId', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_ClientToggledPasswordVisible:
                 msg = this.i18nService.t('viewedPasswordItemId', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('viewedPasswordItemId', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_ClientToggledHiddenFieldVisible:
                 msg = this.i18nService.t('viewedHiddenFieldItemId', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('viewedHiddenFieldItemId', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_ClientToggledCardCodeVisible:
                 msg = this.i18nService.t('viewedSecurityCodeItemId', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('viewedSecurityCodeItemId', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_ClientCopiedHiddenField:
                 msg = this.i18nService.t('copiedHiddenFieldItemId', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('copiedHiddenFieldItemId', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_ClientCopiedPassword:
                 msg = this.i18nService.t('copiedPasswordItemId', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('copiedPasswordItemId', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_ClientCopiedCardCode:
                 msg = this.i18nService.t('copiedSecurityCodeItemId', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('copiedSecurityCodeItemId', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_ClientAutofilled:
                 msg = this.i18nService.t('autofilledItemId', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('autofilledItemId', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_UpdatedCollections:
                 msg = this.i18nService.t('editedCollectionsForItem', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('editedCollectionsForItem', this.getShortId(ev.cipherId));
                 break;
             // Collection
             case EventType.Collection_Created:
                 msg = this.i18nService.t('createdCollectionId', this.formatCollectionId(ev));
+                humanReadableMsg = this.i18nService.t('createdCollectionId', this.getShortId(ev.collectionId));
                 break;
             case EventType.Collection_Updated:
                 msg = this.i18nService.t('editedCollectionId', this.formatCollectionId(ev));
+                humanReadableMsg = this.i18nService.t('editedCollectionId', this.getShortId(ev.collectionId));
                 break;
             case EventType.Collection_Deleted:
                 msg = this.i18nService.t('deletedCollectionId', this.formatCollectionId(ev));
+                humanReadableMsg = this.i18nService.t('deletedCollectionId', this.getShortId(ev.collectionId));
                 break;
             // Group
             case EventType.Group_Created:
                 msg = this.i18nService.t('createdGroupId', this.formatGroupId(ev));
+                humanReadableMsg = this.i18nService.t('createdGroupId', this.getShortId(ev.groupId));
                 break;
             case EventType.Group_Updated:
                 msg = this.i18nService.t('editedGroupId', this.formatGroupId(ev));
+                humanReadableMsg = this.i18nService.t('editedGroupId', this.getShortId(ev.groupId));
                 break;
             case EventType.Group_Deleted:
                 msg = this.i18nService.t('deletedGroupId', this.formatGroupId(ev));
+                humanReadableMsg = this.i18nService.t('deletedGroupId', this.getShortId(ev.groupId));
                 break;
             // Org user
             case EventType.OrganizationUser_Invited:
                 msg = this.i18nService.t('invitedUserId', this.formatOrgUserId(ev));
+                humanReadableMsg = this.i18nService.t('invitedUserId', this.getShortId(ev.organizationUserId));
                 break;
             case EventType.OrganizationUser_Confirmed:
                 msg = this.i18nService.t('confirmedUserId', this.formatOrgUserId(ev));
+                humanReadableMsg = this.i18nService.t('confirmedUserId', this.getShortId(ev.organizationUserId));
                 break;
             case EventType.OrganizationUser_Updated:
                 msg = this.i18nService.t('editedUserId', this.formatOrgUserId(ev));
+                humanReadableMsg = this.i18nService.t('editedUserId', this.getShortId(ev.organizationUserId));
                 break;
             case EventType.OrganizationUser_Removed:
                 msg = this.i18nService.t('removedUserId', this.formatOrgUserId(ev));
+                humanReadableMsg = this.i18nService.t('removedUserId', this.getShortId(ev.organizationUserId));
                 break;
             case EventType.OrganizationUser_UpdatedGroups:
                 msg = this.i18nService.t('editedGroupsForUser', this.formatOrgUserId(ev));
+                humanReadableMsg = this.i18nService.t('editedGroupsForUser', this.getShortId(ev.organizationUserId));
                 break;
             case EventType.OrganizationUser_UnlinkedSso:
                 msg = this.i18nService.t('unlinkedSsoUser', this.formatOrgUserId(ev));
+                humanReadableMsg = this.i18nService.t('unlinkedSsoUser', this.getShortId(ev.organizationUserId));
                 break;
             case EventType.OrganizationUser_ResetPassword_Enroll:
                 msg = this.i18nService.t('eventEnrollPasswordReset', this.formatOrgUserId(ev));
+                humanReadableMsg = this.i18nService.t('eventEnrollPasswordReset', this.getShortId(ev.organizationUserId));
                 break;
             case EventType.OrganizationUser_ResetPassword_Withdraw:
                 msg = this.i18nService.t('eventWithdrawPasswordReset', this.formatOrgUserId(ev));
+                humanReadableMsg = this.i18nService.t('eventWithdrawPasswordReset', this.getShortId(ev.organizationUserId));
                 break;
             // Org
             case EventType.Organization_Updated:
-                msg = this.i18nService.t('editedOrgSettings');
+                msg  = humanReadableMsg = this.i18nService.t('editedOrgSettings');
                 break;
             case EventType.Organization_PurgedVault:
-                msg = this.i18nService.t('purgedOrganizationVault');
+                msg = humanReadableMsg = this.i18nService.t('purgedOrganizationVault');
                 break;
             /*
             case EventType.Organization_ClientExportedVault:
@@ -176,13 +212,25 @@ export class EventService {
             */
             // Policies
             case EventType.Policy_Updated:
-                msg = this.i18nService.t('modifiedPolicy', this.formatPolicyId(ev));
+                msg = this.i18nService.t('modifiedPolicyId', this.formatPolicyId(ev));
+
+                const policies = await this.policyService.getAll();
+                const policy = policies.filter(p => p.id === ev.policyId)[0];
+                let p1 = this.getShortId(ev.policyId);
+                if (policy !== null) {
+                    p1 = PolicyType[policy.type];
+                }
+
+                humanReadableMsg = this.i18nService.t('modifiedPolicyId', p1);
                 break;
 
             default:
                 break;
         }
-        return msg === '' ? null : msg;
+        return {
+            message: msg === '' ? null : msg,
+            humanReadableMessage: humanReadableMsg === '' ? null : humanReadableMsg,
+        };
     }
 
     private getAppInfo(deviceType: DeviceType): [string, string] {
@@ -299,6 +347,7 @@ export class EventService {
 
 export class EventInfo {
     message: string;
+    humanReadableMessage: string;
     appIcon: string;
     appName: string;
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -817,6 +817,9 @@
   "exportMasterPassword": {
     "message": "Enter your master password to export your vault data."
   },
+  "export": {
+    "message": "Export"
+  },
   "exportVault": {
     "message": "Export Vault"
   },


### PR DESCRIPTION
# Overview

Closes https://app.asana.com/0/1199950673439194/1155011472108808/f
Related to bitwarden/jslib#375

Adds the ability to export Organization events to a csv.

# Files Changed
* **entity-events.component.ts**: update eventService call to async
* **event.component.html**: Add export button.
* **events.component.ts**: Add events export and update eventService get event info to async
* **event.service.ts**: Add human readable information to event info. This is to support export since we don't want html in our export CSVs. All things we use html for can be searched for by the `shortId` except Policy. Here we need to convert the policyId to a policy type for the organization. This is done through an async call to policyService, which bubbles the whole thing async up to the component level.


### Requires bitwarden/jslib#375