### PR TITLE
Force download of file regardless of type

### DIFF
--- a/src/services/webPlatformUtils.service.ts
+++ b/src/services/webPlatformUtils.service.ts
@@ -103,10 +103,8 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
         let blob: Blob = null;
         let type: string = null;
         const fileNameLower = fileName.toLowerCase();
-        let doDownload = true;
         if (fileNameLower.endsWith('.pdf')) {
             type = 'application/pdf';
-            doDownload = false;
         } else if (fileNameLower.endsWith('.xlsx')) {
             type = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
         } else if (fileNameLower.endsWith('.docx')) {
@@ -137,11 +135,7 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
             navigator.msSaveBlob(blob, fileName);
         } else {
             const a = win.document.createElement('a');
-            if (doDownload) {
-                a.download = fileName;
-            } else if (!this.isSafari()) {
-                a.target = '_blank';
-            }
+            a.download = fileName;
             a.href = URL.createObjectURL(blob);
             a.style.position = 'fixed';
             win.document.body.appendChild(a);


### PR DESCRIPTION
The file download feature in Bitwarden Send currently treats PDF files as a special case by not forcing the file to be downloaded. By the looks of it the reasoning is to make use of the built-in PDF viewer that comes with the browser.

Based on my use of the application, and our extensive sharing of PDFs with non-technical people, this special case is a genuine usability problem. Almost every person we have shared a PDF document with has thought that the download feature hasn't worked because of the built-in popup blocker.

The code in question makes an exemption for Safari, so it's not an issue in that case, but for every other browser this is proving to be a concern.

From a usability point of view, I do not think that PDF files should be treated any differently. When a user clicks a link that says "Download File", they would expect a file to be downloaded. That's certainly what I would expect. I also personally dislike it when applications try to be too smart in cases like this and try to use built-in browser features for certain file types.

Attempting to download a file in Bitwarden Send should result in the file being downloaded. If the user has their browser configured to view PDF files, then that's what will happen when they try to open it. If they do not, then their other chosen viewer will be invoked. This option is still under the control of the user even when the file has been downloaded first.

This small change removes the code that treats PDF files as a special case. Instead the files are downloaded directly just like any other file type. This consistency is a win for useability and avoids the problem of popup blocker getting in the way of downloading PDF files.

I checked to see where else in the code this download feature is used and found the following:

```
./src/app/settings/user-subscription.component.ts:        this.platformUtilsService.saveFile(window, licenseString, null, 'bitwarden_premium_license.json');
./src/app/organizations/manage/events.component.ts:        this.platformUtilsService.saveFile(window, data, { type: 'text/plain' }, fileName);
./src/app/organizations/settings/download-license.component.ts:            this.platformUtilsService.saveFile(window, licenseString, null, 'bitwarden_organization_license.json');
```

The above cases are all non-PDF files, so the change does not impact them at all.

I'm sure there were good reasons for putting this feature in place to begin with. I just feel that treating any file as a special case is a bad idea, removes control from the user and results in unexpected behaviour. It's especially bad when downloads just don't work because popups are silently blocked.

I welcome any discussion on the topic. Thanks very much for your time.