### PR TITLE
Add cache-busting query param to dropin script

### DIFF
--- a/src/app/settings/payment.component.ts
+++ b/src/app/settings/payment.component.ts
@@ -73,7 +73,7 @@ export class PaymentComponent implements OnInit {
             this.setStripeElement();
         };
         this.btScript = window.document.createElement('script');
-        this.btScript.src = 'scripts/dropin.js';
+        this.btScript.src = `scripts/dropin.js?cache=${process.env.CACHE_TAG}`;
         this.btScript.async = true;
     }
 


### PR DESCRIPTION
## Objective
We had some issues with updating the braintree dependency in #936. Which turned out to be due to the `dropin.js` script being cached both in users browsers and on servers. To avoid this in the future, I've added a cache-busting query parameter similar to how we do it in other places.