### PR TITLE
Fix ModalService refactor bugs

### DIFF
--- a/bitwarden_license/src/app/providers/clients/clients.component.ts
+++ b/bitwarden_license/src/app/providers/clients/clients.component.ts
@@ -124,7 +124,7 @@ export class ClientsComponent implements OnInit {
     }
 
     async addExistingOrganization() {
-        const [modal, childComponent] = await this.modalService.openViewRef(AddOrganizationComponent, this.addModalRef, comp => {
+        const [modal] = await this.modalService.openViewRef(AddOrganizationComponent, this.addModalRef, comp => {
             comp.providerId = this.providerId;
             comp.organizations = this.addableOrganizations;
             comp.onAddedOrganization.subscribe(async () => {

--- a/bitwarden_license/src/app/providers/providers.module.ts
+++ b/bitwarden_license/src/app/providers/providers.module.ts
@@ -1,6 +1,9 @@
 import { CommonModule } from '@angular/common';
+import { ComponentFactoryResolver } from '@angular/core';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+
+import { ModalService } from 'jslib-angular/services/modal.service';
 
 import { ProviderGuardService } from './services/provider-guard.service';
 import { ProviderTypeGuardService } from './services/provider-type-guard.service';
@@ -59,4 +62,8 @@ import { OssModule } from 'src/app/oss.module';
         ProviderTypeGuardService,
     ],
 })
-export class ProvidersModule {}
+export class ProvidersModule {
+    constructor(modalService: ModalService, componentFactoryResolver: ComponentFactoryResolver) {
+        modalService.registerComponentFactoryResolver(AddOrganizationComponent, componentFactoryResolver);
+    }
+}

--- a/src/app/send/send.component.ts
+++ b/src/app/send/send.component.ts
@@ -72,7 +72,7 @@ export class SendComponent extends BaseSendComponent {
 
     async editSend(send: SendView) {
         const [modal, childComponent] = await this.modalService.openViewRef(AddEditComponent, this.sendAddEditModalRef, comp => {
-            childComponent.sendId = send == null ? null : send.id;
+            comp.sendId = send == null ? null : send.id;
             comp.onSavedSend.subscribe(async (s: SendView) => {
                 modal.close();
                 await this.load();


### PR DESCRIPTION
## Objective
In #1034 we refactored all modals to use the new `ModalService` which introduced two bugs. Which are resolved in this PR.

1. AddOrganization in Provider Portal generated a NullInjector due to the Provider Module being lazy loaded. This was resolved using a work around where the ProviderModule defines the component factory resolver.
2. SendComponent attempted to use `childComponent` before it was initialized, due to a typo. Changed to use `comp`.

Depends on https://github.com/bitwarden/jslib/pull/471