### PR TITLE
Redefine cipher "share" to "move to organization"

### DIFF
--- a/src/app/services/event.service.ts
+++ b/src/app/services/event.service.ts
@@ -101,8 +101,8 @@ export class EventService {
                 humanReadableMsg = this.i18nService.t('deletedAttachmentForItem', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_Shared:
-                msg = this.i18nService.t('sharedItemId', this.formatCipherId(ev, options));
-                humanReadableMsg = this.i18nService.t('sharedItemId', this.getShortId(ev.cipherId));
+                msg = this.i18nService.t('movedItemIdToOrg', this.formatCipherId(ev, options));
+                humanReadableMsg = this.i18nService.t('movedItemIdToOrg', this.getShortId(ev.cipherId));
                 break;
             case EventType.Cipher_ClientViewed:
                 msg = this.i18nService.t('viewedItemId', this.formatCipherId(ev, options));

--- a/src/app/settings/emergency-access-view.component.html
+++ b/src/app/settings/emergency-access-view.component.html
@@ -12,7 +12,7 @@
                     <td class="reduced-lh wrap">
                         <a href="#" appStopClick (click)="selectCipher(c)" title="{{'editItem' | i18n}}">{{c.name}}</a>
                         <ng-container *ngIf="!organization && c.organizationId">
-                            <i class="fa fa-share-alt" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
+                            <i class="fa fa-cube" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
                             <span class="sr-only">{{'shared' | i18n}}</span>
                         </ng-container>
                         <ng-container *ngIf="c.hasAttachments">

--- a/src/app/tools/exposed-passwords-report.component.html
+++ b/src/app/tools/exposed-passwords-report.component.html
@@ -28,7 +28,7 @@
                             <span>{{c.name}}</span>
                         </ng-template>
                         <ng-container *ngIf="!organization && c.organizationId">
-                            <i class="fa fa-share-alt" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
+                            <i class="fa fa-cube" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
                             <span class="sr-only">{{'shared' | i18n}}</span>
                         </ng-container>
                         <ng-container *ngIf="c.hasAttachments">

--- a/src/app/tools/inactive-two-factor-report.component.html
+++ b/src/app/tools/inactive-two-factor-report.component.html
@@ -29,7 +29,7 @@
                     <td class="reduced-lh wrap">
                         <a href="#" appStopClick (click)="selectCipher(c)" title="{{'editItem' | i18n}}">{{c.name}}</a>
                         <ng-container *ngIf="!organization && c.organizationId">
-                            <i class="fa fa-share-alt" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
+                            <i class="fa fa-cube" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
                             <span class="sr-only">{{'shared' | i18n}}</span>
                         </ng-container>
                         <ng-container *ngIf="c.hasAttachments">

--- a/src/app/tools/reused-passwords-report.component.html
+++ b/src/app/tools/reused-passwords-report.component.html
@@ -34,7 +34,7 @@
                             <span>{{c.name}}</span>
                         </ng-template>
                         <ng-container *ngIf="!organization && c.organizationId">
-                            <i class="fa fa-share-alt" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
+                            <i class="fa fa-cube" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
                             <span class="sr-only">{{'shared' | i18n}}</span>
                         </ng-container>
                         <ng-container *ngIf="c.hasAttachments">

--- a/src/app/tools/unsecured-websites-report.component.html
+++ b/src/app/tools/unsecured-websites-report.component.html
@@ -29,7 +29,7 @@
                     <td class="reduced-lh wrap">
                         <a href="#" appStopClick (click)="selectCipher(c)" title="{{'editItem' | i18n}}">{{c.name}}</a>
                         <ng-container *ngIf="!organization && c.organizationId">
-                            <i class="fa fa-share-alt" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
+                            <i class="fa fa-cube" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
                             <span class="sr-only">{{'shared' | i18n}}</span>
                         </ng-container>
                         <ng-container *ngIf="c.hasAttachments">

--- a/src/app/tools/weak-passwords-report.component.html
+++ b/src/app/tools/weak-passwords-report.component.html
@@ -34,7 +34,7 @@
                             <span>{{c.name}}</span>
                         </ng-template>
                         <ng-container *ngIf="!organization && c.organizationId">
-                            <i class="fa fa-share-alt" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
+                            <i class="fa fa-cube" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
                             <span class="sr-only">{{'shared' | i18n}}</span>
                         </ng-container>
                         <ng-container *ngIf="c.hasAttachments">

--- a/src/app/vault/bulk-actions.component.html
+++ b/src/app/vault/bulk-actions.component.html
@@ -9,8 +9,8 @@
             {{'moveSelected' | i18n}}
         </button>
         <button class="dropdown-item" appStopClick (click)="bulkShare()" *ngIf="!deleted && !organization">
-            <i class="fa fa-fw fa-share-alt" aria-hidden="true"></i>
-            {{'shareSelected' | i18n}}
+            <i class="fa fa-fw fa-arrow-circle-o-right" aria-hidden="true"></i>
+            {{'moveSelectedToOrg' | i18n}}
         </button>
         <button class="dropdown-item" (click)="bulkRestore()" *ngIf="deleted && !organization">
             <i class="fa fa-fw fa-undo" aria-hidden="true"></i>

--- a/src/app/vault/bulk-share.component.html
+++ b/src/app/vault/bulk-share.component.html
@@ -1,17 +1,17 @@
-<div class="modal fade" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="shareSelectedTitle">
+<div class="modal fade" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="moveSelectedToOrgTitle">
     <div class="modal-dialog modal-dialog-scrollable" role="document">
         <form class="modal-content" #form (ngSubmit)="submit()" [appApiAction]="formPromise">
             <div class="modal-header">
-                <h2 class="modal-title" id="shareSelectedTitle">
-                    {{'shareSelected' | i18n}}
+                <h2 class="modal-title" id="moveSelectedToOrgTitle">
+                    {{'moveSelectedToOrg' | i18n}}
                 </h2>
                 <button type="button" class="close" data-dismiss="modal" appA11yTitle="{{'close' | i18n}}">
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
             <div class="modal-body">
-                <p>{{'shareManyDesc' | i18n}}</p>
-                <p>{{'shareSelectedItemsCountDesc' | i18n: this.ciphers.length : shareableCiphers.length : nonShareableCount}}
+                <p>{{'moveManyToOrgDesc' | i18n}}</p>
+                <p>{{'moveSelectedItemsCountDesc' | i18n: this.ciphers.length : shareableCiphers.length : nonShareableCount}}
                 </p>
                 <div class="form-group">
                     <label for="organization">{{'organization' | i18n}}</label>

--- a/src/app/vault/bulk-share.component.ts
+++ b/src/app/vault/bulk-share.component.ts
@@ -71,7 +71,8 @@ export class BulkShareComponent implements OnInit {
                 checkedCollectionIds);
             await this.formPromise;
             this.onShared.emit();
-            this.toasterService.popAsync('success', null, this.i18nService.t('sharedItems'));
+            const orgName = this.organizations.find(o => o.id === this.organizationId)?.name ?? this.i18nService.t('organization');
+            this.toasterService.popAsync('success', null, this.i18nService.t('movedItemsToOrg', orgName));
         } catch { }
     }
 

--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -13,7 +13,7 @@
                     <a href="#" appStopClick appStopProp (click)="selectCipher(c)"
                         title="{{'editItem' | i18n}}">{{c.name}}</a>
                     <ng-container *ngIf="!organization && c.organizationId">
-                        <i class="fa fa-share-alt" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
+                        <i class="fa fa-cube" appStopProp title="{{'shared' | i18n}}" aria-hidden="true"></i>
                         <span class="sr-only">{{'shared' | i18n}}</span>
                     </ng-container>
                     <ng-container *ngIf="c.hasAttachments">
@@ -70,8 +70,8 @@
                             </a>
                             <a class="dropdown-item" href="#" appStopClick
                                 *ngIf="!organization && !c.organizationId && !c.isDeleted" (click)="share(c)">
-                                <i class="fa fa-fw fa-share-alt" aria-hidden="true"></i>
-                                {{'share' | i18n}}
+                                <i class="fa fa-fw fa-arrow-circle-o-right" aria-hidden="true"></i>
+                                {{'moveToOrganization' | i18n}}
                             </a>
                             <a class="dropdown-item" href="#" appStopClick *ngIf="c.organizationId && !c.isDeleted"
                                 (click)="collections(c)">

--- a/src/app/vault/share.component.html
+++ b/src/app/vault/share.component.html
@@ -3,7 +3,7 @@
         <form class="modal-content" #form (ngSubmit)="submit()" [appApiAction]="formPromise">
             <div class="modal-header">
                 <h2 class="modal-title" id="shareTitle">
-                    {{'share' | i18n}}
+                    {{'moveToOrganization' | i18n}}
                     <small *ngIf="cipher">{{cipher.name}}</small>
                 </h2>
                 <button type="button" class="close" data-dismiss="modal" appA11yTitle="{{'close' | i18n}}">
@@ -14,7 +14,7 @@
                 {{'noOrganizationsList' | i18n}}
             </div>
             <div class="modal-body" *ngIf="organizations && organizations.length">
-                <p>{{'shareDesc' | i18n}}</p>
+                <p>{{'moveToOrgDesc' | i18n}}</p>
                 <div class="form-group">
                     <label for="organization">{{'organization' | i18n}}</label>
                     <select id="organization" name="OrganizationId" [(ngModel)]="organizationId" class="form-control"

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -360,6 +360,9 @@
   "share": {
     "message": "Share"
   },
+  "moveToOrganization": {
+    "message": "Move to Organization"
+  },
   "valueCopied": {
     "message": "$VALUE$ copied",
     "description": "Value has been copied to the clipboard.",
@@ -400,8 +403,8 @@
   "vault": {
     "message": "Vault"
   },
-  "shareSelected": {
-    "message": "Share Selected"
+  "moveSelectedToOrg": {
+    "message": "Move Selected to Organization"
   },
   "deleteSelected": {
     "message": "Delete Selected"
@@ -448,11 +451,27 @@
   "editedItem": {
     "message": "Edited item"
   },
-  "sharedItem": {
-    "message": "Shared item"
+  "movedItemToOrg": {
+    "message": "$ITEMNAME$ moved to $ORGNAME$",
+    "placeholders": {
+      "itemname": {
+        "content": "$1",
+        "example": "Secret Item"
+      },
+      "orgname": {
+        "content": "$2",
+        "example": "Company Name"
+      }
+    }
   },
-  "sharedItems": {
-    "message": "Shared items"
+  "movedItemsToOrg": {
+    "message": "Selected items moved to $ORGNAME$",
+    "placeholders": {
+      "orgname": {
+        "content": "$1",
+        "example": "Company Name"
+      }
+    }
   },
   "deleteItem": {
     "message": "Delete Item"
@@ -749,11 +768,11 @@
   "organizations": {
     "message": "Organizations"
   },
-  "shareDesc": {
-    "message": "Choose an organization that you wish to share this item with. Sharing transfers ownership of the item to the organization. You will no longer be the direct owner of this item once it has been shared."
+  "moveToOrgDesc": {
+    "message": "Choose an organization that you wish to move this item to. Moving to an organization transfers ownership of the item to that organization. You will no longer be the direct owner of this item once it has been moved."
   },
-  "shareManyDesc": {
-    "message": "Choose an organization that you wish to share these items with. Sharing transfers ownership of the items to the organization. You will no longer be the direct owner of these items once they have been shared."
+  "moveManyToOrgDesc": {
+    "message": "Choose an organization that you wish to move these items to. Moving to an organization transfers ownership of the items to that organization. You will no longer be the direct owner of these items once they have been moved."
   },
   "collectionsDesc": {
     "message": "Edit the collections that this item is being shared with. Only organization users with access to these collections will be able to see this item."
@@ -776,18 +795,18 @@
       }
     }
   },
-  "shareSelectedItemsCountDesc": {
-    "message": "You have selected $COUNT$ item(s). $SHAREABLE_COUNT$ items are sharable, $NONSHAREABLE_COUNT$ are not.",
+  "moveSelectedItemsCountDesc": {
+    "message": "You have selected $COUNT$ item(s). $MOVEABLE_COUNT$ item(s) can be moved to an organization, $NONMOVEABLE_COUNT$ cannot.",
     "placeholders": {
       "count": {
         "content": "$1",
         "example": "10"
       },
-      "shareable_count": {
+      "moveable_count": {
         "content": "$2",
         "example": "8"
       },
-      "nonshareable_count": {
+      "nonmoveable_count": {
         "content": "$3",
         "example": "2"
       }
@@ -2333,8 +2352,8 @@
       }
     }
   },
-  "sharedItemId": {
-    "message": "Shared item $ID$.",
+  "movedItemIdToOrg": {
+    "message": "Moved item $ID$ to an organization.",
     "placeholders": {
       "id": {
         "content": "$1",


### PR DESCRIPTION
# Overview

The term "Share" is confusing to users because it implies maintaining ownership and control of a cipher while allowing others to access it as well. It also implies the ability to revoke access or to stop sharing -- neither of these things is true.

In addition to the share term being misleading, the [`fa-share-alt`](https://fontawesome.com/v4.7/icon/share-alt) icon implies a forking of the cipher item rather than transferring ownership.

When a cipher is "shared" it is irrevocably taken over by an organization. This occurs for good cryptographic and security reasons. The better solution to this is to revise the communication around "sharing." To that end, this work changes the term "share" to "move to organization" and the icon is changed to [`fa-cube`](https://fontawesome.com/v4.7/icon/cube), which is used to indicate a collection. The act of moving an item to an organization is denoted by [`fa-arrow-circle-o-right`](https://fontawesome.com/v4.7/icon/arrow-circle-o-right) rather than `fa-share-alt`.

# Screen Shots
#### Confirm move single item
![image](https://user-images.githubusercontent.com/18214891/122412758-748fa580-cf4b-11eb-9ad9-9b26641a7e80.png)
#### Confirm move multiple items
![image](https://user-images.githubusercontent.com/18214891/122412875-8e30ed00-cf4b-11eb-9ea5-d047cd3cbaaf.png)
#### Multiple items moved toast
<img width="377" alt="image" src="https://user-images.githubusercontent.com/18214891/122413008-a86acb00-cf4b-11eb-869f-1436e6f04e72.png">
#### New "Org Owned" indicator
<img width="519" alt="image" src="https://user-images.githubusercontent.com/18214891/122413213-cfc19800-cf4b-11eb-873a-1fa732634b8e.png">
#### Action menu
<img width="519" alt="image" src="https://user-images.githubusercontent.com/18214891/122413964-64c49100-cf4c-11eb-95af-e1135677deb4.png">
#### Bulk action menu
<img width="519" alt="image" src="https://user-images.githubusercontent.com/18214891/122414008-70b05300-cf4c-11eb-86b5-f434b74e97f3.png">