### PR TITLE
Change WebAuthn connectors to not use inline onclick

### DIFF
--- a/src/connectors/webauthn-fallback.html
+++ b/src/connectors/webauthn-fallback.html
@@ -25,7 +25,7 @@
                         </div>
                         <hr>
                         <p class="text-center mb-0">
-                            <button id="webauthn-button" onClick="javascript:init()" class="btn btn-primary btn-lg"></button>
+                            <button id="webauthn-button" class="btn btn-primary btn-lg"></button>
                         </p>
                     </div>
                 </div>

--- a/src/connectors/webauthn-fallback.ts
+++ b/src/connectors/webauthn-fallback.ts
@@ -19,7 +19,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     document.getElementById('msg').innerText = translate('webAuthnFallbackMsg');
     document.getElementById('remember-label').innerText = translate('rememberMe');
-    document.getElementById('webauthn-button').innerText = translate('webAuthnAuthenticate');
+
+    const button = document.getElementById('webauthn-button');
+    button.innerText = translate('webAuthnAuthenticate');
+    button.onclick = start;
 
     document.getElementById('spinner').classList.add('d-none');
     const content = document.getElementById('content');
@@ -30,10 +33,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 function translate(id: string) {
     return locales[id]?.message || '';
 }
-
-(window as any).init = () => {
-    start();
-};
 
 function start() {
     if (sentSuccess) {

--- a/src/connectors/webauthn.html
+++ b/src/connectors/webauthn.html
@@ -9,7 +9,7 @@
 <body style="background: transparent;">
     <img src="../images/u2fkey.jpg" class="rounded img-fluid mb-3">
     <div class="text-center">
-        <button id="webauthn-button" class="btn btn-primary" onclick="javascript:executeWebAuthn()"></button>
+        <button id="webauthn-button" class="btn btn-primary"></button>
     </div>
 </body>
 

--- a/src/connectors/webauthn.ts
+++ b/src/connectors/webauthn.ts
@@ -9,7 +9,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const text = getQsParam('btnText');
     if (text) {
-        document.getElementById('webauthn-button').innerText = decodeURI(text);
+        const button = document.getElementById('webauthn-button');
+        button.innerText = decodeURI(text);
+        button.onclick = executeWebAuthn;
     }
 });
 
@@ -75,8 +77,6 @@ function executeWebAuthn() {
         .then(success)
         .catch(err => error('WebAuth Error: ' + err));
 }
-
-(window as any).executeWebAuthn = executeWebAuthn;
 
 function onMessage() {
     window.addEventListener('message', event => {


### PR DESCRIPTION
## Objective
The cloud web vault prevents inline js using CSP rules. Which breaks the WebAuthn buttons. To work-around this I set the `onclick` handler in the script files instead.

### Code Changes
- **src/connectors/webauthn(-fallback).html**:  Remove inline `onclick`.
- **src/connectors/webauthn(-fallback).ts**: Set `onclick` handler.