### PR TITLE
[Provider] Add events for Provider Organizations

### DIFF
--- a/bitwarden_license/src/app/providers/clients/clients.component.ts
+++ b/bitwarden_license/src/app/providers/clients/clients.component.ts
@@ -58,6 +58,13 @@ export class ClientsComponent implements OnInit {
             this.providerId = params.providerId;
 
             await this.load();
+
+            const queryParamsSub = this.route.queryParams.subscribe(async qParams => {
+                this.searchText = qParams.search;
+                if (queryParamsSub != null) {
+                    queryParamsSub.unsubscribe();
+                }
+            });
         });
     }
 

--- a/src/app/services/event.service.ts
+++ b/src/app/services/event.service.ts
@@ -245,6 +245,18 @@ export class EventService {
                 msg = this.i18nService.t('removedUserId', this.formatProviderUserId(ev));
                 humanReadableMsg = this.i18nService.t('removedUserId', this.getShortId(ev.providerUserId));
                 break;
+            case EventType.ProviderOrganization_Created:
+                msg = this.i18nService.t('createdOrganizationId', this.formatProviderOrganizationId(ev));
+                humanReadableMsg = this.i18nService.t('createdOrganizationId', this.getShortId(ev.providerOrganizationId));
+                break;
+            case EventType.ProviderOrganization_Added:
+                msg = this.i18nService.t('addedOrganizationId', this.formatProviderOrganizationId(ev));
+                humanReadableMsg = this.i18nService.t('addedOrganizationId', this.getShortId(ev.providerOrganizationId));
+                break;
+            case EventType.ProviderOrganization_Removed:
+                msg = this.i18nService.t('removedOrganizationId', this.formatProviderOrganizationId(ev));
+                humanReadableMsg = this.i18nService.t('removedOrganizationId', this.getShortId(ev.providerOrganizationId));
+                break;
             default:
                 break;
         }
@@ -342,6 +354,13 @@ export class EventService {
         return a.outerHTML;
     }
 
+    private formatProviderOrganizationId(ev: EventResponse) {
+        const shortId = this.getShortId(ev.providerOrganizationId);
+        const a = this.makeAnchor(shortId);
+        a.setAttribute('href', '#/providers/' + ev.providerId + '/clients?search=' + shortId);
+        return a.outerHTML;
+    }
+
     private formatPolicyId(ev: EventResponse) {
         const shortId = this.getShortId(ev.policyId);
         const a = this.makeAnchor(shortId);
@@ -357,7 +376,7 @@ export class EventService {
     }
 
     private getShortId(id: string) {
-        return id.substring(0, 8);
+        return id?.substring(0, 8);
     }
 
     private toDateTimeLocalString(date: Date) {

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -2577,6 +2577,33 @@
       }
     }
   },
+  "createdOrganizationId": {
+    "message": "Created organization $ID$.",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "John Smith"
+      }
+    }
+  },
+  "addedOrganizationId": {
+    "message": "Added organization $ID$.",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "John Smith"
+      }
+    }
+  },
+  "removedOrganizationId": {
+    "message": "Removed organization $ID$.",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "John Smith"
+      }
+    }
+  },
   "device": {
     "message": "Device"
   },


### PR DESCRIPTION
## Objective
Add events for creating/adding/removing organizations from a provider.

### Code Changes
- **bitwarden_license/src/app/providers/clients/clients.component.ts**: Add support for `search` query param.
- **src/app/services/event.service.ts**: Handle the new events. I also made `getShortId` fail gracefully if the value is null. (Should not happen in regular usage, but feels better to show `undefined` than a crashed view.

Depends on: https://github.com/bitwarden/server/pull/1475 & https://github.com/bitwarden/jslib/pull/432