### PR TITLE
Handle vault accessed event types

### DIFF
--- a/src/app/services/event.service.ts
+++ b/src/app/services/event.service.ts
@@ -215,6 +215,9 @@ export class EventService {
                 msg = this.i18nService.t('exportedOrganizationVault');
                 break;
             */
+            case EventType.Organization_VaultAccessed:
+                msg = humanReadableMsg = this.i18nService.t('vaultAccessedByProvider');
+                break;
             // Policies
             case EventType.Policy_Updated:
                 msg = this.i18nService.t('modifiedPolicyId', this.formatPolicyId(ev));
@@ -256,6 +259,10 @@ export class EventService {
             case EventType.ProviderOrganization_Removed:
                 msg = this.i18nService.t('removedOrganizationId', this.formatProviderOrganizationId(ev));
                 humanReadableMsg = this.i18nService.t('removedOrganizationId', this.getShortId(ev.providerOrganizationId));
+                break;
+            case EventType.ProviderOrganization_VaultAccessed:
+                msg = this.i18nService.t('accessedClientVault', this.formatProviderOrganizationId(ev));
+                humanReadableMsg = this.i18nService.t('accessedClientVault', this.getShortId(ev.providerOrganizationId));
                 break;
             default:
                 break;

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -998,6 +998,9 @@
   "purgedOrganizationVault": {
     "message": "Purged organization vault."
   },
+  "vaultAccessedByProvider": {
+    "message": "Vault accessed by provider."
+  },
   "purgeVaultDesc": {
     "message": "Proceed below to delete all items and folders in your vault. Items that belong to an organization that you share with will not be deleted."
   },
@@ -2588,7 +2591,7 @@
     "placeholders": {
       "id": {
         "content": "$1",
-        "example": "John Smith"
+        "example": "Google"
       }
     }
   },
@@ -2597,7 +2600,7 @@
     "placeholders": {
       "id": {
         "content": "$1",
-        "example": "John Smith"
+        "example": "Google"
       }
     }
   },
@@ -2606,7 +2609,16 @@
     "placeholders": {
       "id": {
         "content": "$1",
-        "example": "John Smith"
+        "example": "Google"
+      }
+    }
+  },
+  "accessedClientVault": {
+    "message": "Accessed $ID$ organization vault.",
+    "placeholders": {
+      "id": {
+        "content": "$1",
+        "example": "Google"
       }
     }
   },


### PR DESCRIPTION
# Overview

Fixes: https://app.asana.com/0/0/1200645727236042/f

Adds vault accessed provider and client organization event types to web event views.

Depends on bitwarden/jslib#448 and bitwarden/server#1496

# Files Changed
* **event.service.ts**: Handle vault accessed event types. Organization text just indicates the vault was accessed by the provider. Provider text indicates which vault was accessed as a link to that client organziation
* **messages.json**: Added new event type description strings and corrected examples for several event descriptions.

# Draft reason

Depends on bitwarden/jslib#448