### PR TITLE
QA deploy to CI push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: Build
 
 on:
+  workflow_dispatch:
+    inputs:
+      custom_tag_extension:
+        description: "custom extension to add to the QA docker image"
+        required: false
   push:
     branches-ignore:
       - 'l10n_master'
@@ -169,13 +174,11 @@ jobs:
           echo "GitHub event: $GITHUB_EVENT"
 
       - name: Login to Azure
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
         with:
           creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Log into container registry
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         run: az acr login -n bitwardenqa
 
       - name: Checkout repo
@@ -198,28 +201,39 @@ jobs:
           docker --version
           docker build -t bitwardenqa.azurecr.io/web .
 
-      - name: Tag rc branch
-        if: github.ref == 'refs/heads/rc'
-        run: docker tag bitwardenqa.azurecr.io/web bitwardenqa.azurecr.io/web:rc
+      - name: Get image tag
+        id: image_tag
+        run: |
+          IMAGE_TAG="$GITHUB_REF"
+          TAG_EXTENSION=${{ github.events.inputs.custom_tag_extension }}
+
+          if [[ $TAG_EXTENSION ]]; then
+            IMAGE_TAG=$IMAGE_TAG-$TAG_EXTENSION
+          fi  
+          echo "::set-output name=value::$IMAGE_TAG"
+
+      - name: Tag image
+        env:
+          IMAGE_TAG: ${{ steps.image_tag.outputs.value }}
+        run: docker tag bitwardenqa.azurecr.io/web bitwardenqa.azurecr.io/web:$IMAGE_TAG
 
       - name: Tag dev
         if: github.ref == 'refs/heads/master'
         run: docker tag bitwardenqa.azurecr.io/web bitwardenqa.azurecr.io/web:dev
 
       - name: List Docker images
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         run: docker images
 
-      - name: Push rc images
-        if: github.ref == 'refs/heads/rc'
-        run: docker push bitwardenqa.azurecr.io/web:rc
+      - name: Push image
+        env:
+          IMAGE_TAG: ${{ steps.image_tag.outputs.value }}
+        run: docker push bitwardenqa.azurecr.io/web:$IMAGE_TAG
 
       - name: Push dev images
         if: github.ref == 'refs/heads/master'
         run: docker push bitwardenqa.azurecr.io/web:dev
 
       - name: Log out of Docker
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         run: docker logout
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       custom_tag_extension:
-        description: "custom extension to add to the QA docker image"
+        description: "Custom image tag extension"
         required: false
   push:
     branches-ignore:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,7 @@ jobs:
       - name: Get image tag
         id: image_tag
         run: |
-          IMAGE_TAG="$GITHUB_REF"
+          IMAGE_TAG=$(echo "$GITHUB_REF" | awk '{split($0, a, "/"); print a[3];}')
           TAG_EXTENSION=${{ github.events.inputs.custom_tag_extension }}
 
           if [[ $TAG_EXTENSION ]]; then
@@ -215,8 +215,7 @@ jobs:
       - name: Tag image
         env:
           IMAGE_TAG: ${{ steps.image_tag.outputs.value }}
-        run: |
-          docker tag bitwardenqa.azurecr.io/web "bitwardenqa.azurecr.io/web:$IMAGE_TAG"
+        run: docker tag bitwardenqa.azurecr.io/web "bitwardenqa.azurecr.io/web:$IMAGE_TAG"
 
       - name: Tag dev
         if: github.ref == 'refs/heads/master'
@@ -228,8 +227,7 @@ jobs:
       - name: Push image
         env:
           IMAGE_TAG: ${{ steps.image_tag.outputs.value }}
-        run: |
-          docker push "bitwardenqa.azurecr.io/web:$IMAGE_TAG"
+        run: docker push "bitwardenqa.azurecr.io/web:$IMAGE_TAG"
 
       - name: Push dev images
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Tag image
         env:
           IMAGE_TAG: ${{ steps.image_tag.outputs.value }}
-        run: docker tag bitwardenqa.azurecr.io/web bitwardenqa.azurecr.io/web:$IMAGE_TAG
+        run: docker tag bitwardenqa.azurecr.io/web "bitwardenqa.azurecr.io/web:$IMAGE_TAG"
 
       - name: Tag dev
         if: github.ref == 'refs/heads/master'
@@ -227,7 +227,7 @@ jobs:
       - name: Push image
         env:
           IMAGE_TAG: ${{ steps.image_tag.outputs.value }}
-        run: docker push bitwardenqa.azurecr.io/web:$IMAGE_TAG
+        run: docker push "bitwardenqa.azurecr.io/web:$IMAGE_TAG"
 
       - name: Push dev images
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,7 +215,8 @@ jobs:
       - name: Tag image
         env:
           IMAGE_TAG: ${{ steps.image_tag.outputs.value }}
-        run: docker tag bitwardenqa.azurecr.io/web "bitwardenqa.azurecr.io/web:$IMAGE_TAG"
+        run: |
+          docker tag bitwardenqa.azurecr.io/web "bitwardenqa.azurecr.io/web:$IMAGE_TAG"
 
       - name: Tag dev
         if: github.ref == 'refs/heads/master'
@@ -227,7 +228,8 @@ jobs:
       - name: Push image
         env:
           IMAGE_TAG: ${{ steps.image_tag.outputs.value }}
-        run: docker push "bitwardenqa.azurecr.io/web:$IMAGE_TAG"
+        run: |
+          docker push "bitwardenqa.azurecr.io/web:$IMAGE_TAG"
 
       - name: Push dev images
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -2,7 +2,10 @@ name: QA Deploy
 
 on: 
   workflow_dispatch:
-    inputs: {}
+    inputs:
+      image_extension:
+        description: "extension to append to the branch name for docker image name"
+        required: false
 
 env:
   QA_CLUSTER_RESOURCE_GROUP: "bitwarden-devops"
@@ -28,7 +31,6 @@ jobs:
           creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Retrieve secrets
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         id: retrieve-secrets
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:
@@ -49,8 +51,20 @@ jobs:
           echo "---az get-creds---"
           az aks get-credentials -n $QA_CLUSTER_NAME -g $QA_CLUSTER_RESOURCE_GROUP
 
-      - name: Redeploy Web image
+      - name: Get image tag
+        id: image_tag
         run: |
-          POD_NAME=$(kubectl get po -n $QA_K8S_NAMESPACE -l app=$QA_K8S_APP_NAME -o jsonpath="{.items[0].metadata.name}")
-          echo "Deleting pod: $POD_NAME"
-          kubectl delete po -n bw-qa $POD_NAME
+          IMAGE_TAG="$GITHUB_REF"
+          TAG_EXTENSION=${{ github.events.inputs.image_extension }}
+
+          if [[ $TAG_EXTENSION ]]; then
+            IMAGE_TAG=$IMAGE_TAG-$TAG_EXTENSION
+          fi  
+          echo "::set-output name=value::$IMAGE_TAG"
+
+      - name: Deploy Web image
+        env:
+          IMAGE_TAG: ${{ steps.image_tag.outputs.value }}
+        run: |
+          kubectl set image deployment/web web=bitwardenqa.azurecr.io/web:$IMAGE_TAG --record
+          kubectl rollout status deployment/web -n bw-qa

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Get image tag
         id: image_tag
         run: |
-          IMAGE_TAG="$GITHUB_REF"
+          IMAGE_TAG=$(echo "$GITHUB_REF" | awk '{split($0, a, "/"); print a[3];}')
           TAG_EXTENSION=${{ github.events.inputs.image_extension }}
 
           if [[ $TAG_EXTENSION ]]; then

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       image_extension:
-        description: "extension to append to the branch name for docker image name"
+        description: "Image tag extension"
         required: false
 
 env:
@@ -15,7 +15,7 @@ env:
 
 jobs:
   deploy:
-    name: Deploy QA Web Vault
+    name: Deploy QA Web
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -66,5 +66,5 @@ jobs:
         env:
           IMAGE_TAG: ${{ steps.image_tag.outputs.value }}
         run: |
-          kubectl set image deployment/web web=bitwardenqa.azurecr.io/web:$IMAGE_TAG --record
-          kubectl rollout status deployment/web -n bw-qa
+          kubectl set image -n $QA_K8S_NAMESPACE deployment/web web=bitwardenqa.azurecr.io/web:$IMAGE_TAG --record
+          kubectl rollout status deployment/web -n $QA_K8S_NAMESPACE


### PR DESCRIPTION
## Summary

Allowing the QA web client to deployed from any branch that has been through a `build` workflow. This change includes a way to manually run a build on a branch and tag it with a custom tag that won't be overwritten on the next build on that branch (`bitwardenqa.azurecr.io/web:master` will always point to the latest build on `master`, but `master-custom` will only be overwritten by manually re-running the build workflow with the custom tag extension `custom`