### PR TITLE
Bulk confirm

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -38,6 +38,7 @@ import { TwoFactorComponent } from './accounts/two-factor.component';
 import { VerifyEmailTokenComponent } from './accounts/verify-email-token.component';
 import { VerifyRecoverDeleteComponent } from './accounts/verify-recover-delete.component';
 
+import { BulkStatusComponent as OrgBulkStatusComponent } from './organizations/manage/bulk-status.component';
 import {
     CollectionAddEditComponent as OrgCollectionAddEditComponent,
 } from './organizations/manage/collection-add-edit.component';
@@ -348,6 +349,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         OrganizationPlansComponent,
         OrganizationSubscriptionComponent,
         OrgAttachmentsComponent,
+        OrgBulkStatusComponent,
         OrgCiphersComponent,
         OrgCollectionAddEditComponent,
         OrgCollectionsComponent,
@@ -447,6 +449,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         ModalComponent,
         OrgAddEditComponent,
         OrgAttachmentsComponent,
+        OrgBulkStatusComponent,
         OrgCollectionAddEditComponent,
         OrgCollectionsComponent,
         OrgEntityEventsComponent,

--- a/src/app/organizations/manage/bulk-status.component.html
+++ b/src/app/organizations/manage/bulk-status.component.html
@@ -10,7 +10,11 @@
                 </button>
             </div>
             <div class="modal-body">
-                <table class="table table-hover table-list">
+                <div class="card-body text-center" *ngIf="loading">
+                    <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
+                    {{'loading' | i18n}}
+                </div>
+                <table class="table table-hover table-list" *ngIf="!loading">
                     <thead>
                         <tr>
                             <th colspan="2">{{'user' | i18n}}</th>

--- a/src/app/organizations/manage/bulk-status.component.html
+++ b/src/app/organizations/manage/bulk-status.component.html
@@ -1,0 +1,43 @@
+<div class="modal fade" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="bulkTitle">
+    <div class="modal-dialog modal-dialog-scrollable modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 class="modal-title" id="bulkTitle">
+                    {{'bulkConfirmStatus' | i18n}}
+                </h2>
+                <button type="button" class="close" data-dismiss="modal" appA11yTitle="{{'close' | i18n}}">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <table class="table table-hover table-list">
+                    <thead>
+                        <tr>
+                            <th colspan="2">{{'user' | i18n}}</th>
+                            <th>{{'status' | i18n}}</th>
+                        </tr>
+                    </thead>
+                    <tr *ngFor="let item of users">
+                        <td width="30">
+                            <app-avatar [data]="item.user.name || item.user.email" [email]="item.user.email" size="25" [circle]="true"
+                                [fontSize]="14"></app-avatar>
+                        </td>
+                        <td>
+                            {{item.user.email}}
+                            <small class="text-muted d-block" *ngIf="item.user.name">{{item.user.name}}</small>
+                        </td>
+                        <td class="text-danger" *ngIf="item.error">
+                            {{item.message}}
+                        </td>
+                        <td *ngIf="!item.error">
+                            {{item.message}}
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">{{'close' | i18n}}</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/organizations/manage/bulk-status.component.ts
+++ b/src/app/organizations/manage/bulk-status.component.ts
@@ -15,5 +15,6 @@ type BulkStatusEntry = {
 export class BulkStatusComponent {
 
     users: BulkStatusEntry[];
+    loading: boolean = false;
 
 }

--- a/src/app/organizations/manage/bulk-status.component.ts
+++ b/src/app/organizations/manage/bulk-status.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+
+import { OrganizationUserUserDetailsResponse } from 'jslib/models/response/organizationUserResponse';
+
+type BulkStatusEntry = {
+    user: OrganizationUserUserDetailsResponse,
+    error: boolean,
+    message: string,
+};
+
+@Component({
+    selector: 'app-bulk-status',
+    templateUrl: 'bulk-status.component.html',
+})
+export class BulkStatusComponent {
+
+    users: BulkStatusEntry[];
+
+}

--- a/src/app/organizations/manage/people.component.html
+++ b/src/app/organizations/manage/people.component.html
@@ -35,6 +35,10 @@
                     <i class="fa fa-fw fa-envelope-o" aria-hidden="true"></i>
                     {{'reinviteSelected' | i18n}}
                 </button>
+                <button class="dropdown-item text-success" appStopClick (click)="bulkConfirm()" *ngIf="showConfirmUsers">
+                    <i class="fa fa-fw fa-check" aria-hidden="true"></i>
+                    {{'confirmSelected' | i18n}}
+                </button>
                 <button class="dropdown-item text-danger" appStopClick (click)="bulkRemove()">
                     <i class="fa fa-fw fa-remove" aria-hidden="true"></i>
                     {{'remove' | i18n}}
@@ -142,3 +146,4 @@
 <ng-template #groupsTemplate></ng-template>
 <ng-template #eventsTemplate></ng-template>
 <ng-template #confirmTemplate></ng-template>
+<ng-template #bulkStatusTemplate></ng-template>

--- a/src/app/organizations/manage/people.component.ts
+++ b/src/app/organizations/manage/people.component.ts
@@ -309,7 +309,7 @@ export class PeopleComponent implements OnInit {
             return;
         }
 
-        
+
         try {
             const request = new OrganizationUserBulkRequest(filteredUsers.map(user => user.id));
             const response = this.apiService.postManyOrganizationUserReinvite(this.organizationId, request);
@@ -487,13 +487,13 @@ export class PeopleComponent implements OnInit {
         if (this.modal) {
             const keyedErrors: any = response.data.filter(r => r.error !== '').reduce((a, x) => ({...a, [x.id]: x.error}), {});
             const keyedFilteredUsers: any = filteredUsers.reduce((a, x) => ({...a, [x.id]: x}), {});
-    
+
             childComponent.users = users.map(user => {
                 let message = keyedErrors[user.id] ?? successfullMessage;
                 if (!keyedFilteredUsers.hasOwnProperty(user.id)) {
                     message = this.i18nService.t('bulkFilteredMessage');
                 }
-    
+
                 return {
                     user: user,
                     error: keyedErrors.hasOwnProperty(user.id),

--- a/src/app/organizations/manage/people.component.ts
+++ b/src/app/organizations/manage/people.component.ts
@@ -288,6 +288,7 @@ export class PeopleComponent implements OnInit {
             const request = new OrganizationUserBulkRequest(users.map(user => user.id));
             const response = this.apiService.deleteManyOrganizationUsers(this.organizationId, request);
             this.showBulkStatus(users, users, response, this.i18nService.t('bulkRemovedMessage'));
+            await response;
             await this.load();
         } catch (e) {
             this.validationService.showError(e);
@@ -371,6 +372,7 @@ export class PeopleComponent implements OnInit {
             const request = new OrganizationUserBulkConfirmRequest(userIdsWithKeys);
             const response = this.apiService.postOrganizationUserBulkConfirm(this.organizationId, request);
             this.showBulkStatus(users, approvedUsers, response, this.i18nService.t('bulkConfirmMessage'));
+            await response;
             await this.load();
         } catch (e) {
             this.validationService.showError(e);

--- a/src/app/organizations/manage/user-confirm.component.ts
+++ b/src/app/organizations/manage/user-confirm.component.ts
@@ -8,11 +8,8 @@ import {
 
 import { ConstantsService } from 'jslib/services/constants.service';
 
-import { ApiService } from 'jslib/abstractions/api.service';
 import { CryptoService } from 'jslib/abstractions/crypto.service';
 import { StorageService } from 'jslib/abstractions/storage.service';
-
-import { Utils } from 'jslib/misc/utils';
 
 @Component({
     selector: 'app-user-confirm',
@@ -23,22 +20,18 @@ export class UserConfirmComponent implements OnInit {
     @Input() userId: string;
     @Input() organizationUserId: string;
     @Input() organizationId: string;
+    @Input() publicKey: Uint8Array;
     @Output() onConfirmedUser = new EventEmitter();
 
     dontAskAgain = false;
     loading = true;
     fingerprint: string;
 
-    private publicKey: Uint8Array = null;
-
-    constructor(private apiService: ApiService, private cryptoService: CryptoService,
-        private storageService: StorageService) { }
+    constructor(private cryptoService: CryptoService, private storageService: StorageService) { }
 
     async ngOnInit() {
         try {
-            const publicKeyResponse = await this.apiService.getUserPublicKey(this.userId);
-            if (publicKeyResponse != null) {
-                this.publicKey = Utils.fromB64ToArray(publicKeyResponse.publicKey);
+            if (this.publicKey != null) {
                 const fingerprint = await this.cryptoService.getFingerprint(this.userId, this.publicKey.buffer);
                 if (fingerprint != null) {
                     this.fingerprint = fingerprint.join('-');
@@ -57,6 +50,6 @@ export class UserConfirmComponent implements OnInit {
             await this.storageService.save(ConstantsService.autoConfirmFingerprints, true);
         }
 
-        this.onConfirmedUser.emit(this.publicKey);
+        this.onConfirmedUser.emit();
     }
 }

--- a/src/app/settings/change-password.component.ts
+++ b/src/app/settings/change-password.component.ts
@@ -201,7 +201,7 @@ export class ChangePasswordComponent extends BaseChangePasswordComponent {
 
         for (const org of orgs) {
             // If not already enrolled, skip
-            if (!org.isResetPasswordEnrolled) {
+            if (!org.resetPasswordEnrolled) {
                 continue;
             }
 

--- a/src/app/settings/organizations.component.ts
+++ b/src/app/settings/organizations.component.ts
@@ -98,7 +98,7 @@ export class OrganizationsComponent implements OnInit {
         let toastStringRef = 'withdrawPasswordResetSuccess';
 
         // Enroll - encrpyt user's encKey.key with organization key
-        if (!org.isResetPasswordEnrolled) {
+        if (!org.resetPasswordEnrolled) {
             const encKey = await this.cryptoService.getEncKey();
             const orgSymKey = await this.cryptoService.getOrgKey(org.id);
             const encryptedKey = await this.cryptoService.encrypt(encKey.key, orgSymKey);

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3911,5 +3911,17 @@
   },
   "usersHasBeenRemoved": {
     "message": "The selected users have been removed."
+  },
+  "confirmSelected": {
+    "message": "Confirm Selected"
+  },
+  "bulkConfirmStatus": {
+    "message": "Bulk action status"
+  },
+  "bulkConfirmMessage": {
+    "message": "Confirmed successfully."
+  },
+  "error": {
+    "message": "Error"
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3903,14 +3903,8 @@
   "noSelectedUsersApplicable": {
     "message": "This action is not applicable to any of the selected users."
   },
-  "usersHasBeenReinvited": {
-    "message": "The selected users have been reinvited."
-  },
   "removeSelectedUsersConfirmation": {
     "message": "Are you sure you want to remove the selected users?"
-  },
-  "usersHasBeenRemoved": {
-    "message": "The selected users have been removed."
   },
   "confirmSelected": {
     "message": "Confirm Selected"
@@ -3921,7 +3915,13 @@
   "bulkConfirmMessage": {
     "message": "Confirmed successfully."
   },
-  "error": {
-    "message": "Error"
+  "bulkReinviteMessage": {
+    "message": "Reinvited successfully."
+  },
+  "bulkRemovedMessage": {
+    "message": "Removed successfully"
+  },
+  "bulkFilteredMessage": {
+    "message": "Excluded, not applicable for this action."
   }
 }


### PR DESCRIPTION
## Objective
Confirming multiple users is currently time consuming and involves multiple steps. I decided to change the behavior slightly for all bulk actions so that they show a confirmed status modal with potential errors.

### Code Changes
- **src/app/organizations/manage/bulk-status.component.{html,ts}**: Added new component for showing the bulk status.
- **src/app/organizations/manage/people.component.html**: Added confirm selected and the new modal.
- **src/app/organizations/manage/people.component.ts**: Add new bulk confirm api. Changed existing bulk apis to show status modal.
- **src/app/organizations/manage/user-confirm.component.ts**: Change user confirm component to get the publickey as an input.

### Testing Considerations
We should do some quick regression testing on regular confirm and verify bulk confirm works with a few scenarios. As well as verifying the status modal behaves correctly for all bulk actions.

### Screenshots

https://user-images.githubusercontent.com/137855/119321013-7af86d80-bc7c-11eb-87e6-c3aa945931a5.mp4

https://user-images.githubusercontent.com/137855/119322146-a92a7d00-bc7d-11eb-9624-fba0315e3a1a.mp4

https://user-images.githubusercontent.com/137855/119322158-ab8cd700-bc7d-11eb-952f-c1b1aeea2974.mp4

Depends on https://github.com/bitwarden/jslib/pull/386
Related: https://github.com/bitwarden/server/pull/1345