### PR TITLE
Remove redundant error messaging

### DIFF
--- a/src/connectors/webauthn.ts
+++ b/src/connectors/webauthn.ts
@@ -119,7 +119,7 @@ function executeWebAuthn() {
 
     navigator.credentials.get({ publicKey: obj })
         .then(success)
-        .catch(err => error(err));
+        .catch(error);
 }
 
 function onMessage() {

--- a/src/connectors/webauthn.ts
+++ b/src/connectors/webauthn.ts
@@ -119,7 +119,7 @@ function executeWebAuthn() {
 
     navigator.credentials.get({ publicKey: obj })
         .then(success)
-        .catch(err => error('WebAuth Error: ' + err));
+        .catch(err => error(err));
 }
 
 function onMessage() {


### PR DESCRIPTION
Remove the "WebAuth Error" prefix from WebAuthn error strings