### PR TITLE
Refactor accept-organization and accept-emergency

### DIFF
--- a/src/app/accounts/accept-emergency.component.ts
+++ b/src/app/accounts/accept-emergency.component.ts
@@ -24,7 +24,7 @@ export class AcceptEmergencyComponent extends BaseAcceptComponent {
 
     name: string;
 
-    protected requiredParameters: string[] = ['name', 'email', 'token'];
+    protected requiredParameters: string[] = ['id', 'name', 'email', 'token'];
     protected failedShortMessage = 'emergencyInviteAcceptFailedShort';
     protected failedMessage = 'emergencyInviteAcceptFailed';
 

--- a/src/app/accounts/accept-emergency.component.ts
+++ b/src/app/accounts/accept-emergency.component.ts
@@ -1,7 +1,4 @@
-import {
-    Component,
-    OnInit,
-} from '@angular/core';
+import { Component } from '@angular/core';
 import {
     ActivatedRoute,
     Router,
@@ -17,77 +14,47 @@ import { I18nService } from 'jslib-common/abstractions/i18n.service';
 import { StateService } from 'jslib-common/abstractions/state.service';
 import { UserService } from 'jslib-common/abstractions/user.service';
 import { EmergencyAccessAcceptRequest } from 'jslib-common/models/request/emergencyAccessAcceptRequest';
+import { BaseAcceptComponent } from '../common/base.accept.component';
 
 @Component({
     selector: 'app-accept-emergency',
     templateUrl: 'accept-emergency.component.html',
 })
-export class AcceptEmergencyComponent implements OnInit {
-    loading = true;
-    authed = false;
+export class AcceptEmergencyComponent extends BaseAcceptComponent {
+
     name: string;
-    email: string;
-    actionPromise: Promise<any>;
 
-    constructor(private router: Router, private toasterService: ToasterService,
-        private i18nService: I18nService, private route: ActivatedRoute,
-        private apiService: ApiService, private userService: UserService,
-        private stateService: StateService) { }
+    protected requiredParameters: string[] = ['name', 'email', 'token'];
+    protected failedShortMessage = 'emergencyInviteAcceptFailedShort';
+    protected failedMessage = 'emergencyInviteAcceptFailed';
 
-    ngOnInit() {
-        let fired = false;
-        this.route.queryParams.subscribe(async qParams => {
-            if (fired) {
-                return;
-            }
-            fired = true;
-            await this.stateService.remove('emergencyInvitation');
-            let error = qParams.id == null || qParams.name == null || qParams.email == null || qParams.token == null;
-            let errorMessage: string = null;
-            if (!error) {
-                this.authed = await this.userService.isAuthenticated();
-                if (this.authed) {
-                    const request = new EmergencyAccessAcceptRequest();
-                    request.token = qParams.token;
-                    try {
-                        this.actionPromise = this.apiService.postEmergencyAccessAccept(qParams.id, request);
-                        await this.actionPromise;
-                        const toast: Toast = {
-                            type: 'success',
-                            title: this.i18nService.t('inviteAccepted'),
-                            body: this.i18nService.t('emergencyInviteAcceptedDesc'),
-                            timeout: 10000,
-                        };
-                        this.toasterService.popAsync(toast);
-                        this.router.navigate(['/vault']);
-                    } catch (e) {
-                        error = true;
-                        errorMessage = e.message;
-                    }
-                } else {
-                    await this.stateService.save('emergencyInvitation', qParams);
-                    this.email = qParams.email;
-                    this.name = qParams.name;
-                    if (this.name != null) {
-                        // Fix URL encoding of space issue with Angular
-                        this.name = this.name.replace(/\+/g, ' ');
-                    }
-                }
-            }
+    constructor(router: Router, toasterService: ToasterService,
+        i18nService: I18nService, route: ActivatedRoute,
+        private apiService: ApiService, userService: UserService,
+        stateService: StateService) {
+        super(router, toasterService, i18nService, route, userService, stateService);
+    }
 
-            if (error) {
-                const toast: Toast = {
-                    type: 'error',
-                    title: null,
-                    body: errorMessage != null ? this.i18nService.t('emergencyInviteAcceptFailedShort', errorMessage) :
-                        this.i18nService.t('emergencyInviteAcceptFailed'),
-                    timeout: 10000,
-                };
-                this.toasterService.popAsync(toast);
-                this.router.navigate(['/']);
-            }
+    async authedHandler(qParams: any): Promise<void> {
+        const request = new EmergencyAccessAcceptRequest();
+        request.token = qParams.token;
+        this.actionPromise = this.apiService.postEmergencyAccessAccept(qParams.id, request);
+        await this.actionPromise;
+        const toast: Toast = {
+            type: 'success',
+            title: this.i18nService.t('inviteAccepted'),
+            body: this.i18nService.t('emergencyInviteAcceptedDesc'),
+            timeout: 10000,
+        };
+        this.toasterService.popAsync(toast);
+        this.router.navigate(['/vault']);
+    }
 
-            this.loading = false;
-        });
+    async unauthedHandler(qParams: any): Promise<void> {
+        this.name = qParams.name;
+        if (this.name != null) {
+            // Fix URL encoding of space issue with Angular
+            this.name = this.name.replace(/\+/g, ' ');
+        }
     }
 }

--- a/src/app/accounts/login.component.ts
+++ b/src/app/accounts/login.component.ts
@@ -76,20 +76,12 @@ export class LoginComponent extends BaseLoginComponent {
     }
 
     async goAfterLogIn() {
-        const orgInvite = await this.stateService.get<any>('orgInvitation');
-        const emergencyInvite = await this.stateService.get<any>('emergencyInvitation');
-        if (orgInvite != null) {
-            this.router.navigate(['accept-organization'], { queryParams: orgInvite });
-        } else if (emergencyInvite != null) {
-            this.router.navigate(['accept-emergency'], { queryParams: emergencyInvite });
+        const loginRedirect = await this.stateService.get<any>('loginRedirect');
+        if (loginRedirect != null) {
+            this.router.navigate([loginRedirect.route], { queryParams: loginRedirect.qParams });
+            await this.stateService.remove('loginRedirect');
         } else {
-            const loginRedirect = await this.stateService.get<any>('loginRedirect');
-            if (loginRedirect != null) {
-                this.router.navigate([loginRedirect.route], { queryParams: loginRedirect.qParams });
-                await this.stateService.remove('loginRedirect');
-            } else {
-                this.router.navigate([this.successRoute]);
-            }
+            this.router.navigate([this.successRoute]);
         }
     }
 }

--- a/src/app/accounts/two-factor.component.ts
+++ b/src/app/accounts/two-factor.component.ts
@@ -60,24 +60,16 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
     }
 
     async goAfterLogIn() {
-        const orgInvite = await this.stateService.get<any>('orgInvitation');
-        const emergencyInvite = await this.stateService.get<any>('emergencyInvitation');
-        if (orgInvite != null) {
-            this.router.navigate(['accept-organization'], { queryParams: orgInvite });
-        } else if (emergencyInvite != null) {
-            this.router.navigate(['accept-emergency'], { queryParams: emergencyInvite });
+        const loginRedirect = await this.stateService.get<any>('loginRedirect');
+        if (loginRedirect != null) {
+            this.router.navigate([loginRedirect.route], { queryParams: loginRedirect.qParams });
+            await this.stateService.remove('loginRedirect');
         } else {
-            const loginRedirect = await this.stateService.get<any>('loginRedirect');
-            if (loginRedirect != null) {
-                this.router.navigate([loginRedirect.route], { queryParams: loginRedirect.qParams });
-                await this.stateService.remove('loginRedirect');
-            } else {
-                this.router.navigate([this.successRoute], {
-                    queryParams: {
-                        identifier: this.identifier,
-                    },
-                });
-            }
+            this.router.navigate([this.successRoute], {
+                queryParams: {
+                    identifier: this.identifier,
+                },
+            });
         }
     }
 }

--- a/src/app/common/base.accept.component.ts
+++ b/src/app/common/base.accept.component.ts
@@ -1,0 +1,90 @@
+import {
+    Directive,
+    OnInit,
+} from '@angular/core';
+import {
+    ActivatedRoute,
+    Router,
+} from '@angular/router';
+
+import {
+    Toast,
+    ToasterService,
+} from 'angular2-toaster';
+
+import { I18nService } from 'jslib-common/abstractions/i18n.service';
+import { StateService } from 'jslib-common/abstractions/state.service';
+import { UserService } from 'jslib-common/abstractions/user.service';
+
+@Directive()
+export abstract class BaseAcceptComponent implements OnInit {
+    loading = true;
+    authed = false;
+    email: string;
+    actionPromise: Promise<any>;
+
+    protected requiredParameters: string[] = [];
+    protected failedShortMessage = 'inviteAcceptFailedShort';
+    protected failedMessage = 'inviteAcceptFailed';
+
+    constructor(protected router: Router, protected toasterService: ToasterService,
+        protected i18nService: I18nService, protected route: ActivatedRoute,
+        protected userService: UserService, private stateService: StateService) { }
+
+    abstract authedHandler(qParams: any): Promise<void>;
+    abstract unauthedHandler(qParams: any): Promise<void>;
+
+    ngOnInit() {
+        let fired = false;
+        this.route.queryParams.subscribe(async qParams => {
+            if (fired) {
+                return;
+            }
+            fired = true;
+            await this.stateService.remove('loginRedirect');
+
+            let error = this.requiredParameters.some(e => qParams?.[e] == null || qParams[e] === '');
+            let errorMessage: string = null;
+            if (!error) {
+                this.authed = await this.userService.isAuthenticated();
+
+                if (this.authed) {
+                    try {
+                        await this.authedHandler(qParams);
+                    } catch (e) {
+                        error = true;
+                        errorMessage = e.message;
+                    }
+                } else {
+                    await this.stateService.save('loginRedirect', {
+                        route: this.getRedirectRoute(),
+                        qParams: qParams,
+                    });
+
+                    this.email = qParams.email;
+                    await this.unauthedHandler(qParams);
+                }
+            }
+
+            if (error) {
+                const toast: Toast = {
+                    type: 'error',
+                    title: null,
+                    body: errorMessage != null ? this.i18nService.t(this.failedShortMessage, errorMessage) :
+                        this.i18nService.t(this.failedMessage),
+                    timeout: 10000,
+                };
+                this.toasterService.popAsync(toast);
+                this.router.navigate(['/']);
+            }
+
+            this.loading = false;
+        });
+    }
+
+    getRedirectRoute() {
+        const urlTree = this.router.parseUrl(this.router.url);
+        urlTree.queryParams = {};
+        return urlTree.toString();
+    }
+}


### PR DESCRIPTION
## Objective
Since Provider (#1014) adds another `accept` flow, and will require yet another before it's feature complete, I decided to take this moment to refactor the accept components to minimize the required code. While at it, I also replaced the previous states with the more generic `loginRedirect`.

### Testing Considerations
We should do a regression sweep on accept emergency and organization flows.