### PR TITLE
Validate permissions before API calls

### DIFF
--- a/src/app/organizations/manage/events.component.ts
+++ b/src/app/organizations/manage/events.component.ts
@@ -59,12 +59,19 @@ export class EventsComponent extends BaseEventsComponent implements OnInit {
             this.orgUsersUserIdMap.set(u.userId, { name: name, email: u.email });
         });
 
-        if (this.organization.providerId != null && (await this.userService.getProvider(this.organization.providerId)) != null) {
-            const providerUsersResponse = await this.apiService.getProviderUsers(this.organization.providerId);
-            providerUsersResponse.data.forEach(u => {
-                const name = this.userNamePipe.transform(u);
-                this.orgUsersUserIdMap.set(u.userId, { name: `${name} (${this.organization.providerName})`, email: u.email });
-            });
+        if (this.organization.providerId != null) {
+            try {
+                const provider = await this.userService.getProvider(this.organization.providerId);
+                if (provider != null && (await this.userService.getProvider(this.organization.providerId)).canManageUsers) {
+                    const providerUsersResponse = await this.apiService.getProviderUsers(this.organization.providerId);
+                    providerUsersResponse.data.forEach(u => {
+                        const name = this.userNamePipe.transform(u);
+                        this.orgUsersUserIdMap.set(u.userId, { name: `${name} (${this.organization.providerName})`, email: u.email });
+                    });
+                }
+            } catch (e) {
+                this.logService.warning(e);
+            }
         }
 
         await this.loadEvents(true);


### PR DESCRIPTION
# Overview

fixes https://app.asana.com/0/0/1200664904812608/f

Manage users is required to list provider users. If this permission is missing we currently fail to load due to an api call failure.

This change skips provider users api call if the user does not have the required permission. the event is then listed as done by the provider name rather than the provider user that did it.