### PR TITLE
typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm install
 ENV=production npm run build:watch
 ```
 
-You can also manually adjusting your API endpoint settings by adding `config/development.js` overriding any of the values in `config/base.json`. For example:
+You can also manually adjusting your API endpoint settings by adding `config/development.json` overriding any of the values in `config/base.json`. For example:
 
 ```typescript
 {
@@ -57,7 +57,7 @@ You can also manually adjusting your API endpoint settings by adding `config/dev
 }
 ```
 
-To pick up the overrides in the newly created `config/development.js` file, run the app with:
+To pick up the overrides in the newly created `config/development.json` file, run the app with:
 
 ```
 npm run build:dev:watch


### PR DESCRIPTION
build:dev:watch requires a development.json file, not development.js

Causes the error "[webpack-cli] Error: Cannot find module './config/development.json'" otherwise.