### PR TITLE
Fix broken Crowdin Sync Workflow

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -183,4 +183,5 @@ jobs:
             --body "Autosync the updated translations"
           else
             echo "[*] Existing PR updated"
+          fi
  


### PR DESCRIPTION
## Summary

A line was mistakenly removed in the last commit. This adds it back in