### PR TITLE
 Fix role not being displayed in organization user table

### DIFF
--- a/src/app/organizations/manage/people.component.ts
+++ b/src/app/organizations/manage/people.component.ts
@@ -66,7 +66,7 @@ export class PeopleComponent extends BasePeopleComponent<OrganizationUserUserDet
     @ViewChild('bulkConfirmTemplate', { read: ViewContainerRef, static: true }) bulkConfirmModalRef: ViewContainerRef;
     @ViewChild('bulkRemoveTemplate', { read: ViewContainerRef, static: true }) bulkRemoveModalRef: ViewContainerRef;
 
-    userType = ProviderUserType;
+    userType = OrganizationUserType;
     userStatusType = OrganizationUserStatusType;
 
     organizationId: string;


### PR DESCRIPTION
## Objective
In the provider user refactor, the role column disappeared from the organization manage page. The root cause seems to be a typo which references the `providerUserType` instead of `OrganizationUserType`.

Note: Will be cherry picked to `rc`.