### PR TITLE
manually resolving the duo_security package with https instead of ssh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3670,7 +3670,7 @@
     },
     "node_modules/duo_web_sdk": {
       "version": "2.7.0",
-      "resolved": "git+ssh://git@github.com/duosecurity/duo_web_sdk.git#5f9a1a8598d2cda494c4f5ee0e38b31474abfee9",
+      "resolved": "git+https://github.com/duosecurity/duo_web_sdk.git#5f9a1a8598d2cda494c4f5ee0e38b31474abfee9",
       "integrity": "sha512-SYnekrMvi6aON7atFPE8H+F6JjXrz5HgVGbmc7GQH2mvYz6DH0Grh+MWNeB1LwD7D8nzrWbnhbZM77U2hoWrxQ==",
       "license": "SEE LICENSE IN LICENSE"
     },


### PR DESCRIPTION
## Summary
The package lock had an ssh git url which was breaking the CI