### PR TITLE
Fixed order of supportedLocales to have 'en' as fallback again

### DIFF
--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -10,8 +10,9 @@ export class I18nService extends BaseI18nService {
             return locales;
         });
 
+        // Please leave 'en' where it is, as it's our fallback language in case no translation can be found
         this.supportedTranslationLocales = [
-            'az', 'en', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'eo', 'en-GB', 'en-IN', 'es', 'et', 'fi', 'fr', 'he', 'hr', 'hu', 'id', 'it', 'ja', 'kn', 'ko', 'lv', 'ml', 'nb',
+            'en', 'az', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'eo', 'en-GB', 'en-IN', 'es', 'et', 'fi', 'fr', 'he', 'hr', 'hu', 'id', 'it', 'ja', 'kn', 'ko', 'lv', 'ml', 'nb',
             'nl', 'pl', 'pt-PT', 'pt-BR', 'ro', 'ru', 'sk', 'sr', 'sv', 'tr', 'uk', 'zh-CN', 'zh-TW',
         ];
     }


### PR DESCRIPTION
With #1079 the AZ language was added. Unfortunately it was set on the first position of the supportedTranslationLocales[]. The first entry is used as a fallback in case the selected locale (browser/system) is not found. This results in users getting for example the login or register site displayed in Azerbaijani.

As can be seen here: https://community.bitwarden.com/t/bitwarden-registration-in-wrong-language/32642