### PR TITLE
Update local web development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,28 @@ npm run build:oss:watch
 
 You can now access the web vault in your browser at `https://localhost:8080`.
 
-If you want to point the development web vault to the production APIs, you can run using:
+If you want to point the development web vault to the production APIs, first create a local configuration file at `./config/local.json` with the following contents:
+
+```json
+{
+    "proxyApi": "https://api.bitwarden.com",
+    "proxyIdentity": "https://identity.bitwarden.com",
+    "proxyEvents": "https://events.bitwarden.com",
+    "proxyNotifications": "https://notifications.bitwarden.com",
+    "proxyPortal": "https://portal.bitwarden.com"
+}
+```
+
+This will create the appropriate proxies from your local webpack server to the Bitwarden production APIs.
+
+you can then run using:
 
 ```
 npm install
-ENV=production npm run build:oss:watch
+npm run build:oss:watch
 ```
 
-You can also manually adjusting your API endpoint settings by adding `config/local.json` overriding any of the following values:
+You can also manually adjust your API endpoint settings by editing `config/local.json` and overriding any of the following values:
 
 ```json
 {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -167,7 +167,7 @@ const plugins = [
 
 // ref: https://webpack.js.org/configuration/dev-server/#devserver
 let certSuffix = fs.existsSync('dev-server.local.pem') ? '.local' : '.shared';
-const devServer = ENV !== 'development' ? {} : {
+const devServer = NODE_ENV !== 'development' ? {} : {
     https: {
         key: fs.readFileSync('dev-server' + certSuffix + '.pem'),
         cert: fs.readFileSync('dev-server' + certSuffix + '.pem'),


### PR DESCRIPTION
# Overview

1. Update instructions to point a local web instance at production servers.
2. Use `NODE_ENV` to more accurately determine if an instance is running in production or development. The `ENV` setting is more accurately used to indicate the configuration of the services, where `NODE_ENV` is used to indicate a mode of operation.
