### PR TITLE
Null Check subscription prior to use

### DIFF
--- a/src/app/organizations/settings/organization-subscription.component.html
+++ b/src/app/organizations/settings/organization-subscription.component.html
@@ -45,7 +45,7 @@
                     </ng-container>
                     </dl>
                     </div>
-            <div class="col-8">
+            <div class="col-8" *ngIf="subscription">
                 <strong class="d-block mb-1">{{'details' | i18n}}</strong>
                 <table class="table">
                     <tbody>


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
#1193 removed a null check on `subscription` that turned out to be critical to the page loading properly. This escaped testing due to innocuous changed to the Free org page and less-than-ideal testing over non-standard organization subscription set ups.

As a post-mortum, this would have been caught with a team or enterprise organization **without** a Stripe subscription set up in Bitwarden.

## Code changes
Null check `subscription` prior to each property access

## Screenshots
###Pre (free org)
![image](https://user-images.githubusercontent.com/18214891/139090908-fbab0b4d-9abf-48cd-8b46-715ecf6c4084.png)
###Post (free org)
![image](https://user-images.githubusercontent.com/18214891/139090962-94a32450-cd9a-4d5f-8436-ff33896b9f03.png)

## Testing requirements
Please test with non-standard, manual trial organizations without Stripe subscriptions as well as free organzations to confirm the look and ability to download licenses


## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [x] This change has particular **deployment requirements** (notify the DevOps team)
  - **Will be a hotfix release**
