### PR TITLE
adding in a workflow to deploy the Web client to the QA environment

### DIFF
--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -1,0 +1,56 @@
+name: QA Deploy
+
+on: 
+  workflow_dispatch:
+    inputs: {}
+
+env:
+  QA_CLUSTER_RESOURCE_GROUP: "bitwarden-devops"
+  QA_CLUSTER_NAME: "dev-aks"
+  QA_K8S_NAMESPACE: "bw-qa"
+  QA_K8S_APP_NAME: "bw-web"
+
+jobs:
+  deploy:
+    name: Deploy QA Web Vault
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Setup
+        run:
+          export PATH=$PATH:~/work/web/web
+
+      - name: Login to Azure
+        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
+        with:
+          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
+
+      - name: Retrieve secrets
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
+        id: retrieve-secrets
+        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
+        with:
+          keyvault: "bitwarden-qa-kv"
+          secrets: "dev-aks-kubectl-credentials"
+
+      - name: Login to dev-aks-kubectl SP
+        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
+        with:
+          creds: ${{ env.dev-aks-kubectl-credentials }}
+
+      - name: Setup AKS access
+        env:
+          USER_ID: ${{ env.qa-kubectl-managed-identity-clientId }}
+        run: |
+          echo "---az install---"
+          az aks install-cli --install-location ./kubectl --kubelogin-install-location ./kubelogin
+          echo "---az get-creds---"
+          az aks get-credentials -n $QA_CLUSTER_NAME -g $QA_CLUSTER_RESOURCE_GROUP
+
+      - name: Redeploy Web image
+        run: |
+          POD_NAME=$(kubectl get po -n $QA_K8S_NAMESPACE -l app=$QA_K8S_APP_NAME -o jsonpath="{.items[0].metadata.name}")
+          echo "Deleting pod: $POD_NAME"
+          kubectl delete po -n bw-qa $POD_NAME

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 *.pem
 *.crx
 *.zip
+*.swp
 build/
 !dev-server.shared.pem
 config/development.json


### PR DESCRIPTION
## Summary
We need an easy, push-button way, for QA to deploy the latest `rc` image of the web client. We are using ArgoCD for a couple of the server services that don't change a bunch set to automatically sync. After thinking through some of the ways to set this up, the best way forward is a workflow that deletes the currently deployed web pod which will then be automatically re-pulled and re-deployed. The ADR can be found [here](https://devops-bitwarden.atlassian.net/l/c/AmW8xfeM).