### PR TITLE
Fix repeat ng insert on safari

### DIFF
--- a/src/app/organizations/settings/organization-subscription.component.html
+++ b/src/app/organizations/settings/organization-subscription.component.html
@@ -71,11 +71,9 @@
             </ng-container>
         </div>
         <ng-container>
-            <div class="d-flex">
-                <button type="button" class="btn btn-outline-secondary" (click)="changePlan()" *ngIf="showChangePlanButton">
-                    {{'changeBillingPlan' | i18n}}
-                </button>
-            </div>
+            <button type="button" class="btn btn-outline-secondary" (click)="changePlan()" *ngIf="showChangePlanButton">
+                {{'changeBillingPlan' | i18n}}
+            </button>
             <app-change-plan [organizationId]="organizationId" (onChanged)="closeChangePlan(true)"
                 (onCanceled)="closeChangePlan(false)" *ngIf="showChangePlan"></app-change-plan>
         </ng-container>


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Bug fix for #1269 that QA found while testing hotfix. Angular was having trouble with the extra div on multiple rounds of toggling the `*ngIf` attribute.


## Code changes
Fix the issue with repeatedly toggling the form

## Screenshots

https://user-images.githubusercontent.com/18214891/139741182-6e86cdd1-52fc-4947-901c-49fd4710584d.mov




## Testing requirements
Test this form in safari in particular


## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
