### PR TITLE
adding the self host check back in

### DIFF
--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -145,7 +145,7 @@ export function initFactory(): Function {
     return async () => {
         await (storageService as HtmlStorageService).init();
 
-        if (process.env.ENV !== 'production') {
+        if (process.env.ENV !== 'production' || platformUtilsService.isSelfHost()) {
             environmentService.baseUrl = window.location.origin;
         } else {
             environmentService.notificationsUrl = 'https://notifications.bitwarden.com';


### PR DESCRIPTION
## Summary
As discovered and discussed with @eliykat, in the previous change, the selfhost check was mistakenly taken out of the `services.modules.ts`. This adds the check back in.