### PR TITLE
Avoid showing provider form if proivder is set up

### DIFF
--- a/bitwarden_license/src/app/providers/setup/setup.component.ts
+++ b/bitwarden_license/src/app/providers/setup/setup.component.ts
@@ -58,9 +58,16 @@ export class SetupComponent implements OnInit {
                 };
                 this.toasterService.popAsync(toast);
                 this.router.navigate(['/']);
-            } else {
-                this.providerId = qParams.providerId;
-                this.token = qParams.token;
+                return;
+            }
+
+            this.providerId = qParams.providerId;
+            this.token = qParams.token;
+            
+            // Check if provider exists, redirect if it does
+            const provider = await this.apiService.getProvider(this.providerId);
+            if (provider.name != null) {
+                this.router.navigate(['/providers', provider.id], { replaceUrl: true });
             }
         });
     }

--- a/bitwarden_license/src/app/providers/setup/setup.component.ts
+++ b/bitwarden_license/src/app/providers/setup/setup.component.ts
@@ -65,9 +65,14 @@ export class SetupComponent implements OnInit {
             this.token = qParams.token;
             
             // Check if provider exists, redirect if it does
-            const provider = await this.apiService.getProvider(this.providerId);
-            if (provider.name != null) {
-                this.router.navigate(['/providers', provider.id], { replaceUrl: true });
+            try {
+                const provider = await this.apiService.getProvider(this.providerId);
+                if (provider.name != null) {
+                    this.router.navigate(['/providers', provider.id], { replaceUrl: true });
+                }
+            } catch (e) {
+                this.validationService.showError(e);
+                this.router.navigate(['/']);
             }
         });
     }


### PR DESCRIPTION
## Objective
Adds a redirect which avoids showing the create provider form if the provider is already set up.
