### PR TITLE
Revert braintree update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bitwarden-web",
-      "version": "2.21.1",
+      "version": "2.20.4",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {
@@ -14,7 +14,7 @@
         "@bitwarden/jslib-common": "file:jslib/common",
         "angular2-toaster": "11.0.1",
         "bootstrap": "4.6.0",
-        "braintree-web-drop-in": "1.30.1",
+        "braintree-web-drop-in": "1.28.0",
         "browser-hrtime": "^1.1.8",
         "core-js": "^3.11.0",
         "date-input-polyfill": "^2.14.0",
@@ -91,7 +91,6 @@
       }
     },
     "jslib/common": {
-      "name": "@bitwarden/jslib-common",
       "version": "0.0.0",
       "license": "GPL-3.0",
       "dependencies": {
@@ -597,9 +596,9 @@
       }
     },
     "node_modules/@braintree/browser-detection": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.12.0.tgz",
-      "integrity": "sha512-fmZcaXYkXr9b0J+3HwXLQogIYV+xSS6aBG7LGu0OjLkSD/k62EAu2xLGEDFHUu6siH/I7vvGoC0/Ds3f3RnS6g=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.11.1.tgz",
+      "integrity": "sha512-jE5GRXNT2Ey3itbR7uTYdzbiLs9CP0kCInjTJFItApMFPj6F2Dm0Yb56C/69f7BL282gcCRqwhXVgaTeVwTWbw=="
     },
     "node_modules/@braintree/class-list": {
       "version": "0.2.0",
@@ -622,9 +621,9 @@
       "integrity": "sha512-tVpr7U6u6bqeQlHreEjYMNtnHX62vLnNWziY2kQLqkWhvusPuY5DfuGEIPpWqsd+V/a1slyTQaxK6HWTlH6A/Q=="
     },
     "node_modules/@braintree/sanitize-url": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-5.0.2.tgz",
-      "integrity": "sha512-NBEJlHWrhQucLhZGHtSxM2loSaNUMajC7KOYJLyfcdW/6goVoff2HoYI3bz8YCDN0wKGbxtUL0gx2dvHpvnWlw=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-5.0.1.tgz",
+      "integrity": "sha512-KzIC8q/UsT8g6bwRAQ0NbOCNxRoGbPKtqGBUtDaN8WN80xqsbHFs8z+Eq0fR0W1wcrcTB5oKNACsrbkK4X+FWA=="
     },
     "node_modules/@braintree/uuid": {
       "version": "0.1.0",
@@ -1879,20 +1878,20 @@
       }
     },
     "node_modules/braintree-web": {
-      "version": "3.78.2",
-      "resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.78.2.tgz",
-      "integrity": "sha512-aYKlog3j4BBAgUjRq52gn54/6Kp9zR7PalAzfhych/OArNq9xL0kO+OuQM7V0AxkTyoOHZ1qswIQ9MYPRws/ag==",
+      "version": "3.76.3",
+      "resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.76.3.tgz",
+      "integrity": "sha512-msXQ6zAs+lK0x58JOaWf5AM/+MISL4Z9P+Hm4nd6Q8SYeKXmu94wRTWYJYJj0S3PnuyoPyBqh9AYOjs709bkAQ==",
       "dependencies": {
         "@braintree/asset-loader": "0.4.4",
-        "@braintree/browser-detection": "1.12.0",
+        "@braintree/browser-detection": "1.11.1",
         "@braintree/class-list": "0.2.0",
         "@braintree/event-emitter": "0.4.1",
         "@braintree/extended-promise": "0.4.1",
         "@braintree/iframer": "1.1.0",
-        "@braintree/sanitize-url": "5.0.2",
+        "@braintree/sanitize-url": "5.0.1",
         "@braintree/uuid": "0.1.0",
         "@braintree/wrap-promise": "2.1.0",
-        "card-validator": "8.1.1",
+        "card-validator": "8.1.0",
         "credit-card-type": "9.1.0",
         "framebus": "5.1.2",
         "inject-stylesheet": "4.0.0",
@@ -1901,17 +1900,17 @@
       }
     },
     "node_modules/braintree-web-drop-in": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/braintree-web-drop-in/-/braintree-web-drop-in-1.30.1.tgz",
-      "integrity": "sha512-W4sbiHZwrK16RWxBe7iYv986N1TlgO+eBdRdukW0qYNakTWSvgNzB9xk8RNpd1RB3Wt6zb64i4ZMU8A/MW+WAQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/braintree-web-drop-in/-/braintree-web-drop-in-1.28.0.tgz",
+      "integrity": "sha512-PM4+BgOGWRKvOwNQdNmxhJaezj9Bxz0jXSLs3xK85z/mppBpEOurM0x7xdSiN5gOCJ6PCuGYXLRFYR/+jA27Mg==",
       "dependencies": {
         "@braintree/asset-loader": "0.4.4",
-        "@braintree/browser-detection": "1.12.0",
+        "@braintree/browser-detection": "1.11.1",
         "@braintree/class-list": "0.2.0",
         "@braintree/event-emitter": "0.4.1",
         "@braintree/uuid": "0.1.0",
         "@braintree/wrap-promise": "2.1.0",
-        "braintree-web": "3.78.2",
+        "braintree-web": "3.76.3",
         "promise-polyfill": "8.2.0"
       }
     },
@@ -2215,11 +2214,11 @@
       "dev": true
     },
     "node_modules/card-validator": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/card-validator/-/card-validator-8.1.1.tgz",
-      "integrity": "sha512-cN4FsKwoTfTFnqPwVc7TQLSsH/QMDB3n/gWm0XelcApz4sKipnOQ6k33sa3bWsNnnIpgs7eXOF+mUV2UQAX2Sw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/card-validator/-/card-validator-8.1.0.tgz",
+      "integrity": "sha512-KlWjnGs6DyxRj9DLGPv+sb7AvU9Y6Od7DJWjnTghzplzsKz/vTYqRMK46xO/BCpHNqvnFNNVbSQa1vBFJ+/o8g==",
       "dependencies": {
-        "credit-card-type": "^9.1.0"
+        "credit-card-type": "^9.0.0"
       }
     },
     "node_modules/caseless": {
@@ -3671,7 +3670,7 @@
     },
     "node_modules/duo_web_sdk": {
       "version": "2.7.0",
-      "resolved": "git+ssh://git@github.com/duosecurity/duo_web_sdk.git#5f9a1a8598d2cda494c4f5ee0e38b31474abfee9",
+      "resolved": "git+https://github.com/duosecurity/duo_web_sdk.git#5f9a1a8598d2cda494c4f5ee0e38b31474abfee9",
       "integrity": "sha512-SYnekrMvi6aON7atFPE8H+F6JjXrz5HgVGbmc7GQH2mvYz6DH0Grh+MWNeB1LwD7D8nzrWbnhbZM77U2hoWrxQ==",
       "license": "SEE LICENSE IN LICENSE"
     },
@@ -14701,9 +14700,9 @@
       }
     },
     "@braintree/browser-detection": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.12.0.tgz",
-      "integrity": "sha512-fmZcaXYkXr9b0J+3HwXLQogIYV+xSS6aBG7LGu0OjLkSD/k62EAu2xLGEDFHUu6siH/I7vvGoC0/Ds3f3RnS6g=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.11.1.tgz",
+      "integrity": "sha512-jE5GRXNT2Ey3itbR7uTYdzbiLs9CP0kCInjTJFItApMFPj6F2Dm0Yb56C/69f7BL282gcCRqwhXVgaTeVwTWbw=="
     },
     "@braintree/class-list": {
       "version": "0.2.0",
@@ -14726,9 +14725,9 @@
       "integrity": "sha512-tVpr7U6u6bqeQlHreEjYMNtnHX62vLnNWziY2kQLqkWhvusPuY5DfuGEIPpWqsd+V/a1slyTQaxK6HWTlH6A/Q=="
     },
     "@braintree/sanitize-url": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-5.0.2.tgz",
-      "integrity": "sha512-NBEJlHWrhQucLhZGHtSxM2loSaNUMajC7KOYJLyfcdW/6goVoff2HoYI3bz8YCDN0wKGbxtUL0gx2dvHpvnWlw=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-5.0.1.tgz",
+      "integrity": "sha512-KzIC8q/UsT8g6bwRAQ0NbOCNxRoGbPKtqGBUtDaN8WN80xqsbHFs8z+Eq0fR0W1wcrcTB5oKNACsrbkK4X+FWA=="
     },
     "@braintree/uuid": {
       "version": "0.1.0",
@@ -15788,20 +15787,20 @@
       }
     },
     "braintree-web": {
-      "version": "3.78.2",
-      "resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.78.2.tgz",
-      "integrity": "sha512-aYKlog3j4BBAgUjRq52gn54/6Kp9zR7PalAzfhych/OArNq9xL0kO+OuQM7V0AxkTyoOHZ1qswIQ9MYPRws/ag==",
+      "version": "3.76.3",
+      "resolved": "https://registry.npmjs.org/braintree-web/-/braintree-web-3.76.3.tgz",
+      "integrity": "sha512-msXQ6zAs+lK0x58JOaWf5AM/+MISL4Z9P+Hm4nd6Q8SYeKXmu94wRTWYJYJj0S3PnuyoPyBqh9AYOjs709bkAQ==",
       "requires": {
         "@braintree/asset-loader": "0.4.4",
-        "@braintree/browser-detection": "1.12.0",
+        "@braintree/browser-detection": "1.11.1",
         "@braintree/class-list": "0.2.0",
         "@braintree/event-emitter": "0.4.1",
         "@braintree/extended-promise": "0.4.1",
         "@braintree/iframer": "1.1.0",
-        "@braintree/sanitize-url": "5.0.2",
+        "@braintree/sanitize-url": "5.0.1",
         "@braintree/uuid": "0.1.0",
         "@braintree/wrap-promise": "2.1.0",
-        "card-validator": "8.1.1",
+        "card-validator": "8.1.0",
         "credit-card-type": "9.1.0",
         "framebus": "5.1.2",
         "inject-stylesheet": "4.0.0",
@@ -15810,17 +15809,17 @@
       }
     },
     "braintree-web-drop-in": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/braintree-web-drop-in/-/braintree-web-drop-in-1.30.1.tgz",
-      "integrity": "sha512-W4sbiHZwrK16RWxBe7iYv986N1TlgO+eBdRdukW0qYNakTWSvgNzB9xk8RNpd1RB3Wt6zb64i4ZMU8A/MW+WAQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/braintree-web-drop-in/-/braintree-web-drop-in-1.28.0.tgz",
+      "integrity": "sha512-PM4+BgOGWRKvOwNQdNmxhJaezj9Bxz0jXSLs3xK85z/mppBpEOurM0x7xdSiN5gOCJ6PCuGYXLRFYR/+jA27Mg==",
       "requires": {
         "@braintree/asset-loader": "0.4.4",
-        "@braintree/browser-detection": "1.12.0",
+        "@braintree/browser-detection": "1.11.1",
         "@braintree/class-list": "0.2.0",
         "@braintree/event-emitter": "0.4.1",
         "@braintree/uuid": "0.1.0",
         "@braintree/wrap-promise": "2.1.0",
-        "braintree-web": "3.78.2",
+        "braintree-web": "3.76.3",
         "promise-polyfill": "8.2.0"
       }
     },
@@ -16074,11 +16073,11 @@
       "dev": true
     },
     "card-validator": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/card-validator/-/card-validator-8.1.1.tgz",
-      "integrity": "sha512-cN4FsKwoTfTFnqPwVc7TQLSsH/QMDB3n/gWm0XelcApz4sKipnOQ6k33sa3bWsNnnIpgs7eXOF+mUV2UQAX2Sw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/card-validator/-/card-validator-8.1.0.tgz",
+      "integrity": "sha512-KlWjnGs6DyxRj9DLGPv+sb7AvU9Y6Od7DJWjnTghzplzsKz/vTYqRMK46xO/BCpHNqvnFNNVbSQa1vBFJ+/o8g==",
       "requires": {
-        "credit-card-type": "^9.1.0"
+        "credit-card-type": "^9.0.0"
       }
     },
     "caseless": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "bitwarden-web",
-      "version": "2.20.4",
+      "version": "2.21.1",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bitwarden-web",
-  "version": "2.21.1",
+  "version": "2.21.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bitwarden-web",
-      "version": "2.21.1",
+      "version": "2.21.2",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitwarden-web",
-  "version": "2.21.1",
+  "version": "2.21.2",
   "license": "GPL-3.0",
   "repository": "https://github.com/bitwarden/web",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@bitwarden/jslib-common": "file:jslib/common",
     "angular2-toaster": "11.0.1",
     "bootstrap": "4.6.0",
-    "braintree-web-drop-in": "1.30.1",
+    "braintree-web-drop-in": "1.28.0",
     "browser-hrtime": "^1.1.8",
     "core-js": "^3.11.0",
     "date-input-polyfill": "^2.14.0",


### PR DESCRIPTION
Reverts https://github.com/bitwarden/web/pull/1066

Cloudflare is holding on to a pretty good amount of the `dropin.js` file in cache, which has kept PayPal checkout working for a lot of folks and has made it spotty across the board, but it was observed that for those users getting the latest/newest version of `dropin.js` using a newer version of the Braintree JavaScript Client SDK, the forever spinner is causing issues.

We need to revert this change and either figure something else out or find actual root cause and determine a proper fix later on. This change reverts the update in hopes of getting production working again across the board for PayPal.

Also, I've cut a new `rc` branch anticipating another release of the web vault and have version bumped accordingly.

cc: @sevensixseven 