### PR TITLE
fixing the prod deploy workflow error with npm ci

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install and Build
         run: |
-          npm install
+          npm ci
           npm run dist
 
       - name: Deploy GitHub Pages


### PR DESCRIPTION
## Summary
The recent manual fix of the duo security package didn't fix the problem

This should bypass the problem according to this: https://github.com/readium/r2-testapp-js/issues/10#issuecomment-424522536