### PR TITLE
Convert sets to arrays before saving to storage

### DIFF
--- a/src/services/htmlStorage.service.ts
+++ b/src/services/htmlStorage.service.ts
@@ -49,6 +49,10 @@ export class HtmlStorageService implements StorageService {
             return this.remove(key);
         }
 
+        if (obj instanceof Set) {
+            obj = Array.from(obj);
+        }
+
         const json = JSON.stringify(obj);
         if (this.isLocalStorage(key)) {
             window.localStorage.setItem(key, json);


### PR DESCRIPTION
## Objective
Fix #1005, which was the web version of https://github.com/bitwarden/desktop/issues/894.

The problem is caused by the fact that sets are not serializable, so they get saved as an empty object `{}`, which throws an error when fed to the Set constructor on loading.

## Code changes
Convert sets to arrays before saving in localStorage. Same fix as the desktop version.