### PR TITLE
Use the helper methods in EnvironmentService

### DIFF
--- a/src/app/accounts/register.component.ts
+++ b/src/app/accounts/register.component.ts
@@ -7,6 +7,7 @@ import {
 import { ApiService } from 'jslib-common/abstractions/api.service';
 import { AuthService } from 'jslib-common/abstractions/auth.service';
 import { CryptoService } from 'jslib-common/abstractions/crypto.service';
+import { EnvironmentService } from 'jslib-common/abstractions/environment.service';
 import { I18nService } from 'jslib-common/abstractions/i18n.service';
 import { PasswordGenerationService } from 'jslib-common/abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
@@ -36,9 +37,10 @@ export class RegisterComponent extends BaseRegisterComponent {
         i18nService: I18nService, cryptoService: CryptoService,
         apiService: ApiService, private route: ActivatedRoute,
         stateService: StateService, platformUtilsService: PlatformUtilsService,
-        passwordGenerationService: PasswordGenerationService, private policyService: PolicyService) {
+        passwordGenerationService: PasswordGenerationService, private policyService: PolicyService,
+        environmentService: EnvironmentService) {
         super(authService, router, i18nService, cryptoService, apiService, stateService, platformUtilsService,
-            passwordGenerationService);
+            passwordGenerationService, environmentService);
     }
 
     getPasswordScoreAlertDisplay() {

--- a/src/app/accounts/sso.component.ts
+++ b/src/app/accounts/sso.component.ts
@@ -7,6 +7,7 @@ import {
 import { ApiService } from 'jslib-common/abstractions/api.service';
 import { AuthService } from 'jslib-common/abstractions/auth.service';
 import { CryptoFunctionService } from 'jslib-common/abstractions/cryptoFunction.service';
+import { EnvironmentService } from 'jslib-common/abstractions/environment.service';
 import { I18nService } from 'jslib-common/abstractions/i18n.service';
 import { PasswordGenerationService } from 'jslib-common/abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
@@ -26,10 +27,10 @@ export class SsoComponent extends BaseSsoComponent {
         i18nService: I18nService, route: ActivatedRoute,
         storageService: StorageService, stateService: StateService,
         platformUtilsService: PlatformUtilsService, apiService: ApiService,
-        cryptoFunctionService: CryptoFunctionService,
+        cryptoFunctionService: CryptoFunctionService, environmentService: EnvironmentService,
         passwordGenerationService: PasswordGenerationService) {
         super(authService, router, i18nService, route, storageService, stateService, platformUtilsService,
-            apiService, cryptoFunctionService, passwordGenerationService);
+            apiService, cryptoFunctionService, environmentService, passwordGenerationService);
         this.redirectUri = window.location.origin + '/sso-connector.html';
         this.clientId = 'web';
     }

--- a/src/app/layouts/organization-layout.component.ts
+++ b/src/app/layouts/organization-layout.component.ts
@@ -34,12 +34,7 @@ export class OrganizationLayoutComponent implements OnInit, OnDestroy {
         private environmentService: EnvironmentService) { }
 
     ngOnInit() {
-        this.businessUrl = 'https://portal.bitwarden.com';
-        if (this.environmentService.enterpriseUrl != null) {
-            this.businessUrl = this.environmentService.enterpriseUrl;
-        } else if (this.environmentService.baseUrl != null) {
-            this.businessUrl = this.environmentService.baseUrl + '/portal';
-        }
+        this.businessUrl = this.environmentService.getEnterpriseUrl();
 
         document.body.classList.remove('layout_frontend');
         this.route.params.subscribe(async params => {

--- a/src/app/organizations/manage/policies.component.ts
+++ b/src/app/organizations/manage/policies.component.ts
@@ -149,12 +149,7 @@ export class PoliciesComponent implements OnInit {
         });
 
         // Remove when removing deprecation warning
-        this.enterpriseUrl = 'https://portal.bitwarden.com';
-        if (this.environmentService.enterpriseUrl != null) {
-            this.enterpriseUrl = this.environmentService.enterpriseUrl;
-        } else if (this.environmentService.baseUrl != null) {
-            this.enterpriseUrl = this.environmentService.baseUrl + '/portal';
-        }
+        this.enterpriseUrl = this.environmentService.getEnterpriseUrl();
     }
 
     async load() {

--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -103,7 +103,8 @@ const cryptoService = new CryptoService(storageService,
     consoleLogService);
 const tokenService = new TokenService(storageService);
 const appIdService = new AppIdService(storageService);
-const apiService = new ApiService(tokenService, platformUtilsService,
+const environmentService = new EnvironmentService(storageService);
+const apiService = new ApiService(tokenService, platformUtilsService, environmentService,
     async (expired: boolean) => messagingService.send('logout', { expired: expired }));
 const userService = new UserService(tokenService, storageService);
 const settingsService = new SettingsService(userService, storageService);
@@ -133,9 +134,8 @@ const authService = new AuthService(cryptoService, apiService,
 const exportService = new ExportService(folderService, cipherService, apiService, cryptoService);
 const importService = new ImportService(cipherService, folderService, apiService, i18nService, collectionService,
     platformUtilsService, cryptoService);
-const notificationsService = new NotificationsService(userService, syncService, appIdService,
-    apiService, vaultTimeoutService, async () => messagingService.send('logout', { expired: true }), consoleLogService);
-const environmentService = new EnvironmentService(apiService, storageService, notificationsService);
+const notificationsService = new NotificationsService(userService, syncService, appIdService, apiService, vaultTimeoutService,
+    environmentService, async () => messagingService.send('logout', { expired: true }), consoleLogService);
 const auditService = new AuditService(cryptoFunctionService, apiService);
 const eventLoggingService = new EventLoggingService(storageService, apiService, userService, cipherService);
 const passwordRepromptService = new PasswordRepromptService(i18nService, cryptoService, platformUtilsService);
@@ -147,19 +147,16 @@ export function initFactory(): Function {
         await (storageService as HtmlStorageService).init();
 
         if (process.env.ENV !== 'production' || platformUtilsService.isSelfHost()) {
-            environmentService.baseUrl = window.location.origin;
+            environmentService.setUrls({ base: window.location.origin }, false);
         } else {
-            environmentService.notificationsUrl = 'https://notifications.bitwarden.com';
-            environmentService.enterpriseUrl = 'https://portal.bitwarden.com';
+            environmentService.setUrls({
+                base: window.location.origin,
+                notifications: 'https://notifications.bitwarden.com',
+                enterprise: 'https://portal.bitwarden.com',
+            }, false);
         }
 
-        apiService.setUrls({
-            base: window.location.origin,
-            api: null,
-            identity: null,
-            events: null,
-        });
-        setTimeout(() => notificationsService.init(environmentService), 3000);
+        setTimeout(() => notificationsService.init(), 3000);
 
         vaultTimeoutService.init(true);
         const locale = await storageService.get<string>(ConstantsService.localeKey);

--- a/src/app/settings/link-sso.component.ts
+++ b/src/app/settings/link-sso.component.ts
@@ -8,6 +8,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { ApiService } from 'jslib-common/abstractions/api.service';
 import { AuthService } from 'jslib-common/abstractions/auth.service';
 import { CryptoFunctionService } from 'jslib-common/abstractions/cryptoFunction.service';
+import { EnvironmentService } from 'jslib-common/abstractions/environment.service';
 import { I18nService } from 'jslib-common/abstractions/i18n.service';
 import { PasswordGenerationService } from 'jslib-common/abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
@@ -30,12 +31,12 @@ export class LinkSsoComponent extends SsoComponent implements AfterContentInit {
         apiService: ApiService, authService: AuthService,
         router: Router, route: ActivatedRoute,
         cryptoFunctionService: CryptoFunctionService, passwordGenerationService: PasswordGenerationService,
-        storageService: StorageService, stateService: StateService) {
+        storageService: StorageService, stateService: StateService, environmentService: EnvironmentService) {
         super(authService, router,
             i18nService, route,
             storageService, stateService,
             platformUtilsService, apiService,
-            cryptoFunctionService, passwordGenerationService);
+            cryptoFunctionService, environmentService, passwordGenerationService);
 
         this.returnUri = '/settings/organizations';
         this.redirectUri = window.location.origin + '/sso-connector.html';


### PR DESCRIPTION
## Objective
It was difficult to figure out which urls were used through the application, since there were no central place to store/retrieve them. To resolve this, I refactored the `EnvironmentService` to keep the state private, and instead expose helper functions for retrieving the appropriate urls.

### Testing Considerations
We should verify all api calls, links, etc still works as expected in our different environments. As well as ensuring notification service gets initialized, since the logic no longer happens in `environmentService`.

Depends on:
https://github.com/bitwarden/jslib/pull/435

Related to:
https://app.asana.com/0/1169444489336079/1200631805316488