### PR TITLE
Toast without Navbar Update

### DIFF
--- a/src/scss/toasts.scss
+++ b/src/scss/toasts.scss
@@ -81,6 +81,10 @@
     }
 }
 
+.layout_frontend .toast-top-right {
+    top: 20px;
+}
+
 .toast-error, .toast-container .toast-error:before, .toast-danger, .toast-container .toast-danger:before, .bg-danger {
     @include themify($themes) {
         background-color: themed('danger') !important;


### PR DESCRIPTION
Adds `.layout_frontend .toast-top-right {top: 20px}` for when the navbar isn't present so the toast position appears where expected instead of being too low

In reference to issue #996

## Previous:
![image](https://user-images.githubusercontent.com/6512845/135465504-1678e59b-2f6f-48da-9715-d4306770b11f.png)
![image](https://user-images.githubusercontent.com/6512845/135465569-9a171e8d-4b7f-4332-af9f-6f2fe68142e0.png)


## Now:
![image](https://user-images.githubusercontent.com/6512845/135465183-bee1daf8-5d2e-442e-bc64-851d139d58ad.png)
![image](https://user-images.githubusercontent.com/6512845/135465268-dd5a0137-7c73-4f55-84e7-ce7f329fc4ce.png)

With the navbar present, the `top` is `76px`. Without the navbar the `top` is `20px` as the navbar is `50px` in height