### PR TITLE
Remove dependency on duo_web_sdk and update jslib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "browser-hrtime": "^1.1.8",
         "core-js": "^3.11.0",
         "date-input-polyfill": "^2.14.0",
-        "duo_web_sdk": "git+https://github.com/duosecurity/duo_web_sdk.git#5f9a1a8598d2cda494c4f5ee0e38b31474abfee9",
         "font-awesome": "4.7.0",
         "jquery": "3.6.0",
         "popper.js": "1.16.1",
@@ -30,7 +29,6 @@
       "devDependencies": {
         "@angular/compiler-cli": "^11.2.11",
         "@ngtools/webpack": "^11.2.10",
-        "@types/duo_web_sdk": "^2.7.0",
         "@types/jquery": "^3.5.5",
         "@types/node": "^14.17.2",
         "@types/webcrypto": "^0.0.28",
@@ -80,12 +78,14 @@
         "@angular/platform-browser-dynamic": "^11.2.11",
         "@angular/router": "^11.2.11",
         "@bitwarden/jslib-common": "file:../common",
+        "duo_web_sdk": "git+https://github.com/duosecurity/duo_web_sdk.git",
         "ngx-infinite-scroll": "10.0.1",
         "rxjs": "6.6.7",
         "tldjs": "^2.3.1",
         "zone.js": "0.11.4"
       },
       "devDependencies": {
+        "@types/duo_web_sdk": "^2.7.1",
         "rimraf": "^3.0.2",
         "typescript": "4.1.5"
       }
@@ -102,6 +102,7 @@
         "lunr": "^2.3.9",
         "node-forge": "^0.10.0",
         "papaparse": "^5.3.0",
+        "rxjs": "6.6.7",
         "tldjs": "^2.3.1",
         "zxcvbn": "^4.4.2"
       },
@@ -740,9 +741,9 @@
       "hasInstallScript": true
     },
     "node_modules/@types/duo_web_sdk": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@types/duo_web_sdk/-/duo_web_sdk-2.7.0.tgz",
-      "integrity": "sha512-E8cRtor4+hYNVYZ/hk+0WoZtiGOWvxhX3UsJtNtVlDIk2d8dnbYX6wdhqBTwixPpw7ea3I8IS3BAK81GRXyLUQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@types/duo_web_sdk/-/duo_web_sdk-2.7.1.tgz",
+      "integrity": "sha512-DePanZjFww36yGSxXwC8B3AsjrrDuPxEcufeh4gTqVsUMpCYByxjX4PERiYZdW0typzKSt9E4I14PPp+PrSIQA==",
       "dev": true
     },
     "node_modules/@types/glob": {
@@ -14662,6 +14663,8 @@
         "@angular/platform-browser-dynamic": "^11.2.11",
         "@angular/router": "^11.2.11",
         "@bitwarden/jslib-common": "file:../common",
+        "@types/duo_web_sdk": "^2.7.1",
+        "duo_web_sdk": "git+https://github.com/duosecurity/duo_web_sdk.git",
         "ngx-infinite-scroll": "10.0.1",
         "rimraf": "^3.0.2",
         "rxjs": "6.6.7",
@@ -14687,6 +14690,7 @@
         "node-forge": "^0.10.0",
         "papaparse": "^5.3.0",
         "rimraf": "^3.0.2",
+        "rxjs": "6.6.7",
         "tldjs": "^2.3.1",
         "typescript": "4.1.5",
         "zxcvbn": "^4.4.2"
@@ -14818,9 +14822,9 @@
       "integrity": "sha512-b2iE8kjjzzUo2WZ0xuE2N77kfnTds7ClrDxcz3Atz7h2XrNVoAPUoT75i7CY0st5x++70V91Y+c6RpBX9MX7Jg=="
     },
     "@types/duo_web_sdk": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@types/duo_web_sdk/-/duo_web_sdk-2.7.0.tgz",
-      "integrity": "sha512-E8cRtor4+hYNVYZ/hk+0WoZtiGOWvxhX3UsJtNtVlDIk2d8dnbYX6wdhqBTwixPpw7ea3I8IS3BAK81GRXyLUQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@types/duo_web_sdk/-/duo_web_sdk-2.7.1.tgz",
+      "integrity": "sha512-DePanZjFww36yGSxXwC8B3AsjrrDuPxEcufeh4gTqVsUMpCYByxjX4PERiYZdW0typzKSt9E4I14PPp+PrSIQA==",
       "dev": true
     },
     "@types/glob": {
@@ -17255,7 +17259,7 @@
     "duo_web_sdk": {
       "version": "git+ssh://git@github.com/duosecurity/duo_web_sdk.git#5f9a1a8598d2cda494c4f5ee0e38b31474abfee9",
       "integrity": "sha512-SYnekrMvi6aON7atFPE8H+F6JjXrz5HgVGbmc7GQH2mvYz6DH0Grh+MWNeB1LwD7D8nzrWbnhbZM77U2hoWrxQ==",
-      "from": "duo_web_sdk@git+https://github.com/duosecurity/duo_web_sdk.git#5f9a1a8598d2cda494c4f5ee0e38b31474abfee9"
+      "from": "duo_web_sdk@git+https://github.com/duosecurity/duo_web_sdk.git"
     },
     "duplexify": {
       "version": "3.7.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@angular/compiler-cli": "^11.2.11",
     "@ngtools/webpack": "^11.2.10",
-    "@types/duo_web_sdk": "^2.7.0",
     "@types/jquery": "^3.5.5",
     "@types/node": "^14.17.2",
     "@types/webcrypto": "^0.0.28",
@@ -79,7 +78,6 @@
     "browser-hrtime": "^1.1.8",
     "core-js": "^3.11.0",
     "date-input-polyfill": "^2.14.0",
-    "duo_web_sdk": "git+https://github.com/duosecurity/duo_web_sdk.git#5f9a1a8598d2cda494c4f5ee0e38b31474abfee9",
     "font-awesome": "4.7.0",
     "jquery": "3.6.0",
     "popper.js": "1.16.1",


### PR DESCRIPTION
## Objective
With bitwarden/jslib#441 I added `duo_web_sdk` as a dependency to `jslib/angular`. As jslib/angular is a dependency of this repo, it will pull in it's sub-dependencies of needed. Hence `duo_web_sdk` will still be available.

## Code Changes
- **package.json**:  Removed dev-dependency `@types/duo_web_sdk` and git link to `duo_web_sdk`
- **package.lock.json**: Changes after running `npm i`
- **jslib**: Updated submodule to current master