### PR TITLE
Set iframe allow on window load

### DIFF
--- a/src/app/accounts/two-factor.component.html
+++ b/src/app/accounts/two-factor.component.html
@@ -35,7 +35,7 @@
                     </ng-container>
                     <ng-container *ngIf="selectedProviderType === providerType.WebAuthn">
                         <div id="web-authn-frame" class="mb-3">
-                            <iframe id="webauthn_iframe"></iframe>
+                            <iframe id="webauthn_iframe" [allow]="webAuthnAllow"></iframe>
                         </div>
                     </ng-container>
                     <ng-container *ngIf="selectedProviderType === providerType.Duo ||


### PR DESCRIPTION
# Overview

Chrome seems to balk at this attribute being added after the fact. It may be a race condition or an intentional block, but adding to the template fixes our missing allow attribute problem.

>Note: this will be cherry picked to `rc`