### PR TITLE
[Policy] Reset Password data bugfix

### DIFF
--- a/src/app/organizations/policies/reset-password.component.html
+++ b/src/app/organizations/policies/reset-password.component.html
@@ -17,7 +17,7 @@
     </app-callout>
     <div class="form-check">
         <input class="form-check-input" type="checkbox" id="autoEnrollEnabled" name="AutoEnrollEnabled"
-            formControlName="autoEnroll">
+            formControlName="autoEnrollEnabled">
         <label class="form-check-label" for="autoEnrollEnabled">
             {{'resetPasswordPolicyAutoEnrollCheckbox' | i18n }}
         </label>

--- a/src/app/organizations/policies/reset-password.component.ts
+++ b/src/app/organizations/policies/reset-password.component.ts
@@ -25,7 +25,7 @@ export class ResetPasswordPolicy extends BasePolicy {
 export class ResetPasswordPolicyComponent extends BasePolicyComponent {
 
     data = this.fb.group({
-        autoEnroll: false,
+        autoEnrollEnabled: false,
     });
 
     defaultTypes: { name: string; value: string; }[];


### PR DESCRIPTION
## Objective
> The `data` key for the `Reset Password` policy options was accidentally changed during [this](https://github.com/bitwarden/web/pull/1147) component refactor which resulted in any reference to the data to return `false`.

## Code Changes
- **reset-password.component.html**: Changed `formControlName` to `autoEnrollEnabled`
- **reset-password.component.ts**: Changed data key from `autoEnroll` to `autoEnrollEnabled`