### PR TITLE
Overwrite icon service url for prod

### DIFF
--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -151,6 +151,7 @@ export function initFactory(): Function {
         } else {
             environmentService.setUrls({
                 base: window.location.origin,
+                icons: 'https://icons.bitwarden.net',
                 notifications: 'https://notifications.bitwarden.com',
                 enterprise: 'https://portal.bitwarden.com',
             }, false);


### PR DESCRIPTION
## Objective
In the #1092 I refactored how environment services are loaded, however I missed that I also needed to overwrite the icon service for cloud to ensure the icons are loaded from `icons.bitwarden.net`.

Note: This will be cherry picked to rc.