### PR TITLE
Do not call parent if callback given

### DIFF
--- a/src/connectors/captcha.ts
+++ b/src/connectors/captcha.ts
@@ -84,9 +84,10 @@ async function start() {
 }
 
 function captchaSuccess(response: string) {
-    success(response);
     if (callbackUri) {
         document.location.replace(callbackUri + '?token=' + encodeURIComponent(response));
+    } else {
+        success(response);
     }
 }
 


### PR DESCRIPTION
# Overview

fixes: https://app.asana.com/0/0/1200777695141203/f

Android < 10 was OK with redirecting from captcha following a success message posted to parent. However, newer versions are not. These versions were never posting to the callback uri.