### PR TITLE
Show upgrade plan button for free orgs.

### DIFF
--- a/src/app/organizations/settings/organization-subscription.component.html
+++ b/src/app/organizations/settings/organization-subscription.component.html
@@ -70,6 +70,15 @@
                 </div>
             </ng-container>
         </div>
+        <ng-container>
+            <div class="d-flex">
+                <button type="button" class="btn btn-outline-secondary" (click)="changePlan()" *ngIf="showChangePlanButton">
+                    {{'changeBillingPlan' | i18n}}
+                </button>
+            </div>
+            <app-change-plan [organizationId]="organizationId" (onChanged)="closeChangePlan(true)"
+                (onCanceled)="closeChangePlan(false)" *ngIf="showChangePlan"></app-change-plan>
+        </ng-container>
         <h2 class="spaced-header">{{'manageSubscription' | i18n}}</h2>
         <p class="mb-4">{{subscriptionDesc}}</p>
         <ng-container *ngIf="subscription && canAdjustSeats && !subscription.cancelled && !subscriptionMarkedForCancel">
@@ -118,8 +127,6 @@
                 <span>{{'cancelSubscription' | i18n}}</span>
             </button>
         </div>
-        <app-change-plan [organizationId]="organizationId" (onChanged)="closeChangePlan(true)"
-            (onCanceled)="closeChangePlan(false)" *ngIf="showChangePlan"></app-change-plan>
         <div class="mt-3" *ngIf="showDownloadLicense">
             <app-download-license [organizationId]="organizationId" (onDownloaded)="closeDownloadLicense()"
                 (onCanceled)="closeDownloadLicense()"></app-download-license>

--- a/src/app/organizations/settings/organization-subscription.component.ts
+++ b/src/app/organizations/settings/organization-subscription.component.ts
@@ -215,6 +215,8 @@ export class OrganizationSubscriptionComponent implements OnInit {
     get subscriptionDesc() {
         if (this.sub.planType === PlanType.Free) {
             return this.i18nService.t('subscriptionFreePlan', this.sub.seats.toString());
+        } else if (this.sub.planType === PlanType.FamiliesAnnually || this.sub.planType === PlanType.FamiliesAnnually2019) {
+            return this.i18nService.t('subscriptionFamiliesPlan', this.sub.seats.toString());
         } else if (this.sub.maxAutoscaleSeats === this.sub.seats && this.sub.seats != null) {
             return this.i18nService.t('subscriptionMaxReached', this.sub.seats.toString());
         } else if (this.sub.maxAutoscaleSeats == null) {

--- a/src/app/organizations/settings/organization-subscription.component.ts
+++ b/src/app/organizations/settings/organization-subscription.component.ts
@@ -110,15 +110,7 @@ export class OrganizationSubscriptionComponent implements OnInit {
     }
 
     async changePlan() {
-        if (this.subscription == null && this.sub.planType === PlanType.Free) {
-            this.showChangePlan = !this.showChangePlan;
-            return;
-        }
-        const contactSupport = await this.platformUtilsService.showDialog(this.i18nService.t('changeBillingPlanDesc'),
-            this.i18nService.t('changeBillingPlan'), this.i18nService.t('contactSupport'), this.i18nService.t('close'));
-        if (contactSupport) {
-            this.platformUtilsService.launchUri('https://bitwarden.com/contact');
-        }
+        this.showChangePlan = !this.showChangePlan;
     }
 
     closeChangePlan(changed: boolean) {
@@ -221,12 +213,18 @@ export class OrganizationSubscriptionComponent implements OnInit {
     }
 
     get subscriptionDesc() {
-        if (this.sub.maxAutoscaleSeats === this.sub.seats && this.sub.seats != null) {
+        if (this.sub.planType === PlanType.Free) {
+            return this.i18nService.t('subscriptionFreePlan', this.sub.seats.toString());
+        } else if (this.sub.maxAutoscaleSeats === this.sub.seats && this.sub.seats != null) {
             return this.i18nService.t('subscriptionMaxReached', this.sub.seats.toString());
         } else if (this.sub.maxAutoscaleSeats == null) {
             return this.i18nService.t('subscriptionUserSeatsUnlimitedAutoscale');
         } else {
             return this.i18nService.t('subscriptionUserSeatsLimitedAutoscale', this.sub.maxAutoscaleSeats.toString());
         }
+    }
+
+    get showChangePlanButton() {
+        return this.subscription == null && this.sub.planType === PlanType.Free && !this.showChangePlan;
     }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -2804,15 +2804,11 @@
     "description": "A billing plan/package. For example: families, teams, enterprise, etc."
   },
   "changeBillingPlan": {
-    "message": "Change Plan",
+    "message": "Upgrade Plan",
     "description": "A billing plan/package. For example: families, teams, enterprise, etc."
   },
   "changeBillingPlanUpgrade": {
     "message": "Upgrade your account to another plan by providing the information below. Please ensure that you have an active payment method added to the account.",
-    "description": "A billing plan/package. For example: families, teams, enterprise, etc."
-  },
-  "changeBillingPlanDesc": {
-    "message": "Contact customer support if you would like to change your plan. Please ensure that you have an active payment method added to the account.",
     "description": "A billing plan/package. For example: families, teams, enterprise, etc."
   },
   "invoiceNumber": {
@@ -2938,6 +2934,15 @@
       }
     }
   },
+    "subscriptionFreePlan": {
+      "message": "You cannot invite more than $COUNT$ users without upgrading your plan.",
+      "placeholders": {
+        "count": {
+          "content": "$1",
+          "example": "2"
+        }
+      }
+    },
   "subscriptionMaxReached": {
     "message": "Adjustments to your subscription will result in prorated changes to your billing totals. You cannot invite more than $COUNT$ users without increasing your subscription seats.",
     "placeholders": {

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -2934,15 +2934,24 @@
       }
     }
   },
-    "subscriptionFreePlan": {
-      "message": "You cannot invite more than $COUNT$ users without upgrading your plan.",
-      "placeholders": {
-        "count": {
-          "content": "$1",
-          "example": "2"
-        }
+  "subscriptionFreePlan": {
+    "message": "You cannot invite more than $COUNT$ users without upgrading your plan.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
       }
-    },
+    }
+  },
+  "subscriptionFamiliesPlan": {
+    "message": "You cannot invite more than $COUNT$ users without upgrading your plan. Please contact Customer Support to upgrade.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "6"
+      }
+    }
+  },
   "subscriptionMaxReached": {
     "message": "Adjustments to your subscription will result in prorated changes to your billing totals. You cannot invite more than $COUNT$ users without increasing your subscription seats.",
     "placeholders": {


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The subscription remodel in #1193 neglected to take into account the change plan form that would be shown for free organizations. Also tweaked the message shown for family plans to be specific the the options available to them.

## Code changes
* **organization-subscription.html**: add back in the button to show change plans and move the form to the top.
* **organization-subscription.ts**:
  * Only show the change plan button for free plans
  * Show a customized manage subscription message for both free and families plans, since those plans have limited self-serve options.
* **messages.json**: update messages. note: the `changeBillingPlan` key was being used only in this context, and you can only upgrade a free plan

## Screenshots
#### form closed
![image](https://user-images.githubusercontent.com/18214891/139718683-590e91f6-e34c-4448-bfdc-890b79fbefa6.png)

#### form open
![image](https://user-images.githubusercontent.com/18214891/139718707-914e1bb3-5158-4e32-ac23-b816b0592a02.png)

## Testing requirements
Test the button appears only for free plans and functions.

Test the `Manage Subscription` section's description text


## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [x] This change has particular **deployment requirements** (notify the DevOps team)
  - This will be a hotfix change. Once it is merged into master, I'll cherry pick to a hotfix branch and bump version.
