### PR TITLE
don't use innerHTML for sso handOffMessage

### DIFF
--- a/src/connectors/sso.ts
+++ b/src/connectors/sso.ts
@@ -25,8 +25,11 @@ function initiateBrowserSso(code: string, state: string) {
     window.postMessage({ command: 'authResult', code: code, state: state }, '*');
     const handOffMessage = ('; ' + document.cookie).split('; ssoHandOffMessage=').pop().split(';').shift();
     document.cookie = 'ssoHandOffMessage=;SameSite=strict;max-age=0';
-    document.getElementById('content').innerHTML =
-        `<p>${handOffMessage}</p>`;
+    let content = document.getElementById('content');
+    content.innerHTML = '';
+    let p = document.createElement('p');
+    p.innerText = handOffMessage;
+    content.appendChild(p);
 }
 
 function extractFromRegex(s: string, regexString: string) {


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
It was discovered that a DOM-based XSS vulnerability via a cookie exists in the sso-connector.html page. The page receives the "ssoHandOffMessage" cookie's value and displays it via the innerHTML property. Here, since critical characters (e.g. "<",">") are not encoded at all, arbitrary HTML can be rendered if an attacker can set the "ssoHandOffMessage" cookie, for example, via a subdomain's XSS. Due to the CSP set on this page, it is not possible to execute JavaScript via this issue, however it may still be possible to perform phishing attacks.

## Code changes
Construct the content paragraph in parts and set the paragraph `handOffMessage` with the element's `innerText` property.

## Testing requirements
Regression test SSO experience via clients to confirm expected behavior persists.

## Before you submit
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
