### PR TITLE
Fix #1020 - XSS via innerHTML property

### DIFF
--- a/src/connectors/webauthn-fallback.ts
+++ b/src/connectors/webauthn-fallback.ts
@@ -104,7 +104,7 @@ async function initWebAuthn(obj: any) {
 function error(message: string) {
     const el = document.getElementById('msg');
     resetMsgBox(el);
-    el.innerHTML = message;
+    el.textContent = message;
     el.classList.add('alert');
     el.classList.add('alert-danger');
 }
@@ -114,7 +114,7 @@ function success(message: string) {
 
     const el = document.getElementById('msg');
     resetMsgBox(el);
-    el.innerHTML = message;
+    el.textContent = message;
     el.classList.add('alert');
     el.classList.add('alert-success');
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3844,7 +3844,7 @@
     "message": "WebAuthn is not supported in this browser."
   },
   "webAuthnSuccess": {
-    "message": "<strong>WebAuthn verified successfully!</strong><br>You may close this tab."
+    "message": "WebAuthn verified successfully! You may close this tab."
   },
   "hintEqualsPassword": {
     "message": "Your password hint cannot be the same as your password."


### PR DESCRIPTION
Closes #1020 

## Overview

While an extremely low risk, it's best practice to not use `.innerHTML` for assignment of values dynamically or coming from unknown origins, in this case within a method where the caller may not be known (OOP concept of encapsulation). It would also appear that in this instance this method is only called in exactly 1 place so if we need special handling of HTML in the future here (e.g. this change isn't entirely _correct_) then we can split the message up and handle it accordingly.

* **webauthn-fallback.ts ** - Assign values to `. textContent` instead of `.innerHTML` to remove the possibility of injecting `<script/>` or other XSS techniques.
* **en/messages.json** - Removed the HTML from the translation string. It may not look as pretty on-screen, but for now changes the only translation string that contained markup to no longer contain markup.