### PR TITLE
Fix deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,14 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
-          ref: rc
-
-      - name: Install and Build
-        run: |
-          npm install
-          npm run dist
+          ref: gh-pages
 
       - name: Get release version
         id: release-version
@@ -35,12 +30,41 @@ jobs:
               echo "::set-output name=version::${{ github.event.inputs.release_version }}"
           fi
 
-      - name: Deploy GitHub Pages
-        uses: crazy-max/ghaction-github-pages@db4476a01402e1a7ce05f41832040eef16d14925  # v2.5.0
+      - name: Create deploy branch
+        run: |
+          git switch -c deploy-${{ steps.release-version.outputs.version }}
+          git push -u origin deploy-${{ steps.release-version.outputs.version }}
+
+      - name: Checkout Repo
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
-          target_branch: gh-pages
+          ref: rc
+
+      - name: setup git config
+        run: |
+          git config user.name = "GitHub Action Bot"
+          git config user.email = "<>"
+
+      - name: Install and Build
+        run: |
+          npm install
+          npm run dist
+
+      - name: Deploy GitHub Pages
+        uses: crazy-max/ghaction-github-pages@db4476a01402e1a7ce05f41832040eef16d14925  # 2.5.0
+        with:
+          target_branch: deploy-${{ steps.release-version.outputs.version }}
           build_dir: build
           keep_history: true
-          commit_message: "Deploying ${{ steps.release-version.outputs.version }}"
+          commit_message: "Staging deploy ${{ steps.release-version.outputs.version }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Deploy PR
+        run: |
+          gh pr create --title "Deploy $VERSION" --body "Deploying $VERSION" --base gh-pages --head "$PR_BRANCH"
+        env:
+          VERSION: ${{ steps.release-version.outputs.version }}
+          PR_BRANCH: deploy-${{ steps.release-version.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
         with:
           ref: gh-pages
 
@@ -36,7 +36,7 @@ jobs:
           git push -u origin deploy-${{ steps.release-version.outputs.version }}
 
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
         with:
           ref: rc
 
@@ -51,7 +51,7 @@ jobs:
           npm run dist
 
       - name: Deploy GitHub Pages
-        uses: crazy-max/ghaction-github-pages@db4476a01402e1a7ce05f41832040eef16d14925  # 2.5.0
+        uses: crazy-max/ghaction-github-pages@db4476a01402e1a7ce05f41832040eef16d14925  # v2.5.0
         with:
           target_branch: deploy-${{ steps.release-version.outputs.version }}
           build_dir: build


### PR DESCRIPTION
## Summary
I didn't catch that the `gh-pages` branch was a protected branch. The last attempt to automate the web deploy errored out when trying to push to that protected branch. 

This fix changes the process a bit and adds a final step that requires a collaborator to go and approve and merge a PR that is automatically created.