### PR TITLE
Use `!=` for null checks

### DIFF
--- a/src/app/services/event.service.ts
+++ b/src/app/services/event.service.ts
@@ -222,7 +222,7 @@ export class EventService {
                 const policies = await this.policyService.getAll();
                 const policy = policies.filter(p => p.id === ev.policyId)[0];
                 let p1 = this.getShortId(ev.policyId);
-                if (policy !== null) {
+                if (policy != null) {
                     p1 = PolicyType[policy.type];
                 }
 


### PR DESCRIPTION
# Overview

Incorrect null/undefined check was causing errors on event loading.

fixes: https://app.asana.com/0/1153292148278596/1200664904812608/f