### PR TITLE
Add Slack notifications constraint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -419,6 +419,7 @@ jobs:
       - windows
     steps:
       - name: Check if any job failed
+        if: ${{ (github.ref == 'refs/heads/master') || (github.ref == 'refs/heads/rc') }}
         env:
           CLOC_STATUS: ${{ needs.cloc.result }}
           SETUP_STATUS: ${{ needs.setup.result }}


### PR DESCRIPTION
This PR constrains failure notifications to `master` and `rc` branches.