### PR TITLE
Add support for emojis in Avatar

### DIFF
--- a/src/app/components/avatar.component.ts
+++ b/src/app/components/avatar.component.ts
@@ -91,7 +91,8 @@ export class AvatarComponent implements OnChanges, OnInit {
         if (parts.length > 1) {
             let text = '';
             for (let i = 0; i < count; i++) {
-                text += Array.from(parts[i]).splice(0, 1).join('');
+                const characters = parts[i].match(/./ug);
+                text += characters != null && characters.length > 0 ? characters[0] : '';
             }
             return text;
         }

--- a/src/app/components/avatar.component.ts
+++ b/src/app/components/avatar.component.ts
@@ -58,7 +58,12 @@ export class AvatarComponent implements OnChanges, OnInit {
                 chars = this.getFirstLetters(upperData, this.charCount);
             }
             if (chars == null) {
-                chars = upperData.substr(0, this.charCount);
+                chars = this.unicodeSafeSubstring(upperData, this.charCount);
+            }
+
+            // If the chars contain an emoji, only show it.
+            if (chars.match(Utils.regexpEmojiPresentation)) {
+                chars = chars.match(Utils.regexpEmojiPresentation)[0];
             }
 
             const charObj = this.getCharText(chars);
@@ -91,8 +96,7 @@ export class AvatarComponent implements OnChanges, OnInit {
         if (parts.length > 1) {
             let text = '';
             for (let i = 0; i < count; i++) {
-                const characters = parts[i].match(/./ug);
-                text += characters != null && characters.length > 0 ? characters[0] : '';
+                text += this.unicodeSafeSubstring(parts[i], 1);
             }
             return text;
         }
@@ -125,5 +129,10 @@ export class AvatarComponent implements OnChanges, OnInit {
         textTag.style.fontWeight = this.fontWeight.toString();
         textTag.style.fontSize = this.fontSize + 'px';
         return textTag;
+    }
+
+    private unicodeSafeSubstring(str: string, count: number) {
+        const characters = str.match(/./ug);
+        return characters != null ? characters.slice(0, count).join('') : '';
     }
 }

--- a/src/app/components/avatar.component.ts
+++ b/src/app/components/avatar.component.ts
@@ -91,7 +91,7 @@ export class AvatarComponent implements OnChanges, OnInit {
         if (parts.length > 1) {
             let text = '';
             for (let i = 0; i < count; i++) {
-                text += parts[i].substr(0, 1);
+                text += Array.from(parts[i]).splice(0, 1).join('');
             }
             return text;
         }


### PR DESCRIPTION
## Objective
The current avatar component breaks when it gets an emoji followed by a space. To improve the emoji support I've switched to using unicode aware regex to split the characters. Which seems to be the only way to provide support for compounding unicode. According to https://caniuse.com/mdn-javascript_builtins_regexp_unicode this should have good support.

## Screenshots
![image](https://user-images.githubusercontent.com/137855/124899618-97f4c000-dfe0-11eb-8019-3f67ae85c6f5.png)
![image](https://user-images.githubusercontent.com/137855/124895154-97f2c100-dfdc-11eb-8c7c-f42579ab56f6.png)
![image](https://user-images.githubusercontent.com/137855/124899517-80b5d280-dfe0-11eb-8a59-cb316005f55d.png)
![image](https://user-images.githubusercontent.com/137855/124899542-857a8680-dfe0-11eb-8f37-3853915382e1.png)
![image](https://user-images.githubusercontent.com/137855/124899674-a4791880-dfe0-11eb-8795-ce2d626aac4c.png)

Depends on https://github.com/bitwarden/jslib/pull/426
Resolves https://github.com/bitwarden/web/issues/838
