### PR TITLE
Disable personal imports if Personal Ownership policy applies

### DIFF
--- a/src/app/organizations/tools/import.component.ts
+++ b/src/app/organizations/tools/import.component.ts
@@ -32,7 +32,7 @@ export class ImportComponent extends BaseImportComponent {
         this.route.parent.parent.params.subscribe(async params => {
             this.organizationId = params.organizationId;
             this.successNavigate = ['organizations', this.organizationId, 'vault'];
-            super.ngOnInit();
+            await super.ngOnInit();
             this.importBlockedByPolicy = false;
         });
         const organization = await this.userService.getOrganization(this.organizationId);

--- a/src/app/organizations/tools/import.component.ts
+++ b/src/app/organizations/tools/import.component.ts
@@ -9,6 +9,7 @@ import { ToasterService } from 'angular2-toaster';
 import { I18nService } from 'jslib-common/abstractions/i18n.service';
 import { ImportService } from 'jslib-common/abstractions/import.service';
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
+import { PolicyService } from 'jslib-common/abstractions/policy.service';
 import { UserService } from 'jslib-common/abstractions/user.service';
 
 import { ImportComponent as BaseImportComponent } from '../../tools/import.component';
@@ -22,9 +23,9 @@ export class ImportComponent extends BaseImportComponent {
 
     constructor(i18nService: I18nService, toasterService: ToasterService,
         importService: ImportService, router: Router, private route: ActivatedRoute,
-        platformUtilsService: PlatformUtilsService,
+        platformUtilsService: PlatformUtilsService, policyService: PolicyService,
         private userService: UserService) {
-        super(i18nService, toasterService, importService, router, platformUtilsService);
+        super(i18nService, toasterService, importService, router, platformUtilsService, policyService);
     }
 
     async ngOnInit() {
@@ -32,6 +33,7 @@ export class ImportComponent extends BaseImportComponent {
             this.organizationId = params.organizationId;
             this.successNavigate = ['organizations', this.organizationId, 'vault'];
             super.ngOnInit();
+            this.importBlockedByPolicy = false;
         });
         const organization = await this.userService.getOrganization(this.organizationId);
         this.organizationName = organization.name;

--- a/src/app/tools/import.component.html
+++ b/src/app/tools/import.component.html
@@ -1,12 +1,16 @@
 <div class="page-header">
     <h1>{{'importData' | i18n}}</h1>
 </div>
+<app-callout type="info" *ngIf="importBlockedByPolicy">
+    {{'personalOwnershipPolicyInEffectImports' | i18n}}
+</app-callout>
 <form #form (ngSubmit)="submit()" ngNativeValidate>
     <div class="row">
         <div class="col-6">
             <div class="form-group">
                 <label for="type">1. {{'selectFormat' | i18n}}</label>
-                <select id="type" name="Format" [(ngModel)]="format" class="form-control" required>
+                <select id="type" name="Format" [(ngModel)]="format" class="form-control"
+                    [disabled]="importBlockedByPolicy" required>
                     <option *ngFor="let o of featuredImportOptions" [ngValue]="o.id">{{o.name}}</option>
                     <ng-container *ngIf="importOptions && importOptions.length">
                         <option value="-" disabled></option>
@@ -240,15 +244,17 @@
         <div class="col-6">
             <div class="form-group">
                 <label for="file">2. {{'selectImportFile' | i18n}}</label>
-                <input type="file" id="file" class="form-control-file" name="file">
+                <input type="file" id="file" class="form-control-file" name="file" [disabled]="importBlockedByPolicy">
             </div>
         </div>
     </div>
     <div class="form-group">
         <label for="fileContents">{{'orCopyPasteFileContents' | i18n}}</label>
-        <textarea id="fileContents" class="form-control" name="FileContents" [(ngModel)]="fileContents"></textarea>
+        <textarea id="fileContents" class="form-control" name="FileContents" [(ngModel)]="fileContents"
+            [disabled]="importBlockedByPolicy"></textarea>
     </div>
-    <button type="submit" class="btn btn-primary btn-submit" [disabled]="loading">
+    <button type="submit" class="btn btn-primary btn-submit" [disabled]="loading || importBlockedByPolicy"
+        [ngClass]="{manual:importBlockedByPolicy}">
         <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
         <span>{{'importData' | i18n}}</span>
     </button>

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3796,6 +3796,9 @@
   "personalOwnershipPolicyInEffect": {
     "message": "An organization policy is affecting your ownership options."
   },
+  "personalOwnershipPolicyInEffectImports": {
+    "message": "An organization policy has disabled importing items into your personal vault."
+  },
   "personalOwnershipCheckboxDesc": {
     "message": "Disable personal ownership for organization users"
   },


### PR DESCRIPTION
## Objective

The Personal Ownership policy prevents users from creating items in their personal vault. However, at the moment it does not prevent a user from _importing_ items into their personal vault.

## Code changes

Update `import.component` template to:
* disable the import form controls if the policy applies (with callout)
* reject any import form submission if the policy applies

Server changes are to follow.

## Screenshots

![Screen Shot 2021-09-03 at 2 04 43 pm](https://user-images.githubusercontent.com/31796059/131949256-d4c7b47e-212e-4fed-8b70-99dbf68d6fcb.png)
