### PR TITLE
Set env with EnvironmentPlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -137,14 +137,12 @@ const plugins = [
         filename: '[name].[hash].css',
         chunkFilename: '[id].[hash].css',
     }),
-    new webpack.DefinePlugin({
-        'process.env': {
-            'ENV': JSON.stringify(ENV),
-            'NODE_ENV': NODE_ENV === 'production' ? 'production' : 'development',
-            'SELF_HOST': JSON.stringify(process.env.SELF_HOST === 'true' ? true : false),
-            'APPLICATION_VERSION': JSON.stringify(pjson.version),
-            'CACHE_TAG': JSON.stringify(Math.random().toString(36).substring(7)),
-        }
+    new webpack.EnvironmentPlugin({
+        'ENV': JSON.stringify(ENV),
+        'NODE_ENV': NODE_ENV === 'production' ? 'production' : 'development',
+        'SELF_HOST': JSON.stringify(process.env.SELF_HOST === 'true' ? true : false),
+        'APPLICATION_VERSION': JSON.stringify(pjson.version),
+        'CACHE_TAG': JSON.stringify(Math.random().toString(36).substring(7)),
     }),
     new AngularCompilerPlugin({
         tsConfigPath: 'tsconfig.json',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -138,11 +138,11 @@ const plugins = [
         chunkFilename: '[id].[hash].css',
     }),
     new webpack.EnvironmentPlugin({
-        'ENV': JSON.stringify(ENV),
+        'ENV': ENV,
         'NODE_ENV': NODE_ENV === 'production' ? 'production' : 'development',
-        'SELF_HOST': JSON.stringify(process.env.SELF_HOST === 'true' ? true : false),
-        'APPLICATION_VERSION': JSON.stringify(pjson.version),
-        'CACHE_TAG': JSON.stringify(Math.random().toString(36).substring(7)),
+        'SELF_HOST': process.env.SELF_HOST === 'true' ? true : false,
+        'APPLICATION_VERSION': pjson.version,
+        'CACHE_TAG': Math.random().toString(36).substring(7),
     }),
     new AngularCompilerPlugin({
         tsConfigPath: 'tsconfig.json',


### PR DESCRIPTION
# Overview

Fixes QA env issue apparently introduced in #1093 

Switch to using `EnvironmentPlugin` to set environment rather than `DefinePlugin`. It appears that the definition of the `process.env` object isn't settings our default values correctly.

I believe the two environment replacements _should_ be identical, but we're seeing issues in qa testing with missing settings. It looks like webpack is replacing the env variable with a variable rather than a string. This plugin just replaces the entire if statement with a boolean

## DefinePlugin:
<img width="538" alt="image" src="https://user-images.githubusercontent.com/18214891/126856832-3b4ba743-4dd9-40a0-9557-3e6d0408f61e.png">

## EnvironmentPlugin
<img width="538" alt="image" src="https://user-images.githubusercontent.com/18214891/126856891-83b2099b-d5b7-404b-bea3-11618b5e1224.png">
