### PR TITLE
Display errors when removing & re-inviting org users

### DIFF
--- a/src/app/organizations/manage/people.component.ts
+++ b/src/app/organizations/manage/people.component.ts
@@ -234,20 +234,29 @@ export class PeopleComponent implements OnInit {
             return false;
         }
 
+        this.actionPromise = this.apiService.deleteOrganizationUser(this.organizationId, user.id);
         try {
-            await this.apiService.deleteOrganizationUser(this.organizationId, user.id);
+            await this.actionPromise;
             this.toasterService.popAsync('success', null, this.i18nService.t('removedUserId', user.name || user.email));
             this.removeUser(user);
-        } catch { }
+        } catch (e) {
+            this.validationService.showError(e);
+        }
+        this.actionPromise = null;
     }
 
     async reinvite(user: OrganizationUserUserDetailsResponse) {
         if (this.actionPromise != null) {
             return;
         }
+
         this.actionPromise = this.apiService.postOrganizationUserReinvite(this.organizationId, user.id);
-        await this.actionPromise;
-        this.toasterService.popAsync('success', null, this.i18nService.t('hasBeenReinvited', user.name || user.email));
+        try {
+            await this.actionPromise;
+            this.toasterService.popAsync('success', null, this.i18nService.t('hasBeenReinvited', user.name || user.email));
+        } catch (e) {
+            this.validationService.showError(e);
+        }
         this.actionPromise = null;
     }
 


### PR DESCRIPTION
## Objective
The UI swallows error messages when we remove or re-invite a user into an org. In other methods we explicitly call validationService.showError`, so I added the same logic to these two functions as well.

### Code Changes
- **src/app/organizations/manage/people.component.ts**: Add catch handler to remove and reinvite.