### PR TITLE
Add notifications to development config

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -6,6 +6,7 @@
     "proxyEnterprise": "http://localhost:52313",
     "allowedHosts": [],
     "urls": {
+        "notifications": "http://localhost:61840",
         "enterprise": "http://localhost:52313"
     }
 }


### PR DESCRIPTION
## Objective
When running `npm run build:dev:watch` we currently cannot speak with the notification service since it uses websockets. Usually I would solve this by adding `ws: true` to the proxy configuration, but for some reason that crashes webpack on my machine.

Since we recently introduced support for overriding service urls, I instead changed so the application speaks directly to the notification service.