### PR TITLE
chore: radio instead of dropdown (refactor)

### DIFF
--- a/src/app/tools/password-generator.component.html
+++ b/src/app/tools/password-generator.component.html
@@ -10,15 +10,12 @@
     </div>
 </div>
 <div class="form-group">
-    <div class="form-check form-check-inline">
-        <input id="generate-password" name="type" value="password" class="form-check-input" type="radio"
-            (change)="saveOptions()" [(ngModel)]="options.type">
-        <label for="generate-password" class="form-check-label">{{'password' | i18n}}</label>
-    </div>
-    <div class="form-check form-check-inline">
-        <input id="generate-passphrase" name="type" value="passphrase" class="form-check-input" type="radio"
-            (change)="saveOptions()" [(ngModel)]="options.type">
-        <label for="generate-passphrase" class="form-check-label">{{'passphrase' | i18n}}</label>
+    <div class="form-check form-check-inline" appBoxRow name="PassTypeOptions" *ngFor="let o of passTypeOptions">
+        <input class="form-check-input" type="radio" [(ngModel)]="options.type" name="Type_{{o.value}}"
+            id="type_{{o.value}}" [value]="o.value" (change)="saveOptions()" [checked]="options.type === o.value">
+        <label class="form-check-label" for="type_{{o.value}}">
+            {{o.name}}
+        </label>
     </div>
 </div>
 <ng-container *ngIf="options.type === 'passphrase'">

--- a/src/app/tools/password-generator.component.html
+++ b/src/app/tools/password-generator.component.html
@@ -10,7 +10,7 @@
     </div>
 </div>
 <div class="form-group">
-    <div class="form-check form-check-inline" appBoxRow name="PassTypeOptions" *ngFor="let o of passTypeOptions">
+    <div class="form-check form-check-inline" *ngFor="let o of passTypeOptions">
         <input class="form-check-input" type="radio" [(ngModel)]="options.type" name="Type_{{o.value}}"
             id="type_{{o.value}}" [value]="o.value" (change)="saveOptions()" [checked]="options.type === o.value">
         <label class="form-check-label" for="type_{{o.value}}">


### PR DESCRIPTION
**Feature name:**

```
Replace the drop down for password/passphrase option with a radio button choice
```

**Feature Description**

There are only two options in the drop down, would it be better to replace it with a radio button for choice?

- Aids in discoverability: I completely missed the option for a whole year before I thought to click on the option and see what it contains.
- Less number of interactions: It would take 1 less click to get the same result

Community Forum post: https://community.bitwarden.com/t/radio-choice-password-passphrase/30636