### PR TITLE
Remove max from minutes in vault timeout input

### DIFF
--- a/src/app/settings/vault-timeout-input.component.html
+++ b/src/app/settings/vault-timeout-input.component.html
@@ -19,7 +19,7 @@
                 <small>{{'hours' | i18n }}</small>
             </div>
             <div class="col-6">
-                <input id="minutes" class="form-control" type="number" min="0" max="59" name="minutes"
+                <input id="minutes" class="form-control" type="number" min="0" name="minutes"
                     formControlName="minutes">
                 <small>{{'minutes' | i18n }}</small>
             </div>


### PR DESCRIPTION
## Objective
Remove the `max` attribute from *hours*. The component will do a nice conversion for the next pageload where minutes gets re-calculated. This is to ensure the same behavior in all clients.

Note: Will be cherry picked to `rc`.