### PR TITLE
Add bump-jslib Github action

### DIFF
--- a/.github/workflows/bump-jslib.yml
+++ b/.github/workflows/bump-jslib.yml
@@ -80,11 +80,10 @@ jobs:
             gh pr create --title "Auto bump jslib" \
               --body "$BODY_TEXT" \
               --reviewer eliykat
-            
             echo "[*] Submitted PR against master branch"
           else
-            gh pr comment \
-              --body "$BODY_TEXT"
+            gh pr comment --body "$BODY_TEXT"
+            echo "[*] Updated existing PR"
           fi
         env:
           GIT_LOG: ${{ steps.bump.outputs.git-log }}

--- a/.github/workflows/bump-jslib.yml
+++ b/.github/workflows/bump-jslib.yml
@@ -1,0 +1,74 @@
+name: Bump jslib
+
+on:
+  workflow_dispatch:
+
+jobs:
+  bump-jslib:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Setup git config
+        run: |
+          git config user.name = "GitHub Action Bot"
+          git config user.email = "<>"
+
+      - name: Bump jslib and commit
+        id: bump
+        run: |
+          TARGET_BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          NEW_BRANCH_NAME="auto-bump-jslib"
+
+          if [ "$TARGET_BRANCH_NAME" = "master" ]; then
+            git checkout -b $NEW_BRANCH_NAME
+            echo "[*] Checked out new branch $NEW_BRANCH_NAME"
+          fi
+
+          npm run sub:init
+          OLD_JSLIB_HASH=`git submodule status | awk '{print $1}'`
+
+          npm run sub:update
+
+          if [ `git diff --quiet jslib` ]; then
+            echo "Unable to bump jslib: branch $TARGET_BRANCH_NAME is already using the latest jslib commit."
+            exit 1
+          fi
+
+          git add jslib
+          git commit -m "bump jslib"
+
+          NEW_JSLIB_HASH=`git submodule status | awk '{print $1}'`
+          echo "[*] Bumped jslib to $NEW_JSLIB_HASH"
+
+          if [ "$TARGET_BRANCH_NAME" = "master" ]; then
+            git push -u origin $NEW_BRANCH_NAME
+            echo "[*] Pushed to $NEW_BRANCH_NAME"
+          else
+            git push origin $TARGET_BRANCH_NAME
+            echo "[*] Pushed to $TARGET_BRANCH_NAME"
+          fi
+
+          cd jslib
+          GIT_LOG=`git log $OLD_JSLIB_HASH..$NEW_JSLIB_HASH --oneline`
+          
+          echo "::set-output name=target-branch-name::${TARGET_BRANCH_NAME}"
+          echo "::set-output name=new-branch-name::${NEW_BRANCH_NAME}"
+          echo "::set-output name=git-log::${GIT_LOG}"
+
+      - name: Submit PR against master branch
+        if: github.ref == 'refs/heads/master'
+        run: |
+          gh pr create --title "Auto bump jslib" \
+            --body "@${{github.actor}} would like to bump jslib in this repo. This will pull in the following new commits:
+              
+            $GIT_LOG" \
+            --reviewer eliykat
+          
+          echo "[*] Submitted PR against master branch"
+        env:
+          GIT_LOG: ${{ steps.bump.outputs.git-log }}
+          TARGET_BRANCH_NAME: ${{ steps.bump.outputs.target-branch-name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump-jslib.yml
+++ b/.github/workflows/bump-jslib.yml
@@ -19,12 +19,23 @@ jobs:
       - name: Bump jslib and commit
         id: bump
         run: |
-          TARGET_BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
-          NEW_BRANCH_NAME="auto-bump-jslib"
+          CHECKED_OUT_BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
 
-          if [ "$TARGET_BRANCH_NAME" = "master" ]; then
-            git checkout -b $NEW_BRANCH_NAME
-            echo "[*] Checked out new branch $NEW_BRANCH_NAME"
+          if [ "$CHECKED_OUT_BRANCH_NAME" = "master" ]; then
+            TARGET_BRANCH_NAME="auto-bump-jslib"
+            git fetch origin
+            EXISTING_PR=`git ls-remote --heads origin $TARGET_BRANCH_NAME | wc -l`
+            if [ "$EXISTING_PR" -gt 0 ]; then
+              git checkout $TARGET_BRANCH_NAME
+              echo "[*] Checked out existing PR branch $TARGET_BRANCH_NAME"
+            else
+              git checkout -b $TARGET_BRANCH_NAME
+              echo "[*] Checked out new branch $TARGET_BRANCH_NAME"
+            fi
+          else
+            TARGET_BRANCH_NAME="$CHECKED_OUT_BRANCH_NAME"
+            EXISTING_PR=0
+            echo "[*] Running on existing feature branch $TARGET_BRANCH_NAME"
           fi
 
           npm run sub:init
@@ -32,43 +43,50 @@ jobs:
 
           npm run sub:update
 
-          if [ `git diff --quiet jslib` ]; then
+          if [ `git diff jslib | wc -l` -eq 0 ]; then
             echo "Unable to bump jslib: branch $TARGET_BRANCH_NAME is already using the latest jslib commit."
+            if [ "$EXISTING_PR" -gt 0 ]; then
+              echo "Try merging the $TARGET_BRANCH_NAME branch into master first."
+            fi
             exit 1
           fi
 
           git add jslib
-          git commit -m "bump jslib"
+          git commit -m "Bump jslib"
 
           NEW_JSLIB_HASH=`git submodule status | awk '{print $1}'`
           echo "[*] Bumped jslib to $NEW_JSLIB_HASH"
 
-          if [ "$TARGET_BRANCH_NAME" = "master" ]; then
-            git push -u origin $NEW_BRANCH_NAME
-            echo "[*] Pushed to $NEW_BRANCH_NAME"
+          if [ "$EXISTING_PR" -eq 0 ]; then
+            git push -u origin $TARGET_BRANCH_NAME
           else
             git push origin $TARGET_BRANCH_NAME
-            echo "[*] Pushed to $TARGET_BRANCH_NAME"
           fi
+          echo "[*] Pushed to $TARGET_BRANCH_NAME"
 
           cd jslib
-          GIT_LOG=`git log $OLD_JSLIB_HASH..$NEW_JSLIB_HASH --oneline`
+          GIT_LOG=`git log $OLD_JSLIB_HASH..$NEW_JSLIB_HASH --oneline | sed 's/^/* /g' | sed 's/#[0-9]*[)]/bitwarden\/jslib&/g'`
           
-          echo "::set-output name=target-branch-name::${TARGET_BRANCH_NAME}"
-          echo "::set-output name=new-branch-name::${NEW_BRANCH_NAME}"
           echo "::set-output name=git-log::${GIT_LOG}"
+          echo "::set-output name=existing-pr::${EXISTING_PR}"
 
-      - name: Submit PR against master branch
+      - name: Submit or update PR against master branch
         if: github.ref == 'refs/heads/master'
         run: |
-          gh pr create --title "Auto bump jslib" \
-            --body "@${{github.actor}} would like to bump jslib in this repo. This will pull in the following new commits:
-              
-            $GIT_LOG" \
-            --reviewer eliykat
-          
-          echo "[*] Submitted PR against master branch"
+          BODY_TEXT="@${{github.actor}} would like to bump jslib in this repo. This will pull in the following new commits:
+          $GIT_LOG"
+
+          if [ "$EXISTING_PR" -eq 0 ]; then
+            gh pr create --title "Auto bump jslib" \
+              --body "$BODY_TEXT" \
+              --reviewer eliykat
+            
+            echo "[*] Submitted PR against master branch"
+          else
+            gh pr comment \
+              --body "$BODY_TEXT"
+          fi
         env:
           GIT_LOG: ${{ steps.bump.outputs.git-log }}
-          TARGET_BRANCH_NAME: ${{ steps.bump.outputs.target-branch-name }}
+          EXISTING_PR: ${{ steps.bump.outputs.existing-pr }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Objective

As discussed in Slack, add a new Github action that lets us bump jslib without having to dive into the command line.

Behaviour:
* must be manually triggered from the "Actions" tab
* if run against master, it will create a new branch, bump jslib on that branch, and submit a PR against master (or update the existing PR if there's already one pending)
* if run against a feature branch, it will bump jslib on that branch and take no further action

## To do

* Permissions should be set so that only Bitwarden org members can run it - @joseph-flinn how does this work?
* Currently it's got me marked as the reviewer so that we don't spam the team with review requests while testing. This will need to be changed back to `bitwarden/dept-engineering` once we're happy with it.
* Once it's finalised, add to all other repos as well.

@joseph-flinn Thanks for your help with this, please feel free to push to this branch if you want to make any changes yourself, or leave any feedback and I'll make them. 