### PR TITLE
Improve bump-jslib GH action

### DIFF
--- a/.github/workflows/bump-jslib.yml
+++ b/.github/workflows/bump-jslib.yml
@@ -24,7 +24,7 @@ jobs:
           if [ "$CHECKED_OUT_BRANCH_NAME" = "master" ]; then
             TARGET_BRANCH_NAME="auto-bump-jslib"
             git fetch origin
-            EXISTING_PR=`git ls-remote --heads origin $TARGET_BRANCH_NAME | wc -l`
+            EXISTING_PR=$(git ls-remote --heads origin $TARGET_BRANCH_NAME | wc -l)
             if [ "$EXISTING_PR" -gt 0 ]; then
               git checkout $TARGET_BRANCH_NAME
               echo "[*] Checked out existing PR branch $TARGET_BRANCH_NAME"
@@ -39,11 +39,11 @@ jobs:
           fi
 
           npm run sub:init
-          OLD_JSLIB_HASH=`git submodule status | awk '{print $1}'`
+          OLD_JSLIB_HASH=$(git submodule status | awk '{print $1}')
 
           npm run sub:update
 
-          if [ `git diff jslib | wc -l` -eq 0 ]; then
+          if [ $(git diff jslib | wc -l) -eq 0 ]; then
             echo "Unable to bump jslib: branch $TARGET_BRANCH_NAME is already using the latest jslib commit."
             if [ "$EXISTING_PR" -gt 0 ]; then
               echo "Try merging the $TARGET_BRANCH_NAME branch into master first."
@@ -54,7 +54,7 @@ jobs:
           git add jslib
           git commit -m "Bump jslib"
 
-          NEW_JSLIB_HASH=`git submodule status | awk '{print $1}'`
+          NEW_JSLIB_HASH=$(git submodule status | awk '{print $1}')
           echo "[*] Bumped jslib to $NEW_JSLIB_HASH"
 
           if [ "$EXISTING_PR" -eq 0 ]; then
@@ -65,7 +65,7 @@ jobs:
           echo "[*] Pushed to $TARGET_BRANCH_NAME"
 
           cd jslib
-          GIT_LOG=`git log $OLD_JSLIB_HASH..$NEW_JSLIB_HASH --oneline | sed 's/^/* /g' | sed 's/#[0-9]*[)]/bitwarden\/jslib&/g'`
+          GIT_LOG="$(git log $OLD_JSLIB_HASH..$NEW_JSLIB_HASH --oneline | sed 's/^/* /g' | sed 's/#[0-9]*[)]/bitwarden\/jslib&/g')"
           
           echo "::set-output name=git-log::${GIT_LOG}"
           echo "::set-output name=existing-pr::${EXISTING_PR}"

--- a/.github/workflows/bump-jslib.yml
+++ b/.github/workflows/bump-jslib.yml
@@ -79,7 +79,7 @@ jobs:
           if [ "$EXISTING_PR" -eq 0 ]; then
             gh pr create --title "Auto bump jslib" \
               --body "$BODY_TEXT" \
-              --reviewer eliykat
+              --reviewer bitwarden/dept-engineering
             echo "[*] Submitted PR against master branch"
           else
             gh pr comment --body "$BODY_TEXT"

--- a/.github/workflows/bump-jslib.yml
+++ b/.github/workflows/bump-jslib.yml
@@ -76,7 +76,7 @@ jobs:
           $GIT_LOG"
 
           if [ "$EXISTING_PR" -eq 0 ]; then
-            gh pr create --title "Auto bump jslib" \
+            gh pr create --title "[Bot] Bump jslib" \
               --body "$BODY_TEXT" \
               --reviewer bitwarden/dept-engineering
             echo "[*] Submitted PR against master branch"

--- a/.github/workflows/bump-jslib.yml
+++ b/.github/workflows/bump-jslib.yml
@@ -54,25 +54,24 @@ jobs:
           git add jslib
           git commit -m "Bump jslib"
 
-          NEW_JSLIB_HASH=$(git submodule status | awk '{print $1}')
-          echo "[*] Bumped jslib to $NEW_JSLIB_HASH"
-
           if [ "$EXISTING_PR" -eq 0 ]; then
             git push -u origin $TARGET_BRANCH_NAME
           else
             git push origin $TARGET_BRANCH_NAME
           fi
           echo "[*] Pushed to $TARGET_BRANCH_NAME"
-
-          cd jslib
-          GIT_LOG="$(git log $OLD_JSLIB_HASH..$NEW_JSLIB_HASH --oneline | sed 's/^/* /g' | sed 's/#[0-9]*[)]/bitwarden\/jslib&/g')"
           
-          echo "::set-output name=git-log::${GIT_LOG}"
+          echo "::set-output name=old-jslib-hash::${OLD_JSLIB_HASH}"
           echo "::set-output name=existing-pr::${EXISTING_PR}"
 
       - name: Submit or update PR against master branch
         if: github.ref == 'refs/heads/master'
         run: |
+          NEW_JSLIB_HASH=$(git submodule status | awk '{print $1}')
+          cd jslib
+          GIT_LOG="$(git log $OLD_JSLIB_HASH..$NEW_JSLIB_HASH --oneline | sed 's/^[a-zA-Z0-9]*/* `&`/g' | sed 's/#[0-9]*[)]/bitwarden\/jslib&/g')"
+          cd ..
+
           BODY_TEXT="@${{github.actor}} would like to bump jslib in this repo. This will pull in the following new commits:
           $GIT_LOG"
 
@@ -86,6 +85,6 @@ jobs:
             echo "[*] Updated existing PR"
           fi
         env:
-          GIT_LOG: ${{ steps.bump.outputs.git-log }}
+          OLD_JSLIB_HASH: ${{ steps.bump.outputs.old-jslib-hash }}
           EXISTING_PR: ${{ steps.bump.outputs.existing-pr }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Objective

Improve a few teething problems with the new `bump-jslib` GH action.

* `set-output` only takes a single line input and will truncate any following newlines. (The issue is documented [here](https://github.community/t/set-output-truncates-multiline-strings/16852/3)). This was cutting off the `git log` output. Fixed by moving `git log` into the final step, which is where it's needed anyway, so we don't have to use `set-output` to pass it around.
* improve formatting on the `git log` output when it's appended to a Github PR or comment
* use the more modern bash command substitution syntax: `$(...)`
* change reviewer to the `dept-engineering` team
* rename PR to `[Bot] Bump jslib`. I didn't think "auto" made much sense.