### PR TITLE
Add warning about 2FA when changing account email

### DIFF
--- a/src/app/settings/change-email.component.html
+++ b/src/app/settings/change-email.component.html
@@ -1,4 +1,7 @@
 <form #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate>
+    <app-callout type="warning" *ngIf="showTwoFactorEmailWarning">
+        {{'changeEmailTwoFactorWarning' | i18n}}
+    </app-callout>
     <div class="row">
         <div class="col-6">
             <div class="form-group">

--- a/src/app/settings/change-email.component.ts
+++ b/src/app/settings/change-email.component.ts
@@ -36,13 +36,13 @@ export class ChangeEmailComponent implements OnInit {
     async ngOnInit() {
         const twoFactorProviders = await this.apiService.getTwoFactorProviders();
         for (const p of twoFactorProviders.data) {
-            if (p.type == TwoFactorProviderType.Email) {
+            if (p.type === TwoFactorProviderType.Email) {
                 this.showTwoFactorEmailWarning = p.enabled;
                 break;
             }
         }
     }
- 
+
     async submit() {
         const hasEncKey = await this.cryptoService.hasEncKey();
         if (!hasEncKey) {

--- a/src/app/settings/change-email.component.ts
+++ b/src/app/settings/change-email.component.ts
@@ -1,5 +1,6 @@
 import {
     Component,
+    OnInit,
 } from '@angular/core';
 
 import { ToasterService } from 'angular2-toaster';
@@ -13,15 +14,18 @@ import { UserService } from 'jslib-common/abstractions/user.service';
 import { EmailRequest } from 'jslib-common/models/request/emailRequest';
 import { EmailTokenRequest } from 'jslib-common/models/request/emailTokenRequest';
 
+import { TwoFactorProviderType } from 'jslib-common/enums';
+
 @Component({
     selector: 'app-change-email',
     templateUrl: 'change-email.component.html',
 })
-export class ChangeEmailComponent {
+export class ChangeEmailComponent implements OnInit {
     masterPassword: string;
     newEmail: string;
     token: string;
     tokenSent = false;
+    showTwoFactorEmailWarning = false;
 
     formPromise: Promise<any>;
 
@@ -29,6 +33,16 @@ export class ChangeEmailComponent {
         private toasterService: ToasterService, private cryptoService: CryptoService,
         private messagingService: MessagingService, private userService: UserService) { }
 
+    async ngOnInit() {
+        const twoFactorProviders = await this.apiService.getTwoFactorProviders();
+        for (const p of twoFactorProviders.data) {
+            if (p.type == TwoFactorProviderType.Email) {
+                this.showTwoFactorEmailWarning = p.enabled;
+                break;
+            }
+        }
+    }
+ 
     async submit() {
         const hasEncKey = await this.cryptoService.hasEncKey();
         if (!hasEncKey) {

--- a/src/app/settings/change-email.component.ts
+++ b/src/app/settings/change-email.component.ts
@@ -35,12 +35,8 @@ export class ChangeEmailComponent implements OnInit {
 
     async ngOnInit() {
         const twoFactorProviders = await this.apiService.getTwoFactorProviders();
-        for (const p of twoFactorProviders.data) {
-            if (p.type === TwoFactorProviderType.Email) {
-                this.showTwoFactorEmailWarning = p.enabled;
-                break;
-            }
-        }
+        this.showTwoFactorEmailWarning = twoFactorProviders.data.some(p => p.type === TwoFactorProviderType.Email &&
+            p.enabled);
     }
 
     async submit() {

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -899,6 +899,9 @@
   "changeEmail": {
     "message": "Change Email"
   },
+  "changeEmailTwoFactorWarning": {
+    "message": "Proceeding will change your account email address. It will not change the email address used for two-factor authentication. You can change this email address in the Two-Step Login settings if required."
+  },
   "newEmail": {
     "message": "New Email"
   },

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -900,7 +900,7 @@
     "message": "Change Email"
   },
   "changeEmailTwoFactorWarning": {
-    "message": "Proceeding will change your account email address. It will not change the email address used for two-factor authentication. You can change this email address in the Two-Step Login settings if required."
+    "message": "Proceeding will change your account email address. It will not change the email address used for two-factor authentication. You can change this email address in the Two-Step Login settings."
   },
   "newEmail": {
     "message": "New Email"


### PR DESCRIPTION
## Objective

The "Change email" panel in Settings lets the user change their account email, but it will not update the email address used for two-factor authentication (if that method is enabled). This is not intuitive:

>  there's a non-zero risk of someone getting locked out of their account because they don't realize 2FA codes are being sent to an old email address, which they might not have access to.

## Code changes
* if the user has the two-factor email method enabled, show a warning callout in the change-email component.

## Screenshots
![Screen Shot 2021-09-09 at 2 03 31 pm](https://user-images.githubusercontent.com/31796059/132621073-fe75a306-afe1-4bb0-9955-b406e568f91e.png)

The warning is hidden if the user is not using email 2FA.