### PR TITLE
Crowdin Automation Cleanup

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -30,7 +30,7 @@ jobs:
           BRANCH_EXISTS=true
 
           git fetch -a
-          git switch master
+          git switch $_DIFF_BRANCH
           if [ $(git branch -a | egrep "remotes/origin/${BRANCH_NAME}$" | wc -l) -eq 0 ]; then
             BRANCH_EXISTS=false
             git switch -c $BRANCH_NAME
@@ -104,7 +104,7 @@ jobs:
               fi
           done
 
-          sleep 60 # Wait for the build download url to become live
+          sleep 15 # Wait for the build download url to become live
 
       - name: Get Crowdin download URL
         id: crowdin-download-url

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -11,8 +11,9 @@ jobs:
     name: Autosync
     runs-on: ubuntu-20.04
     env:
-      CROWDIN_BASE_URL: "https://api.crowdin.com/api/v2/projects"
-      CROWDIN_PROJECT_ID: "308189"
+      _CROWDIN_BASE_URL: "https://api.crowdin.com/api/v2/projects"
+      _CROWDIN_PROJECT_ID: "308189"
+      _DIFF_BRANCH: "master"
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
@@ -61,7 +62,7 @@ jobs:
           # Step 1: GET master branchId
           BRANCH_ID=$(
               curl -s -H "Authorization: Bearer $CROWDIN_API_TOKEN" \
-              $CROWDIN_BASE_URL/$CROWDIN_PROJECT_ID/branches | jq -r '.data[0].data.id'
+              $_CROWDIN_BASE_URL/$_CROWDIN_PROJECT_ID/branches | jq -r '.data[0].data.id'
           )
           echo "::set-output name=id::$BRANCH_ID"
 
@@ -76,7 +77,7 @@ jobs:
               curl -X POST -s \
               -H "Authorization: Bearer $CROWDIN_API_TOKEN" \
               -H "Content-Type: application/json" \
-              $CROWDIN_BASE_URL/$CROWDIN_PROJECT_ID/translations/builds \
+              $_CROWDIN_BASE_URL/$_CROWDIN_PROJECT_ID/translations/builds \
               -d "{\"branchId\": $CROWDIN_MASTER_BRANCH_ID}" | jq -r '.data.id'
           )
           echo "[*] Crowin translations build id: $BRANCH_ID"
@@ -91,7 +92,7 @@ jobs:
           for try in {1..$MAX_TRIES}; do
               BRANCH_STATUS=$(
                   curl -s -H "Authorization: Bearer $CROWDIN_API_TOKEN" \
-                  $CROWDIN_BASE_URL/$CROWDIN_PROJECT_ID/translations/builds/$CROWDIN_BUILD_ID | jq -r '.data.status'
+                  $_CROWDIN_BASE_URL/$_CROWDIN_PROJECT_ID/translations/builds/$CROWDIN_BUILD_ID | jq -r '.data.status'
               )
               echo "[*] Build status: $BRANCH_STATUS"
               if [[ "$BRANCH_STATUS" == "finished" ]]; then break; fi
@@ -112,7 +113,7 @@ jobs:
           # Step 4: when build is finished, get download url
           DOWNLOAD_URL=$(
               curl -s -H "Authorization: Bearer $CROWDIN_API_TOKEN" \
-              $CROWDIN_BASE_URL/$CROWDIN_PROJECT_ID/translations/builds/$CROWDIN_BUILD_ID/download | jq -r '.data.url'
+              $_CROWDIN_BASE_URL/$_CROWDIN_PROJECT_ID/translations/builds/$CROWDIN_BUILD_ID/download | jq -r '.data.url'
           )
           echo "[*] Crowin translations download url: $DOWNLOAD_URL"
           echo "::set-output name=value::$DOWNLOAD_URL"
@@ -134,8 +135,8 @@ jobs:
         env:
           BRANCH_NAME: ${{ steps.branch.outputs.branch-name }}
           BRANCH_EXISTS: ${{ steps.branch.outputs.branch-exists }}
+          DIFF_BRANCH: ${{ env._DIFF_BRANCH }}
         run: |
-          DIFF_BRANCH=master
           if [[ "$BRANCH_EXISTS" == "true" ]]; then
             DIFF_BRANCH=$BRANCH_NAME
           fi
@@ -148,7 +149,7 @@ jobs:
         env:
           BRANCH_NAME: ${{ steps.branch.outputs.branch-name }}
           BRANCH_EXISTS: ${{ steps.branch.outputs.branch-exists }}
-          DIFF_BRANCH: master
+          DIFF_BRANCH: ${{ env._DIFF_BRANCH }}
           DIFF_LEN: ${{ steps.files-changed.outputs.num }}
         run: |
           echo "=====Translations Changed====="

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       _CROWDIN_BASE_URL: "https://api.crowdin.com/api/v2/projects"
       _CROWDIN_PROJECT_ID: "308189"
-      _DIFF_BRANCH: "crowdin-testing-2-21-1"
+      _DIFF_BRANCH: "master"
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -104,6 +104,8 @@ jobs:
               fi
           done
 
+          sleep 60 # Wait for the build download url to become live
+
       - name: Get Crowdin download URL
         id: crowdin-download-url
         env:
@@ -180,8 +182,9 @@ jobs:
         run: |
           if [ "$BRANCH_EXISTS" == "false" ]; then
             echo "[*] Creating PR"
-            gh pr create --title "Autosync Crowdin Translations" \
-            --body "Autosync the updated translations"
+            gh pr create --base $_DIFF_BRANCH \
+              --title "Autosync Crowdin Translations" \
+              --body "Autosync the updated translations"
           else
             echo "[*] Existing PR updated"
           fi

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -137,13 +137,12 @@ jobs:
         env:
           BRANCH_NAME: ${{ steps.branch.outputs.branch-name }}
           BRANCH_EXISTS: ${{ steps.branch.outputs.branch-exists }}
-          DIFF_BRANCH: ${{ env._DIFF_BRANCH }}
         run: |
           if [[ "$BRANCH_EXISTS" == "true" ]]; then
-            DIFF_BRANCH=$BRANCH_NAME
+            _DIFF_BRANCH=$BRANCH_NAME
           fi
 
-          DIFF_LEN=$(git diff origin/${DIFF_BRANCH} | wc -l | xargs)
+          DIFF_LEN=$(git diff origin/${_DIFF_BRANCH} | wc -l | xargs)
           echo "[*] git diff lines: ${DIFF_LEN}"
           echo "::set-output name=num::$DIFF_LEN"
 
@@ -151,11 +150,10 @@ jobs:
         env:
           BRANCH_NAME: ${{ steps.branch.outputs.branch-name }}
           BRANCH_EXISTS: ${{ steps.branch.outputs.branch-exists }}
-          DIFF_BRANCH: ${{ env._DIFF_BRANCH }}
           DIFF_LEN: ${{ steps.files-changed.outputs.num }}
         run: |
           echo "=====Translations Changed====="
-          git diff --name-only origin/${DIFF_BRANCH}
+          git diff --name-only origin/${_DIFF_BRANCH}
           echo "=============================="
 
           if [ "$DIFF_LEN" != "0" ]; then

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       _CROWDIN_BASE_URL: "https://api.crowdin.com/api/v2/projects"
       _CROWDIN_PROJECT_ID: "308189"
-      _DIFF_BRANCH: "master"
+      _DIFF_BRANCH: "crowdin-testing-2-21-1"
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4


### PR DESCRIPTION
## Summary

- Adding a new coding standard to help identify global variables in a job
- Adding in delay after the crowdin build because crowdin's api is slow. It is labeled "finished" before the download is actually available. Sleeps 15 seconds to wait for their system to catch up.
- Adding a global diff branch for better testing in the future