### PR TITLE
Add release assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           echo "::set-output name=value::${GITHUB_SHA:0:7}"
 
 
-  build-oss:
+  build-oss-selfhost:
     name: Build OSS zip
     runs-on: ubuntu-20.04
     needs: setup
@@ -148,7 +148,7 @@ jobs:
           if-no-files-found: error
 
 
-  build-selfhost:
+  build-commercial-selfhost:
     name: Build SelfHost Docker image
     runs-on: ubuntu-20.04
     needs: setup
@@ -252,7 +252,7 @@ jobs:
 
 
   build-qa:
-    name: Build Docker images for testing
+    name: Build Docker images for QA environment
     runs-on: ubuntu-20.04
     steps:
       - name: Set up Node
@@ -397,6 +397,7 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
       - name: NPM install
         run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,17 +117,17 @@ jobs:
           git config --global url."https://github.com/".insteadOf ssh://git@github.com/
           git config --global url."https://".insteadOf ssh://
 
-      - name: Download latest RC Production build
-        uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74  # v2.14.0
+      - name: Download latest cloud asset
+        uses: bitwarden/gh-actions/download-artifacts@23433be15ed6fd046ce12b6889c5184a8d9c8783
         with:
           workflow: build.yml
           workflow_conclusion: success
           branch: rc
-          name: prod-build-artifact.zip
+          artifacts: web-*-cloud-COMMERCIAL.zip
 
       # This should result in a build directory in the current working directory
       - name: Unzip build asset
-        run: unzip prod-build-artifact.zip
+        run: unzip web-*-cloud-COMMERCIAL.zip
 
       - name: Deploy GitHub Pages
         uses: crazy-max/ghaction-github-pages@db4476a01402e1a7ce05f41832040eef16d14925  # v2.5.0
@@ -158,20 +158,27 @@ jobs:
       - self-host
       - ghpages-deploy
     steps:
-      - name: Download latest RC Production build
-        uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74  # v2.14.0
+      - name: Download latest build artifacts
+        uses: bitwarden/gh-actions/download-artifacts@23433be15ed6fd046ce12b6889c5184a8d9c8783
         with:
           workflow: build.yml
           workflow_conclusion: success
           branch: rc
-          name: prod-build-artifact.zip
+          artifacts: "web-*-selfhosted-COMMERCIAL.zip,
+                      web-*-selfhosted-open-source.zip"
+
+      - name: Rename assets
+        run: |
+          mv web-*-selfhosted-COMMERCIAL.zip web-${{ needs.setup.outputs.release_version }}-selfhosted-COMMERCIAL.zip
+          mv web-*-selfhosted-open-source.zip web-${{ needs.setup.outputs.release_version }}-selfhosted-open-source.zip
 
       - name: Create release
         uses: ncipollo/release-action@95215a3cb6e6a1908b3c44e00b4fdb15548b1e09
         with:
-          artifacts: prod-build-artifact.zip
+          name: "Version ${{ needs.setup.outputs.release_version }}"
           commit: ${{ github.sha }}
           tag: "${{ needs.setup.outputs.tag_version }}"
-          name: "Version ${{ needs.setup.outputs.release_version }}"
           body: "<insert release notes here>"
+          artifacts: "web-${{ needs.setup.outputs.release_version }}-selfhosted-COMMERCIAL.zip,
+                      web-${{ needs.setup.outputs.release_version }}-selfhosted-open-source.zip"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

We have updated our `npm` scripts to be easier to distinguish what builds our selfhosted OSS offering and our selfhosted commercial offering. This adds both of those build artifacts as release assets.