### PR TITLE
[Reset Password] BUG Org Keys backfill force sync

### DIFF
--- a/src/app/organizations/manage/people.component.ts
+++ b/src/app/organizations/manage/people.component.ts
@@ -23,6 +23,7 @@ import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.se
 import { PolicyService } from 'jslib-common/abstractions/policy.service';
 import { SearchService } from 'jslib-common/abstractions/search.service';
 import { StorageService } from 'jslib-common/abstractions/storage.service';
+import { SyncService } from 'jslib-common/abstractions/sync.service';
 import { UserService } from 'jslib-common/abstractions/user.service';
 
 import { OrganizationKeysRequest } from 'jslib-common/models/request/organizationKeysRequest';
@@ -98,7 +99,7 @@ export class PeopleComponent implements OnInit {
         private cryptoService: CryptoService, private userService: UserService, private router: Router,
         private storageService: StorageService, private searchService: SearchService,
         private validationService: ValidationService, private policyService: PolicyService,
-        private searchPipe: SearchPipe) { }
+        private searchPipe: SearchPipe, private syncService: SyncService) { }
 
     async ngOnInit() {
         this.route.parent.parent.params.subscribe(async params => {
@@ -122,6 +123,7 @@ export class PeopleComponent implements OnInit {
                 const response = await this.apiService.postOrganizationKeys(this.organizationId, request);
                 if (response != null) {
                     this.orgHasKeys = response.publicKey != null && response.privateKey != null;
+                    await this.syncService.fullSync(true); // Replace oganizations with new data
                 } else {
                     throw new Error(this.i18nService.t('resetPasswordOrgKeysError'));
                 }


### PR DESCRIPTION
## Objective
> Fix the following: for an organization with no Public/Private keys, the `Manage -> People` component will automatically create/set the key pair on the server. If the user stays within the organization context before a `sync` occurs, returning to the `People` component will result in an infinite loading spinner.

## Code Changes
- **people.component.ts**: Force a one time `sync` operation that will replace all of the Organizational data in local storage with the latest from the server.

## Notes
- This is a bit quick & dirty but is how we currently handle changing organizational data/refreshing the local storage. A potentially cleaner way would be to change the data locally via a successful API response and save those changes to local storage. Unfortunately the only way to update /any/ organizational data is by using API responses directly from the server en mass (no singular update organization method, ex: ProfileResponse from Sync).