### PR TITLE
Remove unnecessary fallbacks

### DIFF
--- a/src/app/organizations/manage/user-add-edit.component.html
+++ b/src/app/organizations/manage/user-add-edit.component.html
@@ -80,20 +80,7 @@
                             <div class="mb-3">
                                 <label class="font-weight-bold mb-0">Manager Permissions</label>
                                 <hr class="my-0 mr-2" />
-                                <!-- Deprecated Sep 29 2021 -->
-                                <div class="form-group mb-0" *ngIf="fallbackToManageAssignedCollections">
-                                    <div class="form-check mt-1 form-check-block">
-                                        <input class="form-check-input" type="checkbox" name="manageAssignedCollections"
-                                            id="manageAssignedCollections"
-                                            [(ngModel)]="permissions.manageAssignedCollections">
-                                        <label class="form-check-label font-weight-normal"
-                                            for="manageAssignedCollections">
-                                            {{'manageAssignedCollections' | i18n}}
-                                        </label>
-                                    </div>
-                                </div>
-                                <!--  -->
-                                <app-nested-checkbox *ngIf="!fallbackToManageAssignedCollections" parentId="manageAssignedCollections"
+                                <app-nested-checkbox parentId="manageAssignedCollections"
                                     [checkboxes]="manageAssignedCollectionsCheckboxes">
                                 </app-nested-checkbox>
                             </div>
@@ -129,18 +116,7 @@
                                         </label>
                                     </div>
                                 </div>
-                                <!-- Deprecated 29 Sep 2021 -->
-                                <div class="form-group mb-0" *ngIf="fallbackToManageAllCollections">
-                                    <div class="form-check mt-1 form-check-block">
-                                        <input class="form-check-input" type="checkbox" name="manageAllCollections"
-                                            id="manageAllCollections" [(ngModel)]="permissions.manageAllCollections">
-                                        <label class="form-check-label font-weight-normal" for="manageAllCollections">
-                                            {{'manageAllCollections' | i18n}}
-                                        </label>
-                                    </div>
-                                </div>
-                                <!--  -->
-                                <app-nested-checkbox *ngIf="!fallbackToManageAllCollections" parentId="manageAllCollections"
+                                <app-nested-checkbox parentId="manageAllCollections"
                                     [checkboxes]="manageAllCollectionsCheckboxes">
                                 </app-nested-checkbox>
                                 <div class="form-group mb-0">

--- a/src/app/organizations/manage/user-add-edit.component.ts
+++ b/src/app/organizations/manage/user-add-edit.component.ts
@@ -79,19 +79,6 @@ export class UserAddEditComponent implements OnInit {
         },
     ];
 
-    get fallbackToManageAllCollections() {
-        return this.editMode &&
-            this.permissions.createNewCollections == null &&
-            this.permissions.editAnyCollection == null &&
-            this.permissions.deleteAnyCollection == null;
-    }
-
-    get fallbackToManageAssignedCollections() {
-        return this.editMode &&
-            this.permissions.editAssignedCollections == null &&
-            this.permissions.deleteAssignedCollections == null;
-    }
-
     get customUserTypeSelected(): boolean {
         return this.type === OrganizationUserType.Custom;
     }


### PR DESCRIPTION
# Overview

Asana Task: https://app.asana.com/0/1200804338582616/1201168652396104/f

Web is in lock-step to server version. We do not need fallbacks since we're sure the server version will support collection permissions split. @Hinton suggested doing this from the beginning, but now I'm convinced we can't tell the difference between an out-of-date permissions model and a role change. It's simple and safer to just assume we're updated since that's the only supported behavior for self-hosted instances.