### PR TITLE
Must await to get a value

### DIFF
--- a/src/services/htmlStorage.service.ts
+++ b/src/services/htmlStorage.service.ts
@@ -45,7 +45,7 @@ export class HtmlStorageService implements StorageService {
     }
 
     async has(key: string): Promise<boolean> {
-        return this.get(key) != null;
+        return await this.get(key) != null;
     }
 
     save(key: string, obj: any): Promise<any> {


### PR DESCRIPTION
# Overview

Fix issue where we aren't awaiting `get` to return its value rather than the promise of one.

FYI, this is a regression item and will be cherry-picked into `rc` upon merger to master. Please evaluate accordingly.

# Testing.

This regression manifests as a failure to lock and failure to decrypt the web vault upon reloading.