### PR TITLE
Fix accessibility (a11y) on swal2 modals

### DIFF
--- a/src/services/webPlatformUtils.service.ts
+++ b/src/services/webPlatformUtils.service.ts
@@ -195,9 +195,9 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
             }
         }
 
-        const bootstrapModal = document.querySelector("div.modal");
+        const bootstrapModal = document.querySelector('div.modal');
         if (bootstrapModal != null) {
-            bootstrapModal.removeAttribute("tabindex");
+            bootstrapModal.removeAttribute('tabindex');
         }
 
         const iconHtmlStr = iconClasses != null ? `<i class="swal-custom-icon fa ${iconClasses}"></i>` : undefined;
@@ -216,7 +216,7 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
         });
 
         if (bootstrapModal != null) {
-            bootstrapModal.setAttribute("tabindex", "-1");
+            bootstrapModal.setAttribute('tabindex', '-1');
         }
 
         return confirmed.value;

--- a/src/services/webPlatformUtils.service.ts
+++ b/src/services/webPlatformUtils.service.ts
@@ -195,6 +195,11 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
             }
         }
 
+        const bootstrapModal = document.querySelector("div.modal");
+        if (bootstrapModal != null) {
+            bootstrapModal.removeAttribute("tabindex");
+        }
+
         const iconHtmlStr = iconClasses != null ? `<i class="swal-custom-icon fa ${iconClasses}"></i>` : undefined;
         const confirmed = await Swal.fire({
             heightAuto: false,
@@ -209,6 +214,10 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
             showConfirmButton: true,
             confirmButtonText: confirmText == null ? this.i18nService.t('ok') : confirmText,
         });
+
+        if (bootstrapModal != null) {
+            bootstrapModal.setAttribute("tabindex", "-1");
+        }
 
         return confirmed.value;
     }


### PR DESCRIPTION
## Objective

Fix #948. Keyboard accessibility of swal2 modals is broken when they pop up over the top of bootstrap modals. For example:
* if you edit a folder (opens a bootstrap modal) and you click delete (opens a swal2 modal to confirm)
* if you edit a login item (bootstrap modal) and you try to regenerate the password (opens a swal2 modal to warn about overwriting existing password)

In these situations, the boostrap modal still has keyboard focus, so:
* screenreaders will not read the swal2 modal
* tab will only cycle focus within the bootstrap modal
* hitting the esc key will close out of the boostrap modal and leave the swal2 modal open

## Code changes

* `webPlatformUtils`: before opening a swal2 dialog, remove `tabindex="-1"` from the bootstrap modal (if any). This lets the swal2 modal take focus. Restore `tabindex="-1"` after the swal2 modal is closed so that bootstrap can recapture focus.

I tested this in FF, Safari and Chrome on MacOS; and with NVDA on FF on Windows, and it works consistently.