### PR TITLE
Fix warnings on webauthn-fallback.ts

### DIFF
--- a/src/connectors/webauthn-fallback.ts
+++ b/src/connectors/webauthn-fallback.ts
@@ -16,8 +16,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     try {
         locales = await loadLocales(locale);
     } catch {
+        // tslint:disable-next-line:no-console
         console.error('Failed to load the locale', locale);
-        locales = await loadLocales('en')
+        locales = await loadLocales('en');
     }
 
     document.getElementById('msg').innerText = translate('webAuthnFallbackMsg');


### PR DESCRIPTION
Add missing semicolon and enable console.error bypass for tslint that were throwing errors in npm