### PR TITLE
Move ciphers paging logic from jslib to web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "date-input-polyfill": "^2.14.0",
         "font-awesome": "4.7.0",
         "jquery": "3.6.0",
+        "ngx-infinite-scroll": "10.0.1",
         "popper.js": "1.16.1",
         "qrious": "4.0.2",
         "sweetalert2": "^10.16.6",
@@ -79,7 +80,6 @@
         "@angular/router": "^11.2.11",
         "@bitwarden/jslib-common": "file:../common",
         "duo_web_sdk": "git+https://github.com/duosecurity/duo_web_sdk.git",
-        "ngx-infinite-scroll": "10.0.1",
         "rxjs": "6.6.7",
         "tldjs": "^2.3.1",
         "zone.js": "0.11.4"
@@ -14665,7 +14665,6 @@
         "@bitwarden/jslib-common": "file:../common",
         "@types/duo_web_sdk": "^2.7.1",
         "duo_web_sdk": "git+https://github.com/duosecurity/duo_web_sdk.git",
-        "ngx-infinite-scroll": "10.0.1",
         "rimraf": "^3.0.2",
         "rxjs": "6.6.7",
         "tldjs": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "date-input-polyfill": "^2.14.0",
     "font-awesome": "4.7.0",
     "jquery": "3.6.0",
+    "ngx-infinite-scroll": "^10.0.1",
     "popper.js": "1.16.1",
     "qrious": "4.0.2",
     "sweetalert2": "^10.16.6",

--- a/src/app/accounts/register.component.ts
+++ b/src/app/accounts/register.component.ts
@@ -7,6 +7,7 @@ import {
 import { ApiService } from 'jslib-common/abstractions/api.service';
 import { AuthService } from 'jslib-common/abstractions/auth.service';
 import { CryptoService } from 'jslib-common/abstractions/crypto.service';
+import { EnvironmentService } from 'jslib-common/abstractions/environment.service';
 import { I18nService } from 'jslib-common/abstractions/i18n.service';
 import { PasswordGenerationService } from 'jslib-common/abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
@@ -36,9 +37,10 @@ export class RegisterComponent extends BaseRegisterComponent {
         i18nService: I18nService, cryptoService: CryptoService,
         apiService: ApiService, private route: ActivatedRoute,
         stateService: StateService, platformUtilsService: PlatformUtilsService,
-        passwordGenerationService: PasswordGenerationService, private policyService: PolicyService) {
+        passwordGenerationService: PasswordGenerationService, environmentService: EnvironmentService,
+        private policyService: PolicyService) {
         super(authService, router, i18nService, cryptoService, apiService, stateService, platformUtilsService,
-            passwordGenerationService);
+            passwordGenerationService, environmentService);
     }
 
     getPasswordScoreAlertDisplay() {

--- a/src/app/vault/ciphers.component.ts
+++ b/src/app/vault/ciphers.component.ts
@@ -44,8 +44,7 @@ export class CiphersComponent extends BaseCiphersComponent implements OnDestroy 
     actionPromise: Promise<any>;
     userHasPremiumAccess = false;
 
-    protected didScroll = false;
-
+    private didScroll = false;
     private pagedCiphersCount = 0;
     private refreshing = false;
 


### PR DESCRIPTION
## Objective

https://github.com/bitwarden/desktop/pull/1001 and https://github.com/bitwarden/browser/pull/1858 removed the infinite scrolling logic from desktop and browser, in favour of a virtual scroll. Infinite scroll is still required for web, but it doesn't need to live in the jslib base class any more.

This PR moves the paging logic into web.

See https://github.com/bitwarden/jslib/pull/436 for removing this logic from jslib.

Note: tests are failing due to jslib, plus unrelated changes in #1101 and #1104 that haven't been merged yet.