### PR TITLE
Fix crowdin sync

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -54,6 +54,7 @@ jobs:
         env:
           CROWDIN_BASE_URL: "https://api.crowdin.com/api/v2/projects"
           CROWDIN_PROJECT_ID: "308189"
+          CROWDIN_API_TOKEN: ${{ steps.retrieve-secrets.outputs.crowdin-api-token }}
         run: |
           # Step 1: GET master branchId
           BRANCH_ID=$(

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -111,7 +111,7 @@ jobs:
           # Step 4: when build is finished, get download url
           DOWNLOAD_URL=$(
               curl -s -H "Authorization: Bearer $CROWDIN_API_TOKEN" \
-              $CROWDIN_BASE_URL/$CROWDIN_PROJECT_ID/translations/builds/$BUILD_ID/download | jq -r '.data.url'
+              $CROWDIN_BASE_URL/$CROWDIN_PROJECT_ID/translations/builds/$CROWDIN_BUILD_ID/download | jq -r '.data.url'
           )
           echo "::set-output name=value::$DOWNLOAD_URL"
 

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -19,27 +19,27 @@ jobs:
 
       - name: Setup git config
         run: |
-          git config user.name = "GitHub Action Bot"
+          git config user.name  = "Github Actions Bot"
           git config user.email = "<>"
 
       - name: Get Crowndin Sync Branch
         id: branch
         run: |
           BRANCH_NAME=crowdin-auto-sync
-          BRANCH_EXISTED=true
+          BRANCH_EXISTS=true
 
           git fetch -a
           git switch master
           if [ $(git branch -a | egrep "remotes/origin/${BRANCH_NAME}$" | wc -l) -eq 0 ]; then
-            BRANCH_EXISTED=false
+            BRANCH_EXISTS=false
             git switch -c $BRANCH_NAME
           else
             git switch $BRANCH_NAME
           fi
           git branch
 
-          echo "::set-output name=branch-existed::${BRANCH_EXISTED}"
-          echo "::set-output name=branch-name::${BRANCH_NAME}"
+          echo "::set-output name=branch-exists::$BRANCH_EXISTS"
+          echo "::set-output name=branch-name::$BRANCH_NAME"
 
       - name: Login to Azure
         uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
@@ -143,11 +143,11 @@ jobs:
 
       - name: Create/Update PR
         env:
-          BRANCH_NAME: ${{ steps.cherry-pick.outputs.branch-name }}
-          BRANCH_EXISTED: ${{ steps.cherry-pick.outputs.branch-existed }}
+          BRANCH_NAME: ${{ steps.branch.outputs.branch-name }}
+          BRANCH_EXISTS: ${{ steps.branch.outputs.branch-exists }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "$BRANCH_EXISTED" == "false" ]; then
+          if [ "$BRANCH_EXISTS" == "false" ]; then
             echo "[*] Creating PR"
             gh pr create --title "Autosync Crowdin Translations" \
             --body "Autosync the updated translations"

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -10,6 +10,9 @@ jobs:
   crowdin-sync:
     name: Autosync
     runs-on: ubuntu-20.04
+    env:
+      CROWDIN_BASE_URL: "https://api.crowdin.com/api/v2/projects"
+      CROWDIN_PROJECT_ID: "308189"
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
@@ -50,10 +53,9 @@ jobs:
           keyvault: "bitwarden-prod-kv"
           secrets: "crowdin-api-token"
 
-      - name: Get Crowdin updates
+      - name: Get Crowdin master branch id
+        id: crowdin-master-branch
         env:
-          CROWDIN_BASE_URL: "https://api.crowdin.com/api/v2/projects"
-          CROWDIN_PROJECT_ID: "308189"
           CROWDIN_API_TOKEN: ${{ steps.retrieve-secrets.outputs.crowdin-api-token }}
         run: |
           # Step 1: GET master branchId
@@ -61,27 +63,37 @@ jobs:
               curl -s -H "Authorization: Bearer $CROWDIN_API_TOKEN" \
               $CROWDIN_BASE_URL/$CROWDIN_PROJECT_ID/branches | jq -r '.data[0].data.id'
           )
+          echo "::set-output name=id::$BRANCH_ID"
 
+      - name: Get Crowdin build id
+        id: crowdin-build
+        env:
+          CROWDIN_API_TOKEN: ${{ steps.retrieve-secrets.outputs.crowdin-api-token }}
+          CROWDIN_MASTER_BRANCH_ID: ${{ steps.crowdin-master-branch.outputs.id }}
+        run: |
           # Step 2: POST Build the translations and get store build id
           BUILD_ID=$(
               curl -X POST -s \
               -H "Authorization: Bearer $CROWDIN_API_TOKEN" \
               -H "Content-Type: application/json" \
               $CROWDIN_BASE_URL/$CROWDIN_PROJECT_ID/translations/builds \
-              -d "{\"branchId\": $BRANCH_ID}" | jq -r '.data.id'
+              -d "{\"branchId\": $CROWDIN_MASTER_BRANCH_ID}" | jq -r '.data.id'
           )
+          echo "::set-output name=id::$BUILD_ID"
 
-          MAX_TRIES=12
+      - name: Wait for Crowdin build to finish
+        env:
+          MAX_TRIES: 12
+          CROWDIN_API_TOKEN: ${{ steps.retrieve-secrets.outputs.crowdin-api-token }}
+          CROWDIN_BUILD_ID: ${{ steps.crowdin-build.outputs.id }}
+        run: |
           for try in {1..$MAX_TRIES}; do
               BRANCH_STATUS=$(
                   curl -s -H "Authorization: Bearer $CROWDIN_API_TOKEN" \
-                  $CROWDIN_BASE_URL/$CROWDIN_PROJECT_ID/translations/builds/$BUILD_ID | jq -r '.data.status'
+                  $CROWDIN_BASE_URL/$CROWDIN_PROJECT_ID/translations/builds/$CROWDIN_BUILD_ID | jq -r '.data.status'
               )
               echo "[*] Build status: $BRANCH_STATUS"
-              if [[ "$BRANCH_STATUS" == "finished" ]]; then
-                  break
-              fi
-
+              if [[ "$BRANCH_STATUS" == "finished" ]]; then break; fi
               if [[ "$try" == "$MAX_TRIES" ]]; then
                   echo "[!] Exceeded tries: $try"
                   exit 1
@@ -90,18 +102,29 @@ jobs:
               fi
           done
 
+      - name: Get Crowdin download URL
+        id: crowdin-download-url
+        env:
+          CROWDIN_API_TOKEN: ${{ steps.retrieve-secrets.outputs.crowdin-api-token }}
+          CROWDIN_BUILD_ID: ${{ steps.crowdin-build.outputs.id }}
+        run: |
           # Step 4: when build is finished, get download url
           DOWNLOAD_URL=$(
               curl -s -H "Authorization: Bearer $CROWDIN_API_TOKEN" \
               $CROWDIN_BASE_URL/$CROWDIN_PROJECT_ID/translations/builds/$BUILD_ID/download | jq -r '.data.url'
           )
+          echo "::set-output name=value::$DOWNLOAD_URL"
 
+      - name: Download Crowding translations
+        env:
+          CROWDIN_API_TOKEN: ${{ steps.retrieve-secrets.outputs.crowdin-api-token }}
+          CROWDIN_DOWNLOAD_URL: ${{ steps.crowdin-download-url.outputs }}
+        run: |
           # Step 5: download the translations via the download url
           SAVE_FILE=translations.zip
-          curl -s $DOWNLOAD_URL --output $SAVE_FILE
+          curl -s $CROWDIN_DOWNLOAD_URL --output $SAVE_FILE
           echo "[*]    Saved to: $SAVE_FILE"
 
-          # Step 6: Unzip and cleanup
           unzip -o $SAVE_FILE
           rm $SAVE_FILE
 

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -19,8 +19,8 @@ jobs:
 
       - name: Setup git config
         run: |
-          git config user.name  = "Github Actions Bot"
-          git config user.email = "<>"
+          git config user.name "github-actions"
+          git config user.email "<>"
 
       - name: Get Crowndin Sync Branch
         id: branch

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -115,16 +115,15 @@ jobs:
           )
           echo "::set-output name=value::$DOWNLOAD_URL"
 
-      - name: Download Crowding translations
+      - name: Download Crowdin translations
         env:
           CROWDIN_API_TOKEN: ${{ steps.retrieve-secrets.outputs.crowdin-api-token }}
-          CROWDIN_DOWNLOAD_URL: ${{ steps.crowdin-download-url.outputs }}
+          CROWDIN_DOWNLOAD_URL: ${{ steps.crowdin-download-url.outputs.value }}
+          SAVE_FILE: "translations.zip"
         run: |
           # Step 5: download the translations via the download url
-          SAVE_FILE=translations.zip
           curl -s $CROWDIN_DOWNLOAD_URL --output $SAVE_FILE
           echo "[*]    Saved to: $SAVE_FILE"
-
           unzip -o $SAVE_FILE
           rm $SAVE_FILE
 

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -81,7 +81,7 @@ jobs:
                   break
               fi
 
-              if [[ $try -eq $MAX_TRIES ]]; then
+              if [[ "$try" == "$MAX_TRIES" ]]; then
                   echo "[!] Exceeded tries: $try"
                   exit 1
               else

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -52,8 +52,8 @@ jobs:
 
       - name: Get Crowdin updates
         env:
-          CROWDIN_BASE_URL="https://api.crowdin.com/api/v2/projects"
-          CROWDIN_PROJECT_ID="308189"
+          CROWDIN_BASE_URL: "https://api.crowdin.com/api/v2/projects"
+          CROWDIN_PROJECT_ID: "308189"
         run: |
           # Step 1: GET master branchId
           BRANCH_ID=$(

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -130,6 +130,7 @@ jobs:
       - name: Commit changes
         env:
           BRANCH_NAME: ${{ steps.branch.outputs.branch-name }}
+          BRANCH_EXISTS: ${{ steps.branch.outputs.branch-exists }}
         run: |
           echo "[*] Adding new translations"
           git add .
@@ -138,8 +139,13 @@ jobs:
           echo "=============================="
           echo "[*] Committing"
           git commit -m "Autosync Crowdin translations"
+
           echo "[*] Pushing"
-          git push -u origin $BRANCH_NAME
+          if [ "$BRANCH_EXISTS" == "false" ]; then
+            git push -u origin $BRANCH_NAME
+          else
+            git push
+          fi
 
       - name: Create/Update PR
         env:


### PR DESCRIPTION
## Summary 

This new workflow makes the Crowdin Sync easier with more control over when we do it (rather than use the Crowdin/GitHub integration). We can manually trigger the workflow or we can set it to run on a schedule, updating a specific Crowdin Sync PR with the changes.