### PR TITLE
Colorful event icons

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -4,5 +4,6 @@
     "proxyEvents": "http://localhost:46273",
     "proxyNotifications": "http://localhost:61840",
     "proxyPortal": "http://localhost:52313",
+    "proxyIcons": "http://localhost:50024",
     "allowedHosts": []
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -15,6 +15,7 @@ import { AppComponent } from './app.component';
 import { ModalComponent } from './modal.component';
 
 import { AvatarComponent } from './components/avatar.component';
+import { EventIconComponent } from './components/eventIcon.component';
 import { PasswordStrengthComponent } from './components/password-strength.component';
 
 import { FooterComponent } from './layouts/footer.component';
@@ -325,6 +326,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         EmergencyAccessViewComponent,
         EmergencyAddEditComponent,
         ExportComponent,
+        EventIconComponent,
         ExposedPasswordsReportComponent,
         FallbackSrcDirective,
         FolderAddEditComponent,

--- a/src/app/components/eventIcon.component.html
+++ b/src/app/components/eventIcon.component.html
@@ -1,0 +1,4 @@
+<div class="icon" aria-hidden="true">
+    <img [src]="image" appFallbackSrc="images/fa-globe" *ngIf="imageEnabled && image" alt="" />
+    <i class="text-muted fa fa-lg {{fallbackIcon}}" *ngIf="!imageEnabled || !image"></i>
+</div>

--- a/src/app/components/eventIcon.component.ts
+++ b/src/app/components/eventIcon.component.ts
@@ -1,0 +1,102 @@
+import {
+    Component,
+    Input,
+    OnChanges,
+} from '@angular/core';
+
+import { EnvironmentService } from 'jslib/abstractions/environment.service';
+import { StateService } from 'jslib/abstractions/state.service';
+
+import { ConstantsService } from 'jslib/services/constants.service';
+
+import { DeviceType } from 'jslib/enums';
+import { Utils } from 'jslib/misc/utils';
+
+@Component({
+    selector: 'app-events-icon',
+    templateUrl: 'eventIcon.component.html',
+})
+export class EventIconComponent implements OnChanges {
+    @Input() deviceType: DeviceType;
+    @Input() fallbackIcon: string;
+    image: string;
+    imageEnabled: boolean;
+
+    private iconsUrl: string;
+
+    constructor(environmentService: EnvironmentService, protected stateService: StateService) {
+        this.iconsUrl = environmentService.iconsUrl;
+        if (!this.iconsUrl) {
+            if (environmentService.baseUrl) {
+                this.iconsUrl = environmentService.baseUrl + '/icons';
+            } else {
+                this.iconsUrl = 'https://icons.bitwarden.net';
+            }
+        }
+    }
+
+    async ngOnChanges() {
+        this.imageEnabled = !(await this.stateService.get<boolean>(ConstantsService.disableFaviconKey));
+        this.load();
+    }
+
+    protected load() {
+        switch (this.deviceType) {
+            case DeviceType.ChromeExtension:
+            case DeviceType.ChromeBrowser:
+                this.setLoginIcon('chrome.com');
+                break;
+            case DeviceType.FirefoxExtension:
+            case DeviceType.FirefoxBrowser:
+                this.setLoginIcon('firefox.com');
+                break;
+            case DeviceType.OperaExtension:
+            case DeviceType.OperaBrowser:
+                this.setLoginIcon('opera.com');
+                break;
+            case DeviceType.EdgeExtension:
+            case DeviceType.WindowsDesktop:
+            case DeviceType.EdgeBrowser:
+            case DeviceType.IEBrowser:
+                this.setLoginIcon('microsoft.com');
+                break;
+            case DeviceType.VivaldiExtension:
+            case DeviceType.VivaldiBrowser:
+                this.setLoginIcon('vivaldi.com');
+                break;
+            case DeviceType.SafariExtension:
+            case DeviceType.MacOsDesktop:
+            case DeviceType.SafariBrowser:
+                this.setLoginIcon('apple.com');
+                break;
+            case DeviceType.Android:
+            case DeviceType.iOS:
+            case DeviceType.UWP:
+            case DeviceType.LinuxDesktop:
+            case DeviceType.UnknownBrowser:
+            default:
+                return;
+        }
+    }
+
+    private setLoginIcon(hostnameUri: string) {
+        if (hostnameUri) {
+            let isWebsite = false;
+
+            if (this.imageEnabled && hostnameUri.indexOf('://') === -1 && hostnameUri.indexOf('.') > -1) {
+                hostnameUri = 'http://' + hostnameUri;
+                isWebsite = true;
+            } else if (this.imageEnabled) {
+                isWebsite = hostnameUri.indexOf('http') === 0 && hostnameUri.indexOf('.') > -1;
+            }
+
+            if (this.imageEnabled && isWebsite) {
+                try {
+                    this.image = this.iconsUrl + '/' + Utils.getHostname(hostnameUri) + '/icon.png';
+                } catch (e) { }
+            }
+        } else {
+            this.image = null;
+        }
+    }
+}

--- a/src/app/organizations/manage/events.component.html
+++ b/src/app/organizations/manage/events.component.html
@@ -27,7 +27,7 @@
 </ng-container>
 <ng-container *ngIf="loaded">
     <p *ngIf="!events || !events.length">{{'noEventsInList' | i18n}}</p>
-    <table class="table table-hover" *ngIf="events && events.length">
+    <table class="table table-hover table-list" *ngIf="events && events.length">
         <thead>
             <tr>
                 <th class="border-top-0" width="210">{{'timestamp' | i18n}}</th>
@@ -41,8 +41,8 @@
         <tbody>
             <tr *ngFor="let e of events">
                 <td>{{e.date | date:'medium'}}</td>
-                <td>
-                    <i class="text-muted fa fa-lg {{e.appIcon}}" title="{{e.appName}}, {{e.ip}}" aria-hidden="true"></i>
+                <td class="table-list-icon">
+                    <app-events-icon [fallbackIcon]="e.appIcon" [deviceType]="e.deviceType"></app-events-icon>
                     <span class="sr-only">{{e.appName}}, {{e.ip}}</span>
                 </td>
                 <td>

--- a/src/app/organizations/manage/events.component.ts
+++ b/src/app/organizations/manage/events.component.ts
@@ -124,6 +124,7 @@ export class EventsComponent implements OnInit {
                 humanReadableMessage: eventInfo.humanReadableMessage,
                 appIcon: eventInfo.appIcon,
                 appName: eventInfo.appName,
+                deviceType: eventInfo.deviceType,
                 userId: userId,
                 userName: user != null ? user.name : this.i18nService.t('unknown'),
                 userEmail: user != null ? user.email : '',

--- a/src/app/services/event.service.ts
+++ b/src/app/services/event.service.ts
@@ -37,6 +37,7 @@ export class EventService {
             message: message,
             humanReadableMessage: humanReadableMessage,
             appIcon: appInfo[0],
+            deviceType: ev.deviceType,
             appName: appInfo[1],
         };
     }
@@ -353,6 +354,7 @@ export class EventInfo {
     message: string;
     humanReadableMessage: string;
     appIcon: string;
+    deviceType: DeviceType;
     appName: string;
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -180,7 +180,13 @@ const devServer = {
             pathRewrite: {'^/portal' : ''},
             secure: false,
             changeOrigin: true
-        }
+        },
+        '/icons': {
+            target: envConfig['proxyIcons'],
+            pathRewrite: { '^/icons': '' },
+            secure: false,
+            changeOrigin: true
+        },
     },
     hot: false,
     allowedHosts: envConfig['allowedHosts']


### PR DESCRIPTION
# Overview

Related to bitwarden/jslib#406.

Events all use [FontAwesome brand icons](https://www.w3schools.com/icons/fontawesome_icons_brand.asp), which are all monochrome. We already have infrastructure in place to grab favicons for websites, which tend to be brand icons.

This PR uses specifies certain icons to pull from icon service for various device types.

## Alternatives

Alternatively, we could just save the relevant icons to the `images` folder. I went this route for two reasons
1. The icons will automatically update should any branding change
2. I'm not sure how legal it is to include trademarked images we don't own in our source code.

# Files Changed
* **base.json/webpack.config.js**: Add reverse proxy for icon service. This allow for local testing of icon server.
* **app.module.ts**: Register the eventIcon component
* **eventIcon.component.html**: Display downloaded favicon, fallback to the `fa-brand` icon we are currently using.
  > Note: Icons service already has a fallback to `fa-globe` so that's what gets shown unless there's a local error. This icon also has a pretty low resolution
* **eventIcon.component.ts**: This is really just switch logic to load the appropriate website's favicon.
  * I couldn't find sites with icons for products which are part of a larger ecosystem
    * Microsoft: edge, IE, and windows desktop just display as windows logo
    * Apple: Safari and apple desktop display as apple logo
    * If we find good sites for these favicons or build something into server to server them, we can update this switch statement easily with the appropriate calls
* **events.component.html**: use the eventIcon component. Make sure the icon has the appropriate sizing
* **events.component.ts/event.service.ts**: Provide device type to eventIcon

# Screenshots

### Color Icons
![image](https://user-images.githubusercontent.com/18214891/121420879-2ff48080-c933-11eb-99a1-14a510037139.png)

### `fa-globe` Low resolution from Icons server
![image](https://user-images.githubusercontent.com/18214891/121420946-44387d80-c933-11eb-9acb-7853f612421a.png)

# Draft Reason

Waiting on bitwarden/jslib#406