### PR TITLE
Add policy for disabling personal vault export

### DIFF
--- a/bitwarden_license/src/app/app.component.ts
+++ b/bitwarden_license/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 
 import { AppComponent as BaseAppComponent } from 'src/app/app.component';
+import { DisablePersonalVaultExportPolicy } from './policies/disable-personal-vault-export.component';
 import { MaximumVaultTimeoutPolicy } from './policies/maximum-vault-timeout.component';
 
 @Component({
@@ -14,6 +15,7 @@ export class AppComponent extends BaseAppComponent {
 
         this.policyListService.addPolicies([
             new MaximumVaultTimeoutPolicy(),
+            new DisablePersonalVaultExportPolicy(),
         ]);
     }
 

--- a/bitwarden_license/src/app/app.module.ts
+++ b/bitwarden_license/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { RouterModule } from '@angular/router';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { DisablePersonalVaultExportPolicyComponent } from './policies/disable-personal-vault-export.component';
 import { MaximumVaultTimeoutPolicyComponent } from './policies/maximum-vault-timeout.component';
 
 import { OssRoutingModule } from 'src/app/oss-routing.module';
@@ -33,6 +34,7 @@ import { ServicesModule } from 'src/app/services/services.module';
     declarations: [
         AppComponent,
         MaximumVaultTimeoutPolicyComponent,
+        DisablePersonalVaultExportPolicyComponent,
     ],
     bootstrap: [AppComponent],
 })

--- a/bitwarden_license/src/app/policies/disable-personal-vault-export.component.html
+++ b/bitwarden_license/src/app/policies/disable-personal-vault-export.component.html
@@ -1,0 +1,6 @@
+<div class="form-group">
+    <div class="form-check">
+        <input class="form-check-input" type="checkbox" id="enabled" [formControl]="enabled" name="Enabled">
+        <label class="form-check-label" for="enabled">{{'enabled' | i18n}}</label>
+    </div>
+</div>

--- a/bitwarden_license/src/app/policies/disable-personal-vault-export.component.ts
+++ b/bitwarden_license/src/app/policies/disable-personal-vault-export.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+
+import { I18nService } from 'jslib-common/abstractions/i18n.service';
+
+import { PolicyType } from 'jslib-common/enums/policyType';
+
+import { PolicyRequest } from 'jslib-common/models/request/policyRequest';
+
+import { BasePolicy, BasePolicyComponent } from 'src/app/organizations/policies/base-policy.component';
+
+export class DisablePersonalVaultExportPolicy extends BasePolicy {
+    name = 'disablePersonalVaultExport';
+    description = 'disablePersonalVaultExportDesc';
+    type = PolicyType.DisablePersonalVaultExport;
+    component = DisablePersonalVaultExportPolicyComponent;
+}
+
+@Component({
+    selector: 'policy-disable-personal-vault-export',
+    templateUrl: 'disable-personal-vault-export.component.html',
+})
+export class DisablePersonalVaultExportPolicyComponent extends BasePolicyComponent {
+}

--- a/src/app/organizations/tools/export.component.ts
+++ b/src/app/organizations/tools/export.component.ts
@@ -6,10 +6,9 @@ import { EventService } from 'jslib-common/abstractions/event.service';
 import { ExportService } from 'jslib-common/abstractions/export.service';
 import { I18nService } from 'jslib-common/abstractions/i18n.service';
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
+import { PolicyService } from 'jslib-common/abstractions/policy.service';
 
 import { ExportComponent as BaseExportComponent } from '../../tools/export.component';
-
-import { EventType } from 'jslib-common/enums/eventType';
 
 @Component({
     selector: 'app-org-export',
@@ -18,14 +17,19 @@ import { EventType } from 'jslib-common/enums/eventType';
 export class ExportComponent extends BaseExportComponent {
     constructor(cryptoService: CryptoService, i18nService: I18nService,
         platformUtilsService: PlatformUtilsService, exportService: ExportService,
-        eventService: EventService, private route: ActivatedRoute) {
-        super(cryptoService, i18nService, platformUtilsService, exportService, eventService);
+        eventService: EventService, private route: ActivatedRoute, policyService: PolicyService) {
+        super(cryptoService, i18nService, platformUtilsService, exportService, eventService, policyService);
     }
 
-    ngOnInit() {
+    async ngOnInit() {
+        await super.ngOnInit();
         this.route.parent.parent.params.subscribe(async params => {
             this.organizationId = params.organizationId;
         });
+    }
+
+    async checkExportDisabled() {
+        return;
     }
 
     getExportData() {

--- a/src/app/tools/export.component.html
+++ b/src/app/tools/export.component.html
@@ -3,7 +3,7 @@
         <h1>{{'exportVault' | i18n}}</h1>
     </div>
 
-    <app-callout type="error" title="{{'vaultExportDisabled' | i18n}}" *ngIf="disablePrivateVaultPolicyEnabled">
+    <app-callout type="error" title="{{'vaultExportDisabled' | i18n}}" *ngIf="disabledByPolicy">
         {{'personalVaultExportPolicyInEffect' | i18n}}
     </app-callout>
 
@@ -11,7 +11,7 @@
     <div class="row">
         <div class="form-group col-6">
             <label for="format">{{'fileFormat' | i18n}}</label>
-            <select class="form-control" id="format" name="Format" [(ngModel)]="format" [disabled]="disablePrivateVaultPolicyEnabled">
+            <select class="form-control" id="format" name="Format" [(ngModel)]="format" [disabled]="disabledByPolicy">
                 <option value="json">.json</option>
                 <option value="csv">.csv</option>
                 <option value="encrypted_json">.json (Encrypted)</option>
@@ -22,10 +22,10 @@
         <div class="form-group col-6">
             <label for="masterPassword">{{'masterPass' | i18n}}</label>
             <input id="masterPassword" type="password" name="MasterPassword" class="form-control"
-                [(ngModel)]="masterPassword" required appInputVerbatim [disabled]="disablePrivateVaultPolicyEnabled">
+                [(ngModel)]="masterPassword" required appInputVerbatim [disabled]="disabledByPolicy">
         </div>
     </div>
-    <button type="submit" class="btn btn-primary" [disabled]="form.loading || disablePrivateVaultPolicyEnabled">
+    <button type="submit" class="btn btn-primary" [disabled]="form.loading || disabledByPolicy">
         <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true" *ngIf="form.loading"></i>
         <span *ngIf="!form.loading">{{'exportVault' | i18n}}</span>
     </button>

--- a/src/app/tools/export.component.html
+++ b/src/app/tools/export.component.html
@@ -2,11 +2,16 @@
     <div class="page-header">
         <h1>{{'exportVault' | i18n}}</h1>
     </div>
+
+    <app-callout type="error" title="{{'vaultExportDisabled' | i18n}}" *ngIf="disablePrivateVaultPolicyEnabled">
+        {{'personalVaultExportPolicyInEffect' | i18n}}
+    </app-callout>
+
     <p>{{'exportMasterPassword' | i18n}}</p>
     <div class="row">
         <div class="form-group col-6">
             <label for="format">{{'fileFormat' | i18n}}</label>
-            <select class="form-control" id="format" name="Format" [(ngModel)]="format">
+            <select class="form-control" id="format" name="Format" [(ngModel)]="format" [disabled]="disablePrivateVaultPolicyEnabled">
                 <option value="json">.json</option>
                 <option value="csv">.csv</option>
                 <option value="encrypted_json">.json (Encrypted)</option>
@@ -17,11 +22,11 @@
         <div class="form-group col-6">
             <label for="masterPassword">{{'masterPass' | i18n}}</label>
             <input id="masterPassword" type="password" name="MasterPassword" class="form-control"
-                [(ngModel)]="masterPassword" required appInputVerbatim>
+                [(ngModel)]="masterPassword" required appInputVerbatim [disabled]="disablePrivateVaultPolicyEnabled">
         </div>
     </div>
-    <button type="submit" class="btn btn-primary btn-submit" [disabled]="form.loading">
-        <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
-        <span>{{'exportVault' | i18n}}</span>
+    <button type="submit" class="btn btn-primary" [disabled]="form.loading || disablePrivateVaultPolicyEnabled">
+        <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true" *ngIf="form.loading"></i>
+        <span *ngIf="!form.loading">{{'exportVault' | i18n}}</span>
     </button>
 </form>

--- a/src/app/tools/export.component.ts
+++ b/src/app/tools/export.component.ts
@@ -7,6 +7,7 @@ import { I18nService } from 'jslib-common/abstractions/i18n.service';
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
 
 import { ExportComponent as BaseExportComponent } from 'jslib-angular/components/export.component';
+import { PolicyService } from 'jslib-common/abstractions/policy.service';
 
 @Component({
     selector: 'app-export',
@@ -17,8 +18,8 @@ export class ExportComponent extends BaseExportComponent {
 
     constructor(cryptoService: CryptoService, i18nService: I18nService,
         platformUtilsService: PlatformUtilsService, exportService: ExportService,
-        eventService: EventService) {
-        super(cryptoService, i18nService, platformUtilsService, exportService, eventService, window);
+        eventService: EventService, policyService: PolicyService) {
+        super(cryptoService, i18nService, platformUtilsService, exportService, eventService, policyService, window);
     }
 
     protected saved() {

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -4232,5 +4232,17 @@
   },
   "vaultTimeoutToLarge": {
     "message": "Your vault timeout exceeds the restriction set by your organization."
+  },
+  "disablePersonalVaultExport": {
+    "message": "Disable Personal Vault Export"
+  },
+  "disablePersonalVaultExportDesc": {
+    "message": "Prohibits users from exporting their private vault data."
+  },
+  "vaultExportDisabled": {
+    "message": "Vault Export Disabled"
+  },
+  "personalVaultExportPolicyInEffect": {
+    "message": "One or more organization policies prevents you from exporting your personal vault."
   }
 }


### PR DESCRIPTION
## Objective
Implements a *Disable Personal Vault Policy* which lets organizations prevent exports of personal vaults.

### Code Changes
- **src/app/tools/export.component.{ts,html}**: Disables input and shows warning if policy is enabled.
- **src/app/organizations/tools/export.component.ts**: Ensure policy is not active for exports of organizations.

### Screenshots
![image](https://user-images.githubusercontent.com/137855/132862423-c5c0edac-94ae-4b7f-acc0-dec56485befa.png)
![image](https://user-images.githubusercontent.com/137855/132862383-f030748b-27f9-4093-b5e6-ac8564c9e6d7.png)

Depends on: https://github.com/bitwarden/jslib/pull/482
Asana: https://app.asana.com/0/1198901840263430/1200900473757540, https://app.asana.com/0/1198901840263430/1200900473757539