### PR TITLE
[Reset Password] Custom Permission pairing

### DIFF
--- a/src/app/organizations/manage/user-add-edit.component.html
+++ b/src/app/organizations/manage/user-add-edit.component.html
@@ -172,7 +172,8 @@
                                 <div class="form-group mb-0">
                                     <div class="form-check mt-1 form-check-block">
                                         <input class="form-check-input" type="checkbox" name="manageUsers"
-                                            id="manageUsers" [(ngModel)]="permissions.manageUsers">
+                                            id="manageUsers" [(ngModel)]="permissions.manageUsers"
+                                            (change)="handleDependentPermissions()">
                                         <label class="form-check-label font-weight-normal" for="manageUsers">
                                             {{'manageUsers' | i18n}}
                                         </label>
@@ -181,7 +182,8 @@
                                 <div class="form-group mb-0">
                                     <div class="form-check mt-1 form-check-block">
                                         <input class="form-check-input" type="checkbox" name="manageResetPassword"
-                                            id="manageResetPassword" [(ngModel)]="permissions.manageResetPassword">
+                                            id="manageResetPassword" [(ngModel)]="permissions.manageResetPassword"
+                                            (change)="handleDependentPermissions()">
                                         <label class="form-check-label font-weight-normal" for="manageResetPassword">
                                             {{'manageResetPassword' | i18n}}
                                         </label>

--- a/src/app/organizations/manage/user-add-edit.component.ts
+++ b/src/app/organizations/manage/user-add-edit.component.ts
@@ -143,6 +143,15 @@ export class UserAddEditComponent implements OnInit {
         return p;
     }
 
+    handleDependentPermissions() {
+        // Manage Password Reset must have Manage Users enabled
+        if (this.permissions.manageResetPassword && !this.permissions.manageUsers) {
+            this.permissions.manageUsers = true;
+            (document.getElementById('manageUsers') as HTMLInputElement).checked = true;
+            this.platformUtilsService.showToast('info', null, this.i18nService.t('resetPasswordManageUsers'));
+        }
+    }
+
     async submit() {
         let collections: SelectionReadOnlyRequest[] = null;
         if (this.access !== 'all') {

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3995,5 +3995,8 @@
   },
   "error": {
     "message": "Error"
+  },
+  "resetPasswordManageUsers": {
+    "message": "Manage Users must also be enabled with the Manage Password Reset permission"
   }
 }


### PR DESCRIPTION
## Objective
> For users that are given the `Custom` type, an option to `Manage Password Reset` is available. If this is enabled, make sure that the `Manage Users` permission is also enabled, as its necessary in order to properly reset a user's master password.

## Code Changes
- **user-add-edit.component.html**: Added method call that fires during the `(change)` action
- **user-add-edit.component.ts**: Created new `handleDependentPermissions` method that will auto-select the `Manage Users` permission if necessary
- **messages.json**: Added informational string during auto-selection

## Screenshot
![Screen Shot 2021-06-11 at 9 17 39 AM](https://user-images.githubusercontent.com/26154748/121701270-57b02980-ca96-11eb-9741-52994a375f61.png)
