### PR TITLE
Add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
         with:
           ref: rc
 
@@ -36,7 +36,7 @@ jobs:
           fi
 
       - name: Deploy GitHub Pages
-        uses: crazy-max/ghaction-github-pages@db4476a01402e1a7ce05f41832040eef16d14925  # 2.5.0
+        uses: crazy-max/ghaction-github-pages@db4476a01402e1a7ce05f41832040eef16d14925  # v2.5.0
         with:
           target_branch: gh-pages
           build_dir: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: Deploy
+
+on: 
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Release Tag Version <vX.X.X>"
+        required: true
+  release:
+    types:
+      - published
+
+
+jobs:
+  deploy:
+    name: Deploy Web Vault
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          ref: rc
+
+      - name: Install and Build
+        run: |
+          npm install
+          npm run dist
+
+      - name: Get release version
+        id: release-version
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+              echo "::set-output name=version::${{ github.event.release.tag_name }}"
+          else
+              echo "::set-output name=version::${{ github.event.inputs.release_version }}"
+          fi
+
+      - name: Deploy GitHub Pages
+        uses: crazy-max/ghaction-github-pages@db4476a01402e1a7ce05f41832040eef16d14925  # 2.5.0
+        with:
+          target_branch: gh-pages
+          build_dir: build
+          keep_history: true
+          commit_message: "Deploying ${{ steps.release-version.outputs.version }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
With one of the last Web client releases, there was an outage when the process stopped halfway through the build. Automating the process will help prevent outages like this in the future.

The new deploy workflow can be triggered in two ways: 1) draft release being published, or 2) manual trigger with release tag version. The publish trigger works like most of the other clients. As soon as you publish the release with the release notes, that pipeline is triggered to deploy the site. For some reason, if the deploy workflow fails, the manual trigger is there as a back up so that we can deploy an already released version (more like the current contents of `rc`). 

## Notes
- The release/deploy flow has been fully tested on a personal repository