### PR TITLE
initial trial of automating the crowdin syncing

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -1,0 +1,133 @@
+name: Crowdin Sync
+
+on:
+  workflow_dispatch:
+    inputs: {}
+  #schedule:
+  #  - cron: '0 0 * * *'
+
+jobs:
+  crowdin-sync:
+    name: Autosync
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
+
+      - name: Setup git config
+        run: |
+          git config user.name = "GitHub Action Bot"
+          git config user.email = "<>"
+
+      - name: Get Crowndin Sync Branch
+        id: branch
+        run: |
+          BRANCH_NAME=crowdin-auto-sync
+          BRANCH_EXISTED=true
+
+          git fetch -a
+          git switch master
+          if [ $(git branch -a | egrep "remotes/origin/${BRANCH_NAME}$" | wc -l) -eq 0 ]; then
+            BRANCH_EXISTED=false
+            git switch -c $BRANCH_NAME
+          else
+            git switch $BRANCH_NAME
+          fi
+          git branch
+
+          echo "::set-output name=branch-existed::${BRANCH_EXISTED}"
+          echo "::set-output name=branch-name::${BRANCH_NAME}"
+
+      - name: Login to Azure
+        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
+        with:
+          creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
+
+      - name: Retrieve secrets
+        id: retrieve-secrets
+        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
+        with:
+          keyvault: "bitwarden-prod-kv"
+          secrets: "crowdin-api-token"
+
+      - name: Get Crowdin updates
+        env:
+          CROWDIN_BASE_URL="https://api.crowdin.com/api/v2/projects"
+          CROWDIN_PROJECT_ID="308189"
+        run: |
+          # Step 1: GET master branchId
+          BRANCH_ID=$(
+              curl -s -H "Authorization: Bearer $CROWDIN_API_TOKEN" \
+              $CROWDIN_BASE_URL/$CROWDIN_PROJECT_ID/branches | jq -r '.data[0].data.id'
+          )
+
+          # Step 2: POST Build the translations and get store build id
+          BUILD_ID=$(
+              curl -X POST -s \
+              -H "Authorization: Bearer $CROWDIN_API_TOKEN" \
+              -H "Content-Type: application/json" \
+              $CROWDIN_BASE_URL/$CROWDIN_PROJECT_ID/translations/builds \
+              -d "{\"branchId\": $BRANCH_ID}" | jq -r '.data.id'
+          )
+
+          MAX_TRIES=12
+          for try in {1..$MAX_TRIES}; do
+              BRANCH_STATUS=$(
+                  curl -s -H "Authorization: Bearer $CROWDIN_API_TOKEN" \
+                  $CROWDIN_BASE_URL/$CROWDIN_PROJECT_ID/translations/builds/$BUILD_ID | jq -r '.data.status'
+              )
+              echo "[*] Build status: $BRANCH_STATUS"
+              if [[ "$BRANCH_STATUS" == "finished" ]]; then
+                  break
+              fi
+
+              if [[ $try -eq $MAX_TRIES ]]; then
+                  echo "[!] Exceeded tries: $try"
+                  exit 1
+              else
+                  sleep 5
+              fi
+          done
+
+          # Step 4: when build is finished, get download url
+          DOWNLOAD_URL=$(
+              curl -s -H "Authorization: Bearer $CROWDIN_API_TOKEN" \
+              $CROWDIN_BASE_URL/$CROWDIN_PROJECT_ID/translations/builds/$BUILD_ID/download | jq -r '.data.url'
+          )
+
+          # Step 5: download the translations via the download url
+          SAVE_FILE=translations.zip
+          curl -s $DOWNLOAD_URL --output $SAVE_FILE
+          echo "[*]    Saved to: $SAVE_FILE"
+
+          # Step 6: Unzip and cleanup
+          unzip -o $SAVE_FILE
+          rm $SAVE_FILE
+
+      - name: Commit changes
+        env:
+          BRANCH_NAME: ${{ steps.branch.outputs.branch-name }}
+        run: |
+          echo "[*] Adding new translations"
+          git add .
+          echo "=====Translations Changed====="
+          git status
+          echo "=============================="
+          echo "[*] Committing"
+          git commit -m "Autosync Crowdin translations"
+          echo "[*] Pushing"
+          git push -u origin $BRANCH_NAME
+
+      - name: Create/Update PR
+        env:
+          BRANCH_NAME: ${{ steps.cherry-pick.outputs.branch-name }}
+          BRANCH_EXISTED: ${{ steps.cherry-pick.outputs.branch-existed }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$BRANCH_EXISTED" == "false" ]; then
+            echo "[*] Creating PR"
+            gh pr create --title "Autosync Crowdin Translations" \
+            --body "Autosync the updated translations"
+          else
+            echo "[*] Existing PR updated"
+          fi


### PR DESCRIPTION
## Summary
Automates the Crowdin translation sync to keep the PR noise down, but increase the ease of use for developers. 

It is currently set up to be manually ran. However, if triggered on a schedule, it will create a single PR and continually update that PR until it is merged in. 

## Testing Notes
This workflow didn't exist in the default branch, so this has not been tested yet. It must be merged in first