### PR TITLE
limit duo connector hosts to duo-owned domains

### DIFF
--- a/src/connectors/duo.ts
+++ b/src/connectors/duo.ts
@@ -12,6 +12,12 @@ document.addEventListener('DOMContentLoaded', event => {
 
     const hostParam = getQsParam('host');
     const requestParam = getQsParam('request');
+
+    var hostUrl = new URL('https://' + hostParam);
+    if (!hostUrl.hostname.endsWith('.duosecurity.com') && !hostUrl.hostname.endsWith('.duofederal.com')) {
+        return;
+    }
+
     DuoWebSDK.init({
         iframe: 'duo_iframe',
         host: hostParam,


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Don't allow using domain hosts that are not owned by Duo.

## Code changes
Whitelist `duosecurity.com` and `duofederal.com`.


## Testing requirements
Regression test mobile to ensure that Duo 2FA still works as expected.


## Before you submit
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
