### PR TITLE
Additional timeouts for the full working day

### DIFF
--- a/src/app/settings/options.component.ts
+++ b/src/app/settings/options.component.ts
@@ -43,6 +43,8 @@ export class OptionsComponent implements OnInit {
             { name: i18nService.t('thirtyMinutes'), value: 30 },
             { name: i18nService.t('oneHour'), value: 60 },
             { name: i18nService.t('fourHours'), value: 240 },
+            { name: i18nService.t('eightHours'), value: 480 },
+            { name: i18nService.t('twelveHours'), value: 720 },
             { name: i18nService.t('onRefresh'), value: -1 },
         ];
         if (this.platformUtilsService.isDev()) {

--- a/src/app/settings/options.component.ts
+++ b/src/app/settings/options.component.ts
@@ -45,6 +45,7 @@ export class OptionsComponent implements OnInit {
             { name: i18nService.t('fourHours'), value: 240 },
             { name: i18nService.t('eightHours'), value: 480 },
             { name: i18nService.t('twelveHours'), value: 720 },
+            { name: i18nService.t('twentyFourHours'), value: 1440 },
             { name: i18nService.t('onRefresh'), value: -1 },
         ];
         if (this.platformUtilsService.isDev()) {

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -2942,6 +2942,9 @@
   "twelveHours": {
     "message": "12 hours"
   },
+  "twentyFourHours": {
+    "message": "24 hours"
+  },
   "onRefresh": {
     "message": "On Browser Refresh"
   },

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -2936,6 +2936,12 @@
   "fourHours": {
     "message": "4 hours"
   },
+  "eightHours": {
+    "message": "8 hours"
+  },
+  "twelveHours": {
+    "message": "12 hours"
+  },
   "onRefresh": {
     "message": "On Browser Refresh"
   },


### PR DESCRIPTION
In relation to the [Longer Lock Time](https://community.bitwarden.com/t/custom-and-longer-lock-time/77/22) requests that are most recent on the forum

I tested it by setting it to 30 seconds and timing it to ensure it was accurate and I hadn't missed any other configuration

I'm looking into the custom option people have been requesting but I feel it's worthwhile merging this in the interim as it will take me a few weeks to get the custom one working properly 😊