### PR TITLE
[Toast] - BUG - Fixed styles

### DIFF
--- a/src/scss/plugins.scss
+++ b/src/scss/plugins.scss
@@ -35,7 +35,7 @@ $fa-font-path: "~font-awesome/fonts";
         }
 
         .toast-content {
-            padding: 15px 15px 15px 15px;
+            padding: 15px;
         }
 
         .toaster-icon {

--- a/src/scss/plugins.scss
+++ b/src/scss/plugins.scss
@@ -3,13 +3,14 @@ $fa-font-path: "~font-awesome/fonts";
 @import "~angular2-toaster/toaster";
 @import "~sweetalert2/src/sweetalert2.scss";
 
-#toast-container {
+.toast-container {
     &.toast-top-right {
         top: 76px;
     }
 
     .toast-close-button {
-        right: -0.15em;
+        margin-right: 4px;
+        font-size: 18px;
     }
 
     .toast {
@@ -30,8 +31,11 @@ $fa-font-path: "~font-awesome/fonts";
             line-height: 20px;
             float: left;
             color: #ffffff;
-            padding-right: 10px;
-            margin: auto 0 auto -36px;
+            margin: auto 0 auto 15px;
+        }
+
+        .toast-content {
+            padding: 15px 15px 15px 15px;
         }
 
         .toaster-icon {
@@ -54,7 +58,6 @@ $fa-font-path: "~font-awesome/fonts";
 
             &:before {
                 content: "\f0e7";
-                margin-left: -30px;
             }
         }
 


### PR DESCRIPTION
## Objective
> A recent update to the `angular2-toast` library cause our custom styling to not be applied properly.

## Code Changes
- **plugins.scss**: The `toast-container` object is now a `class` and not an `id`. Updated some padding/margin to more closely match the current production toasts style.

## Screenshots
![0-all-toasts](https://user-images.githubusercontent.com/26154748/122255211-86157680-ce93-11eb-896b-a58b3f594dda.png)
