### PR TITLE
maxAccessCountDesc locale string update

### DIFF
--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3413,7 +3413,7 @@
     "message": "Maximum Access Count"
   },
   "maxAccessCountDesc": {
-    "message": "If set, users will no longer be able to access this send once the maximum access count is reached.",
+    "message": "If set, users will no longer be able to access this Send once the maximum access count is reached.",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   },
   "currentAccessCount": {


### PR DESCRIPTION
Hey, I noticed that the string doesn't have a capitalized "Send" word.

It a bit messes up with the Crowdin comparing system, as both browser and desktop versions have "Send" capitalized correctly - while mobile and web don't.

I will make a PR on the mobile version too.