### PR TITLE
Enable redeploying same image for QA

### DIFF
--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -12,7 +12,7 @@ env:
   _QA_CLUSTER_NAME: "dev-aks"
   _QA_K8S_NAMESPACE: "bw-qa"
   _QA_K8S_APP_NAME: "bw-web"
-master
+
 jobs:
   deploy:
     name: Deploy QA Web


### PR DESCRIPTION
## Summary

The current deploy logic combined with the `imagePullPolicy` of `Always` wasn't quite going to work if we want to redeploy a new updated version of `image:tag` where `tag` is the same as the last deployment (ie. `web:master`). Setting the image and then restarting the last rollout will cover both scenarios: new image tag and a redeploy of a new version of the same image tag.