### PR TITLE
Fixing Automated Web Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,9 +44,12 @@ jobs:
         run: |
           git config user.name = "GitHub Action Bot"
           git config user.email = "<>"
+          git config --global url."https://github.com/".insteadOf ssh://git@github.com/
+          git config --global url."https://".insteadOf ssh://
 
       - name: Install and Build
         run: |
+          npm run sub:init
           npm ci
           npm run dist
 


### PR DESCRIPTION
## Summary
With the version bump to npm version 7, we were experiencing some issues with npm resolving the package source to ssh instead of https. A workaround was presented in https://github.com/npm/cli/issues/2610 to force http in the CI pipeline. That change fixes the issue that happened in the web deploy.