### PR TITLE
Toast without Navbar Styling

### DIFF
--- a/src/scss/toasts.scss
+++ b/src/scss/toasts.scss
@@ -115,7 +115,8 @@
             }
         }
     }
-    .layout_frontend .toast-top-right {
-        top: 20px;
-    }
+}
+
+.layout_frontend .toast-top-right {
+    top: 20px;
 }


### PR DESCRIPTION
Fix PR #1210

`.layout_frontend .toast-top-right` shouldn't be within `.toast-container`

Ready for @djsmith85 