### PR TITLE
Fix bug duplicate error messages in emergency access add-edit

### DIFF
--- a/src/app/settings/emergency-access-add-edit.component.html
+++ b/src/app/settings/emergency-access-add-edit.component.html
@@ -56,7 +56,7 @@
             </div>
             <div class="modal-footer">
                 <button #submitBtn type="submit" class="btn btn-primary" 
-                    [disabled]="loading || submitBtn.loading || readOnly" [appApiAction]="formPromise">
+                    [disabled]="loading || submitBtn.loading || readOnly">
                     <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true" 
                         *ngIf="loading || submitBtn.loading"></i>
                     <span *ngIf="!loading && !submitBtn.loading">{{'save' | i18n}}</span>
@@ -65,8 +65,7 @@
                     data-dismiss="modal">{{'cancel' | i18n}}</button>
                 <div class="ml-auto">
                     <button #deleteBtn type="button" (click)="delete()" class="btn btn-outline-danger"
-                        appA11yTitle="{{'delete' | i18n}}" *ngIf="editMode" [disabled]="deleteBtn.loading"
-                        [appApiAction]="deletePromise">
+                        appA11yTitle="{{'delete' | i18n}}" *ngIf="editMode" [disabled]="deleteBtn.loading">
                         <i class="fa fa-trash-o fa-lg fa-fw" [hidden]="deleteBtn.loading" aria-hidden="true"></i>
                         <i class="fa fa-spinner fa-spin fa-lg fa-fw" [hidden]="!deleteBtn.loading"
                             title="{{'loading' | i18n}}" aria-hidden="true"></i>


### PR DESCRIPTION
## Objective

In the emergency access add-edit component, if the grantee email is invalid, the error toast will show twice.

## Code changes
* The `[appApiAction]` directive was applied twice: once to the `<form>` element, and once to the `<button type="submit">` element. Remove the duplicate directive on the `<button>` element
* There was an `[appApiAction]` directive on the delete button, but it was pointing to an undefined promise. The delete method emits an event for the parent component to handle, so this just seems like erroneous/leftover code that needs to be removed.