### PR TITLE
Add validation to ensure maximum vault timeout is larger than 0

### DIFF
--- a/bitwarden_license/src/app/policies/maximum-vault-timeout.component.ts
+++ b/bitwarden_license/src/app/policies/maximum-vault-timeout.component.ts
@@ -60,6 +60,11 @@ export class MaximumVaultTimeoutPolicyComponent extends BasePolicyComponent {
             throw new Error(this.i18nService.t('requireSsoPolicyReqError'));
         }
 
+        const data = this.buildRequestData();
+        if (data?.minutes == null || data?.minutes <= 0) {
+            throw new Error(this.i18nService.t('invalidMaximumVaultTimeout'));
+        }
+
         return super.buildRequest(policiesEnabledMap);
     }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -4275,6 +4275,9 @@
   "maximumVaultTimeoutLabel": {
     "message": "Maximum Vault Timeout"
   },
+  "invalidMaximumVaultTimeout": {
+    "message": "Invalid Maximum Vault Timeout."
+  },
   "hours": {
     "message": "Hours"
   },


### PR DESCRIPTION
Using a maximum vault timeout of 0 provides a bad user experience.

Resolves https://app.asana.com/0/1198901840263430/1201121327050886