### PR TITLE
[Provider] Verify user is owner of organization

### DIFF
--- a/bitwarden_license/src/app/providers/clients/clients.component.ts
+++ b/bitwarden_license/src/app/providers/clients/clients.component.ts
@@ -79,7 +79,7 @@ export class ClientsComponent implements OnInit {
         const response = await this.apiService.getProviderClients(this.providerId);
         this.clients = response.data != null && response.data.length > 0 ? response.data : [];
         this.manageOrganizations = (await this.userService.getProvider(this.providerId)).type === ProviderUserType.ProviderAdmin;
-        const candidateOrgs = (await this.userService.getAllOrganizations()).filter(o => o.providerId == null);
+        const candidateOrgs = (await this.userService.getAllOrganizations()).filter(o => o.isOwner && o.providerId == null);
         const allowedOrgsIds = await Promise.all(candidateOrgs.map(o => this.apiService.getOrganization(o.id))).then(orgs =>
             orgs.filter(o => !DisallowedPlanTypes.includes(o.planType))
                 .map(o => o.id));


### PR DESCRIPTION
## Objective
We had an issue where users didn't have permission to call organizations/:id, which caused an never-ending spinner in the provider portal. To resolve this, I added a check to ensure the user has owner permission of organization, which is required to add an org either way.

Asana: https://app.asana.com/0/1200578627114106/1200880201964177