### PR TITLE
Ensure Angular is running as production

### DIFF
--- a/bitwarden_license/src/app/main.ts
+++ b/bitwarden_license/src/app/main.ts
@@ -10,7 +10,7 @@ require('src/scss/styles.scss');
 
 import { AppModule } from './app.module';
 
-if (process.env.ENV === 'production') {
+if (process.env.NODE_ENV === 'production') {
     enableProdMode();
 }
 

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -10,7 +10,7 @@ require('../scss/styles.scss');
 
 import { AppModule } from './app.module';
 
-if (process.env.ENV === 'production') {
+if (process.env.NODE_ENV === 'production') {
     enableProdMode();
 }
 

--- a/src/app/polyfills.ts
+++ b/src/app/polyfills.ts
@@ -7,7 +7,7 @@ if (!Element.prototype.matches && (Element.prototype as any).msMatchesSelector) 
     Element.prototype.matches = (Element.prototype as any).msMatchesSelector;
 }
 
-if (process.env.ENV === 'production') {
+if (process.env.NODE_ENV === 'production') {
     // Production
 } else {
     // Development and test

--- a/src/app/settings/add-credit.component.ts
+++ b/src/app/settings/add-credit.component.ts
@@ -47,7 +47,7 @@ export class AddCreditComponent implements OnInit {
 
     constructor(private userService: UserService, private apiService: ApiService,
         private platformUtilsService: PlatformUtilsService) {
-        if (platformUtilsService.isDev()) {
+        if (process.env.ENV !== 'production') {
             this.ppButtonFormAction = WebConstants.paypal.buttonActionSandbox;
             this.ppButtonBusinessId = WebConstants.paypal.businessIdSandbox;
         }

--- a/src/app/settings/add-credit.component.ts
+++ b/src/app/settings/add-credit.component.ts
@@ -47,7 +47,7 @@ export class AddCreditComponent implements OnInit {
 
     constructor(private userService: UserService, private apiService: ApiService,
         private platformUtilsService: PlatformUtilsService) {
-        if (process.env.ENV !== 'production') {
+        if (process.env.ENV !== 'production' || platformUtilsService.isDev()) {
             this.ppButtonFormAction = WebConstants.paypal.buttonActionSandbox;
             this.ppButtonBusinessId = WebConstants.paypal.businessIdSandbox;
         }

--- a/src/app/settings/payment.component.ts
+++ b/src/app/settings/payment.component.ts
@@ -67,7 +67,7 @@ export class PaymentComponent implements OnInit {
         this.stripeScript.src = 'https://js.stripe.com/v3/';
         this.stripeScript.async = true;
         this.stripeScript.onload = () => {
-            this.stripe = (window as any).Stripe(process.env.ENV === 'production'  ?
+            this.stripe = (window as any).Stripe(process.env.ENV === 'production' && !platformUtilsService.isDev()  ?
                 WebConstants.stripeLiveKey : WebConstants.stripeTestKey);
             this.stripeElements = this.stripe.elements();
             this.setStripeElement();

--- a/src/app/settings/payment.component.ts
+++ b/src/app/settings/payment.component.ts
@@ -126,8 +126,8 @@ export class PaymentComponent implements OnInit {
         if (this.method === PaymentMethodType.PayPal) {
             window.setTimeout(() => {
                 (window as any).braintree.dropin.create({
-                    authorization: this.platformUtilsService.isDev() ?
-                        WebConstants.btSandboxKey : WebConstants.btProductionKey,
+                    authorization: process.env.ENV === 'production' ?
+                        WebConstants.btProductionKey : WebConstants.btSandboxKey,
                     container: '#bt-dropin-container',
                     paymentOptionPriority: ['paypal'],
                     paypal: {

--- a/src/services/webPlatformUtils.service.ts
+++ b/src/services/webPlatformUtils.service.ts
@@ -249,7 +249,7 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
     }
 
     isDev(): boolean {
-        return process.env.ENV === 'development';
+        return process.env.NODE_ENV === 'development';
     }
 
     isSelfHost(): boolean {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -135,6 +135,7 @@ const plugins = [
     new webpack.DefinePlugin({
         'process.env': {
             'ENV': JSON.stringify(ENV),
+            'NODE_ENV': NODE_ENV === 'production' ? 'production' : 'development',
             'SELF_HOST': JSON.stringify(process.env.SELF_HOST === 'true' ? true : false),
             'APPLICATION_VERSION': JSON.stringify(pjson.version),
             'CACHE_TAG': JSON.stringify(Math.random().toString(36).substring(7)),


### PR DESCRIPTION
## Objective
In #994, we changed `process.env.ENV` to use `ENV` instead of `NODE_ENV`. This had the side effect of also propagating to other parts where we want to use `NODE_ENV`.

### Code Changes
- **app/main.ts**: Angular now only runs in development mode when NODE_ENV==production.
- **webpack.config.js**: Added `NODE_ENV`, and enforce it to be either `production` or `development`.
- **src/services/webPlatformUtils.service.ts**: Changed `isDev` to use `NODE_ENV` to be more consistent with other platforms. And avoid development settings from being exposed in production.
- **src/app/settings/payment.component.ts**: Ensured `ENV` is still used to toggle paypal sandbox.
- **src/app/settings/add-credit.component.ts**: Ensured `ENV` is still used to toggle paypal sandbox.

https://app.asana.com/0/1169444489336079/1200631708822147