### PR TITLE
Prevent disabling single org when max vault timeout policy is enabled

### DIFF
--- a/src/app/organizations/policies/single-org.component.ts
+++ b/src/app/organizations/policies/single-org.component.ts
@@ -28,11 +28,11 @@ export class SingleOrgPolicyComponent extends BasePolicyComponent {
     buildRequest(policiesEnabledMap: Map<PolicyType, boolean>): Promise<PolicyRequest> {
         if (!this.enabled.value) {
             if (policiesEnabledMap.get(PolicyType.RequireSso) ?? false) {
-                throw new Error(this.i18nService.t('disableRequireSsoError'));
+                throw new Error(this.i18nService.t('disableRequiredError', this.i18nService.t('requireSso')));
             }
 
             if (policiesEnabledMap.get(PolicyType.MaximumVaultTimeout) ?? false) {
-                throw new Error(this.i18nService.t('disableMaximumVaultTimeoutError'));
+                throw new Error(this.i18nService.t('disableRequiredError', this.i18nService.t('maximumVaultTimeoutLabel')));
             }
         }
 

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3853,11 +3853,14 @@
   "manageResetPassword": {
     "message": "Manage Password Reset"
   },
-  "disableRequireSsoError": {
-    "message": "You must manually disable the Single Sign-On Authentication policy before this policy can be disabled."
-  },
-  "disableMaximumVaultTimeoutError": {
-    "message": "You must manually disable the Maximum Vault Timeout policy before this policy can be disabled."
+  "disableRequiredError": {
+    "message": "You must manually disable the $POLICYNAME$ policy before this policy can be disabled.",
+    "placeholders": {
+      "policyName": {
+        "content": "$1",
+        "example": "Single Sign-On Authentication"
+      }
+    }
   },
   "personalOwnershipPolicyInEffect": {
     "message": "An organization policy is affecting your ownership options."


### PR DESCRIPTION
## Objective
The *Maximum Vault Timeout* policy requires *Single Organization* policy to be enabled, hence it should not be possible to disable *Single Organization* when *Maximum Vault Timeout* is enabled.

Note: Will be cherry picked to `rc`.