### PR TITLE
Fix Require SSO Policy prerequisite check

### DIFF
--- a/src/app/organizations/policies/require-sso.component.ts
+++ b/src/app/organizations/policies/require-sso.component.ts
@@ -31,7 +31,7 @@ export class RequireSsoPolicyComponent extends BasePolicyComponent {
 
     buildRequest(policiesEnabledMap: Map<PolicyType, boolean>): Promise<PolicyRequest> {
         const singleOrgEnabled = policiesEnabledMap.get(PolicyType.SingleOrg) ?? false;
-        if (this.enabled.value && singleOrgEnabled) {
+        if (this.enabled.value && !singleOrgEnabled) {
             throw new Error(this.i18nService.t('requireSsoPolicyReqError'));
         }
 


### PR DESCRIPTION
## Objective
Resolves an issue where Require SSO policy could not be enabled with single org policy enabled, the reverse of what it is supposed to be. (Introduced by #1147)

https://app.asana.com/0/inbox/1198901840256133/1200873625261850/1200873689311802