### PR TITLE
Possible fix for blocked nav on some devices

### DIFF
--- a/src/connectors/webauthn.ts
+++ b/src/connectors/webauthn.ts
@@ -156,9 +156,8 @@ function success(assertedCredential: PublicKeyCredential) {
         document.location.replace(callbackUri + '?data=' + encodeURIComponent(dataString));
     } else {
         parent.postMessage('success|' + dataString, parentUrl);
+        sentSuccess = true;
     }
-
-    sentSuccess = true;
 }
 
 function info(message: string) {


### PR DESCRIPTION
I have a device that is blocking navigation (per chrome dev tools) on the success callback for reasons unknown.  After comparing with the captcha connector (which works flawlessly), the only difference I can find is that captcha doesn't do anything else after `document.location.replace` for mobile.  I'm not sure if this is the culprit but it can't hurt to try.