### PR TITLE
Add owner email to provider org creation

### DIFF
--- a/bitwarden_license/src/app/providers/clients/create-organization.component.html
+++ b/bitwarden_license/src/app/providers/clients/create-organization.component.html
@@ -2,4 +2,4 @@
     <h1>{{'newClientOrganization' | i18n}}</h1>
 </div>
 <p>{{'newClientOrganizationDesc' | i18n}}</p>
-<app-organization-plans [providerId]="providerId" [showOwnerInvite]="true"></app-organization-plans>
+<app-organization-plans [providerId]="providerId"></app-organization-plans>

--- a/bitwarden_license/src/app/providers/clients/create-organization.component.html
+++ b/bitwarden_license/src/app/providers/clients/create-organization.component.html
@@ -2,4 +2,4 @@
     <h1>{{'newClientOrganization' | i18n}}</h1>
 </div>
 <p>{{'newClientOrganizationDesc' | i18n}}</p>
-<app-organization-plans [providerId]="providerId"></app-organization-plans>
+<app-organization-plans [providerId]="providerId" [showOwnerInvite]="true"></app-organization-plans>

--- a/src/app/settings/organization-plans.component.html
+++ b/src/app/settings/organization-plans.component.html
@@ -8,7 +8,8 @@
         <div class="form-group">
             <label for="file">{{'licenseFile' | i18n}}</label>
             <input type="file" id="file" class="form-control-file" name="file" required>
-            <small class="form-text text-muted">{{'licenseFileDesc' | i18n : 'bitwarden_organization_license.json'}}</small>
+            <small class="form-text text-muted">{{'licenseFileDesc' | i18n :
+                'bitwarden_organization_license.json'}}</small>
         </div>
         <button type="submit" class="btn btn-primary btn-submit" [disabled]="form.loading">
             <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
@@ -34,22 +35,19 @@
             <input id="email" class="form-control" type="text" name="Email" [(ngModel)]="clientOwnerEmail" required>
             <small class="text-muted">{{'ownerDesc' | i18n : '20'}}</small>
         </div>
-        <div class="form-group col-6" *ngIf="!!providerId">
-            <label for="businessName">{{'businessName' | i18n}}</label>
-            <input id="businessName" class="form-control" type="text" name="BusinessName" [(ngModel)]="businessName">
-        </div>
-        </div>
-        <div *ngIf="!providerId">
+    </div>
+    <div *ngIf="!providerId">
         <div class="form-group form-check">
-            <input id="ownedBusiness" class="form-check-input" type="checkbox" name="OwnedBusiness" [(ngModel)]="ownedBusiness"
-                (change)="changedOwnedBusiness()">
+            <input id="ownedBusiness" class="form-check-input" type="checkbox" name="OwnedBusiness"
+                [(ngModel)]="ownedBusiness" (change)="changedOwnedBusiness()">
             <label for="ownedBusiness" class="form-check-label">{{'accountOwnedBusiness' | i18n}}</label>
         </div>
         <div class="row" *ngIf="ownedBusiness">
             <div class="form-group col-6">
                 <label for="businessName">{{'businessName' | i18n}}</label>
-                <input id="businessName" class="form-control" type="text" name="BusinessName" [(ngModel)]="businessName">
-                </div>
+                <input id="businessName" class="form-control" type="text" name="BusinessName"
+                    [(ngModel)]="businessName">
+            </div>
         </div>
     </div>
     <h2 class="mt-5">{{'chooseYourPlan' | i18n}}</h2>
@@ -99,7 +97,7 @@
                     {{'includesXUsers' | i18n : selectableProduct.baseSeats}}
                     <ng-container *ngIf="selectableProduct.hasAdditionalSeatsOption">
                         {{('additionalUsers' | i18n).toLowerCase()}}
-                        {{selectableProduct.seatPrice  / 12 | currency:'$'}} /{{'month' | i18n}}
+                        {{selectableProduct.seatPrice / 12 | currency:'$'}} /{{'month' | i18n}}
                     </ng-container>
                 </ng-container>
             </span>
@@ -128,8 +126,8 @@
                 <label for="additionalSeats">{{'additionalUserSeats' | i18n}}</label>
                 <input id="additionalSeats" class="form-control" type="number" name="AdditionalSeats"
                     [(ngModel)]="additionalSeats" min="0" max="100000" placeholder="{{'userSeatsDesc' | i18n}}">
-                <small
-                    class="text-muted form-text">{{'userSeatsAdditionalDesc' | i18n : selectedPlan.baseSeats : (seatPriceMonthly(selectedPlan) | currency:'$')}}</small>
+                <small class="text-muted form-text">{{'userSeatsAdditionalDesc' | i18n : selectedPlan.baseSeats :
+                    (seatPriceMonthly(selectedPlan) | currency:'$')}}</small>
             </div>
         </div>
         <div class="row">
@@ -138,8 +136,8 @@
                 <input id="additionalStorage" class="form-control" type="number" name="AdditionalStorageGb"
                     [(ngModel)]="additionalStorage" min="0" max="99" step="1"
                     placeholder="{{'additionalStorageGbDesc' | i18n}}">
-                <small
-                    class="text-muted form-text">{{'additionalStorageIntervalDesc' | i18n : '1 GB' : (additionalStoragePriceMonthly(selectedPlan) | currency:'$') : ('month' | i18n)}}</small>
+                <small class="text-muted form-text">{{'additionalStorageIntervalDesc' | i18n : '1 GB' :
+                    (additionalStoragePriceMonthly(selectedPlan) | currency:'$') : ('month' | i18n)}}</small>
             </div>
         </div>
         <div class="row">
@@ -149,8 +147,8 @@
                         [(ngModel)]="premiumAccessAddon">
                     <label for="premiumAccess" class="form-check-label bold">{{'premiumAccess' | i18n}}</label>
                 </div>
-                <small
-                    class="text-muted form-text">{{'premiumAccessDesc' | i18n : (3.33 | currency:'$') : ('month' | i18n)}}</small>
+                <small class="text-muted form-text">{{'premiumAccessDesc' | i18n : (3.33 | currency:'$') : ('month' |
+                    i18n)}}</small>
             </div>
         </div>
         <h2 class="spaced-header">{{'summary' | i18n}}</h2>
@@ -172,7 +170,7 @@
                         <span *ngIf="!selectablePlan.baseSeats">{{'users' | i18n}}:</span>
                         {{additionalSeats || 0}} &times; {{selectablePlan.seatPrice / 12 | currency:'$'}} &times; 12
                         {{'monthAbbr' | i18n}} = {{seatTotal(selectablePlan)
-                    | currency:'$'}} /{{'year' | i18n}}
+                        | currency:'$'}} /{{'year' | i18n}}
                     </small>
                     <small *ngIf="selectablePlan.hasAdditionalStorageOption">
                         {{'additionalStorageGb' | i18n}}: {{additionalStorage || 0}} &times;
@@ -201,7 +199,7 @@
                         <span *ngIf="!selectablePlan.baseSeats">{{'users' | i18n}}:</span>
                         {{additionalSeats || 0}} &times; {{selectablePlan.seatPrice | currency:'$'}}
                         {{'monthAbbr' | i18n}} = {{seatTotal(selectablePlan)
-                    | currency:'$'}} /{{'month' | i18n}}
+                        | currency:'$'}} /{{'month' | i18n}}
                     </small>
                     <small *ngIf="selectablePlan.hasAdditionalStorageOption">
                         {{'additionalStorageGb' | i18n}}: {{additionalStorage || 0}} &times;
@@ -219,7 +217,8 @@
             </label>
         </div>
         <hr class="my-3">
-        <h2 class="spaced-header mb-4">{{ (createOrganization ? 'paymentInformation' : 'billingInformation') | i18n}}</h2>
+        <h2 class="spaced-header mb-4">{{ (createOrganization ? 'paymentInformation' : 'billingInformation') | i18n}}
+        </h2>
         <app-payment *ngIf="createOrganization" [hideCredit]="true"></app-payment>
         <app-tax-info (onCountryChanged)="changedCountry()"></app-tax-info>
         <div id="price" class="my-4">
@@ -237,7 +236,7 @@
         <small class="text-muted font-italic" *ngIf="freeTrial && createOrganization; else paymentChargedImmediately">
             {{'paymentChargedWithTrial' | i18n : (selectedPlanInterval | i18n) }}
         </small>
-        <ng-template  #paymentChargedImmediately>
+        <ng-template #paymentChargedImmediately>
             <small class="text-muted font-italic mt-2 d-block">
                 {{'paymentCharged' | i18n : (selectedPlanInterval | i18n) }}
             </small>

--- a/src/app/settings/organization-plans.component.ts
+++ b/src/app/settings/organization-plans.component.ts
@@ -34,10 +34,9 @@ import { ProductType } from 'jslib-common/enums/productType';
 import { OrganizationCreateRequest } from 'jslib-common/models/request/organizationCreateRequest';
 import { OrganizationKeysRequest } from 'jslib-common/models/request/organizationKeysRequest';
 import { OrganizationUpgradeRequest } from 'jslib-common/models/request/organizationUpgradeRequest';
+import { ProviderOrganizationCreateRequest } from 'jslib-common/models/request/provider/providerOrganizationCreateRequest';
 
 import { PlanResponse } from 'jslib-common/models/response/planResponse';
-import { OrganizationUserInviteRequest } from 'jslib-common/models/request/organizationUserInviteRequest';
-import { PermissionsApi } from 'jslib-common/models/api/permissionsApi';
 
 @Component({
     selector: 'app-organization-plans',
@@ -340,17 +339,10 @@ export class OrganizationPlansComponent implements OnInit {
         }
 
         if (this.providerId) {
+            const providerRequest = new ProviderOrganizationCreateRequest(this.clientOwnerEmail, request);
             const providerKey = await this.cryptoService.getProviderKey(this.providerId);
-            request.key = (await this.cryptoService.encrypt(orgKey.key, providerKey)).encryptedString;
-            const orgId = (await this.apiService.postProviderCreateOrganization(this.providerId, request)).organizationId;
-
-            const userRequest = new OrganizationUserInviteRequest();
-            userRequest.emails = [this.clientOwnerEmail];
-            userRequest.accessAll = true;
-            userRequest.type = OrganizationUserType.Owner;
-            userRequest.permissions = new PermissionsApi();
-            userRequest.collections = [];
-            await this.apiService.postOrganizationUserInvite(orgId, userRequest);
+            providerRequest.organizationCreateRequest.key = (await this.cryptoService.encrypt(orgKey.key, providerKey)).encryptedString;
+            const orgId = (await this.apiService.postProviderCreateOrganization(this.providerId, providerRequest)).organizationId;
 
             return orgId;
         } else {

--- a/src/app/settings/organization-plans.component.ts
+++ b/src/app/settings/organization-plans.component.ts
@@ -49,7 +49,6 @@ export class OrganizationPlansComponent implements OnInit {
     @Input() organizationId: string;
     @Input() showFree = true;
     @Input() showCancel = false;
-    @Input() showOwnerInvite = false;
     @Input() product: ProductType = ProductType.Free;
     @Input() plan: PlanType = PlanType.Free;
     @Input() providerId: string;

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -2247,6 +2247,9 @@
   "ownerDesc": {
     "message": "The highest access user that can manage all aspects of your organization."
   },
+  "clientOwnerDesc": {
+    "message": "This email should NOT be associated with the provider. This user will have permissions to access and manage all aspects of this organization."
+  },
   "admin": {
     "message": "Admin"
   },

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -2238,6 +2238,9 @@
   "confirmed": {
     "message": "Confirmed"
   },
+  "clientOwnerEmail": {
+    "message": "Client Owner Email"
+  },
   "owner": {
     "message": "Owner"
   },


### PR DESCRIPTION
# Overview

fixes: https://app.asana.com/0/1153292148278596/1200645727236036/f
Depends on bitwarden/jslib#442, bitwarden/jslib#444, and bitwarden/server#1488

Add owner invite to provider organization creation.

# Files Changed
* **create-organization.component**: require owner invite
* **organization-plans.component**: If `showOwnerInvite` is true, a required field is shown for an owner to invite upon creation.

# Screenshots
<img width="1202" alt="image" src="https://user-images.githubusercontent.com/18214891/127383951-7c5ce342-7415-4c26-9cd5-c3a9e9b26331.png">
