### PR TITLE
Remove class attribute from instructions link in 2fa report

### DIFF
--- a/src/app/tools/inactive-two-factor-report.component.html
+++ b/src/app/tools/inactive-two-factor-report.component.html
@@ -41,8 +41,7 @@
                         <small>{{c.subTitle}}</small>
                     </td>
                     <td class="text-right">
-                        <a class="badge badge-primary" href="{{cipherDocs.get(c.id)}}" target="_blank" rel="noopener"
-                            *ngIf="cipherDocs.has(c.id)">
+                        <a href="{{cipherDocs.get(c.id)}}" target="_blank" rel="noopener" *ngIf="cipherDocs.has(c.id)">
                             {{'instructions' | i18n}}</a>
                     </td>
                 </tr>


### PR DESCRIPTION
## Objective
Typically we use badges in our reports, to indicate state or more information. In case of the Inactive 2FA report the badge contains a link to the instructions on how to activate 2FA for the specific site. Due to recent changes with the Dark Theme, this has become hardly readable. As to clearly mark it as a link and not a badge looking like a button, I removed the styling.

## Code Changes
- **inactive-two-factor-report.component.html**:  Removed class attribute from instructions link

## Screenshots
**Before:**
![with_badge](https://user-images.githubusercontent.com/2670567/136066212-3ff3060b-5e28-4137-b4a1-5d839b824b22.PNG)

**After:**
![without_badge](https://user-images.githubusercontent.com/2670567/136066228-799cbf52-e8ec-463d-bf11-94b88a215820.PNG)