### PR TITLE
Removed create account button from provider setup email

### DIFF
--- a/bitwarden_license/src/app/providers/setup/setup-provider.component.html
+++ b/bitwarden_license/src/app/providers/setup/setup-provider.component.html
@@ -19,10 +19,6 @@
                         <a routerLink="/" [queryParams]="{email: email}" class="btn btn-primary btn-block">
                             {{'logIn' | i18n}}
                         </a>
-                        <a routerLink="/register" [queryParams]="{email: email}"
-                            class="btn btn-primary btn-block ml-2 mt-0">
-                            {{'createAccount' | i18n}}
-                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Related Work
[Bug report](https://app.asana.com/0/1183359552741420/1200652187192756/f)

### Issue
Currently, the user flow supports an existing Bitwarden user being able to set up a Provider. If a user is not an existing Bitwarden user and attempts to create an account, the page errors out. Create Account should be removed. We will address the non-existing Bitwarden user flow in the next release, given that most of our MSP customers are already using Bitwarden internally. 

### Fix
* Simply Removed the "Create Account" button from the page. The "Log In" button stretches to fill the empty space. I messed around with making it smaller, but ultimately thought the block behavior looked the best.

![Screen Shot 2021-07-28 at 12 56 03 PM](https://user-images.githubusercontent.com/15897251/127371323-a4ae9513-c869-47a0-9edb-4793b4ceb7f7.png)
