### PR TITLE
remove callbackUri input for fixed mobile uri

### DIFF
--- a/src/connectors/webauthn.ts
+++ b/src/connectors/webauthn.ts
@@ -11,7 +11,8 @@ let btnText: string = null;
 let btnReturnText: string = null;
 let parentUrl: string = null;
 let parentOrigin: string = null;
-let callbackUri: string = null;
+let mobileResponse = false;
+let mobileCallbackUri = 'bitwarden://webauthn-callback';
 let stopWebAuthn = false;
 let sentSuccess = false;
 let obj: any = null;
@@ -75,7 +76,14 @@ function parseParametersV1() {
 }
 
 function parseParametersV2() {
-    let dataObj: { data: any, headerText: string; btnText: string; btnReturnText: string; callbackUri?: string } = null;
+    let dataObj: {
+        data: any,
+        headerText: string;
+        btnText: string;
+        btnReturnText: string;
+        callbackUri?: string;
+        mobile?: boolean 
+    } = null;
     try {
         dataObj = JSON.parse(b64Decode(getQsParam('data')));
     }
@@ -84,7 +92,7 @@ function parseParametersV2() {
         return;
     }
 
-    callbackUri = dataObj.callbackUri;
+    mobileResponse = dataObj.callbackUri != null || dataObj.mobile === true;
     webauthnJson = dataObj.data;
     headerText = dataObj.headerText;
     btnText = dataObj.btnText;
@@ -115,7 +123,7 @@ function start() {
 
     stopWebAuthn = false;
 
-    if (callbackUri != null || (navigator.userAgent.indexOf(' Safari/') !== -1 && navigator.userAgent.indexOf('Chrome') === -1)) {
+    if (mobileResponse || (navigator.userAgent.indexOf(' Safari/') !== -1 && navigator.userAgent.indexOf('Chrome') === -1)) {
         // Safari and mobile chrome blocks non-user initiated WebAuthn requests.
     } else {
         executeWebAuthn();
@@ -148,9 +156,9 @@ function onMessage() {
 }
 
 function error(message: string) {
-    if (callbackUri) {
-        document.location.replace(callbackUri + '?error=' + encodeURIComponent(message));
-        returnButton(callbackUri + '?error=' + encodeURIComponent(message));
+    if (mobileResponse) {
+        document.location.replace(mobileCallbackUri + '?error=' + encodeURIComponent(message));
+        returnButton(mobileCallbackUri + '?error=' + encodeURIComponent(message));
     } else {
         parent.postMessage('error|' + message, parentUrl);
     }
@@ -163,9 +171,9 @@ function success(assertedCredential: PublicKeyCredential) {
 
     const dataString = buildDataString(assertedCredential);
 
-    if (callbackUri) {
-        document.location.replace(callbackUri + '?data=' + encodeURIComponent(dataString));
-        returnButton(callbackUri + '?data=' + encodeURIComponent(dataString));
+    if (mobileResponse) {
+        document.location.replace(mobileCallbackUri + '?data=' + encodeURIComponent(dataString));
+        returnButton(mobileCallbackUri + '?data=' + encodeURIComponent(dataString));
     } else {
         parent.postMessage('success|' + dataString, parentUrl);
         sentSuccess = true;
@@ -173,7 +181,7 @@ function success(assertedCredential: PublicKeyCredential) {
 }
 
 function info(message: string) {
-    if (callbackUri) {
+    if (mobileResponse) {
         return;
     }
 


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Add a fixed-URL for mobile since it does not need to be dynamically passed.

## Code changes

Add a fixed-URL of `bitwarden://webauthn-callback` for mobile redirect.

## Testing requirements

Ensure that webauthn login works across all clients, especially mobile.

## Before you submit
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
