### PR TITLE
[Key Connector] Test that Key Connector URL can be reached before saving

### DIFF
--- a/bitwarden_license/src/app/organizations/manage/sso.component.html
+++ b/bitwarden_license/src/app/organizations/manage/sso.component.html
@@ -56,10 +56,12 @@
             <label for="keyConnectorUrl">{{'keyConnectorUrl' | i18n}}</label>
             <input class="form-control" formControlName="keyConnectorUrl" id="keyConnectorUrl" required>
         </div>
-        <div *ngIf="keyConnectorIsValid === false">
+        <div class="text-danger" *ngIf="keyConnectorIsValid === false">
+            <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
             {{'keyConnectorTestFail' | i18n}}
         </div>
-        <div *ngIf="keyConnectorIsValid">
+        <div class="text-success" *ngIf="keyConnectorIsValid">
+            <i class="fa fa-check-circle-o" aria-hidden="true"></i>
             {{'keyConnectorTestSuccess' | i18n}}
         </div>
 

--- a/bitwarden_license/src/app/organizations/manage/sso.component.html
+++ b/bitwarden_license/src/app/organizations/manage/sso.component.html
@@ -63,11 +63,11 @@
                     </button>
                 </div>
             </div>
-            <div class="text-danger" *ngIf="keyConnectorIsValid === false" role="alert">
+            <div class="text-danger" *ngIf="keyConnectorIsValid === false && keyConnectorUrl.pristine" role="alert">
                 <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
                 {{'keyConnectorTestFail' | i18n}}
             </div>
-            <div class="text-success" *ngIf="keyConnectorIsValid" role="alert">
+            <div class="text-success" *ngIf="keyConnectorIsValid && keyConnectorUrl.pristine" role="alert">
                 <i class="fa fa-check-circle-o" aria-hidden="true"></i>
                 {{'keyConnectorTestSuccess' | i18n}}
             </div>

--- a/bitwarden_license/src/app/organizations/manage/sso.component.html
+++ b/bitwarden_license/src/app/organizations/manage/sso.component.html
@@ -56,10 +56,10 @@
             <label for="keyConnectorUrl">{{'keyConnectorUrl' | i18n}}</label>
             <input class="form-control" formControlName="keyConnectorUrl" id="keyConnectorUrl" required>
         </div>
-        <div *ngIf="keyConnectorUrl.errors?.testFail === true">
+        <div *ngIf="keyConnectorIsValid === false">
             {{'keyConnectorTestFail' | i18n}}
         </div>
-        <div *ngIf="keyConnectorUrl.errors?.testFail === false">
+        <div *ngIf="keyConnectorIsValid">
             {{'keyConnectorTestSuccess' | i18n}}
         </div>
 

--- a/bitwarden_license/src/app/organizations/manage/sso.component.html
+++ b/bitwarden_license/src/app/organizations/manage/sso.component.html
@@ -63,11 +63,11 @@
                     </button>
                 </div>
             </div>
-            <div class="text-danger" *ngIf="keyConnectorIsValid === false">
+            <div class="text-danger" *ngIf="keyConnectorIsValid === false" role="alert">
                 <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
                 {{'keyConnectorTestFail' | i18n}}
             </div>
-            <div class="text-success" *ngIf="keyConnectorIsValid">
+            <div class="text-success" *ngIf="keyConnectorIsValid" role="alert">
                 <i class="fa fa-check-circle-o" aria-hidden="true"></i>
                 {{'keyConnectorTestSuccess' | i18n}}
             </div>

--- a/bitwarden_license/src/app/organizations/manage/sso.component.html
+++ b/bitwarden_license/src/app/organizations/manage/sso.component.html
@@ -54,21 +54,24 @@
     
         <div class="form-group">
             <label for="keyConnectorUrl">{{'keyConnectorUrl' | i18n}}</label>
-            <input class="form-control" formControlName="keyConnectorUrl" id="keyConnectorUrl" required>
+            <div class="input-group">
+                <input class="form-control" formControlName="keyConnectorUrl" id="keyConnectorUrl" required>
+                <div class="input-group-append">
+                    <button type="button" class="btn btn-outline-secondary" (click)="testKeyConnector()"
+                        [disabled]="!enableTestKeyConnector">
+                        {{'keyConnectorTest' | i18n}}
+                    </button>
+                </div>
+            </div>
+            <div class="text-danger" *ngIf="keyConnectorIsValid === false">
+                <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+                {{'keyConnectorTestFail' | i18n}}
+            </div>
+            <div class="text-success" *ngIf="keyConnectorIsValid">
+                <i class="fa fa-check-circle-o" aria-hidden="true"></i>
+                {{'keyConnectorTestSuccess' | i18n}}
+            </div>
         </div>
-        <div class="text-danger" *ngIf="keyConnectorIsValid === false">
-            <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
-            {{'keyConnectorTestFail' | i18n}}
-        </div>
-        <div class="text-success" *ngIf="keyConnectorIsValid">
-            <i class="fa fa-check-circle-o" aria-hidden="true"></i>
-            {{'keyConnectorTestSuccess' | i18n}}
-        </div>
-
-        <button type="button" class="btn btn-outline-secondary" (click)="testKeyConnector()"
-            [disabled]="!enableTestKeyConnector">
-            {{'keyConnectorTest' | i18n}}
-        </button>
     </ng-container>
 
     <div class="form-group">

--- a/bitwarden_license/src/app/organizations/manage/sso.component.html
+++ b/bitwarden_license/src/app/organizations/manage/sso.component.html
@@ -56,6 +56,17 @@
             <label for="keyConnectorUrl">{{'keyConnectorUrl' | i18n}}</label>
             <input class="form-control" formControlName="keyConnectorUrl" id="keyConnectorUrl" required>
         </div>
+        <div *ngIf="keyConnectorUrl.errors?.testFail === true">
+            {{'keyConnectorTestFail' | i18n}}
+        </div>
+        <div *ngIf="keyConnectorUrl.errors?.testFail === false">
+            {{'keyConnectorTestSuccess' | i18n}}
+        </div>
+
+        <button type="button" class="btn btn-outline-secondary" (click)="testKeyConnector()"
+            [disabled]="!enableTestKeyConnector">
+            {{'keyConnectorTest' | i18n}}
+        </button>
     </ng-container>
 
     <div class="form-group">

--- a/bitwarden_license/src/app/organizations/manage/sso.component.ts
+++ b/bitwarden_license/src/app/organizations/manage/sso.component.ts
@@ -115,16 +115,7 @@ export class SsoComponent implements OnInit {
     }
 
     async submit() {
-        if (this.data.get('useKeyConnector').value) {
-            const keyConnectorUrl = this.data.get('keyConnectorUrl').value;
-            try {
-                await this.apiService.getKeyConnectorAlive(keyConnectorUrl);
-            } catch {
-                this.platformUtilsService.showToast('error', null,
-                    'Unable to reach Key Connector. Check the URL and try again.');
-                return;
-            }
-        }
+        await this.pingKeyConnector();
 
         const request = new OrganizationSsoRequest();
         request.enabled = this.enabled.value;
@@ -138,5 +129,17 @@ export class SsoComponent implements OnInit {
 
         this.formPromise = null;
         this.platformUtilsService.showToast('success', null, this.i18nService.t('ssoSettingsSaved'));
+    }
+
+    private async pingKeyConnector() {
+        if (this.data.get('useKeyConnector').value) {
+            const keyConnectorUrl = this.data.get('keyConnectorUrl').value;
+            try {
+                await this.apiService.getKeyConnectorAlive(keyConnectorUrl);
+            } catch {
+                this.platformUtilsService.showToast('error', null, this.i18nService.t('cannotReachKeyConnector'));
+                return;
+            }
+        }
     }
 }

--- a/bitwarden_license/src/app/organizations/manage/sso.component.ts
+++ b/bitwarden_license/src/app/organizations/manage/sso.component.ts
@@ -118,6 +118,15 @@ export class SsoComponent implements OnInit {
     }
 
     async submit() {
+        if (this.keyConnectorUrl.errors?.testFail !== false)
+        {
+            await this.testKeyConnector();
+            if (this.keyConnectorUrl.errors?.testFail !== false) {
+                this.platformUtilsService.showToast('error', null, 'error occurred');
+                return;
+            }
+        }
+
         this.platformUtilsService.showToast('success', null, 'form saved');
         return;
 

--- a/bitwarden_license/src/app/organizations/manage/sso.component.ts
+++ b/bitwarden_license/src/app/organizations/manage/sso.component.ts
@@ -108,6 +108,17 @@ export class SsoComponent implements OnInit {
     }
 
     async submit() {
+        if (this.data.get('useKeyConnector').value) {
+            const keyConnectorUrl = this.data.get('keyConnectorUrl').value;
+            try {
+                await this.apiService.getKeyConnectorAlive(keyConnectorUrl);
+            } catch {
+                this.platformUtilsService.showToast('error', null,
+                    'Unable to reach Key Connector. Check the URL and try again.');
+                return;
+            }
+        }
+
         const request = new OrganizationSsoRequest();
         request.enabled = this.enabled.value;
         request.data = this.data.value;

--- a/bitwarden_license/src/app/organizations/manage/sso.component.ts
+++ b/bitwarden_license/src/app/organizations/manage/sso.component.ts
@@ -153,7 +153,7 @@ export class SsoComponent implements OnInit, OnDestroy {
 
     async testKeyConnector() {
         if (this.keyConnectorIsValid) {
-            return true;
+            return;
         }
 
         try {

--- a/bitwarden_license/src/app/organizations/manage/sso.component.ts
+++ b/bitwarden_license/src/app/organizations/manage/sso.component.ts
@@ -103,6 +103,9 @@ export class SsoComponent implements OnInit {
         this.spMetadataUrl = ssoSettings.urls.spMetadataUrl;
         this.spAcsUrl = ssoSettings.urls.spAcsUrl;
 
+        // TESTING ONLY
+        this.organization.useKeyConnector = true;
+
         this.loading = false;
     }
 
@@ -115,7 +118,8 @@ export class SsoComponent implements OnInit {
     }
 
     async submit() {
-        await this.pingKeyConnector();
+        this.platformUtilsService.showToast('success', null, 'form saved');
+        return;
 
         const request = new OrganizationSsoRequest();
         request.enabled = this.enabled.value;
@@ -131,15 +135,28 @@ export class SsoComponent implements OnInit {
         this.platformUtilsService.showToast('success', null, this.i18nService.t('ssoSettingsSaved'));
     }
 
-    private async pingKeyConnector() {
-        if (this.data.get('useKeyConnector').value) {
-            const keyConnectorUrl = this.data.get('keyConnectorUrl').value;
-            try {
-                await this.apiService.getKeyConnectorAlive(keyConnectorUrl);
-            } catch {
-                this.platformUtilsService.showToast('error', null, this.i18nService.t('cannotReachKeyConnector'));
-                return;
-            }
+    async testKeyConnector() {
+        try {
+            await this.apiService.getKeyConnectorAlive(this.keyConnectorUrl.value);
+        } catch {
+            this.keyConnectorUrl.setErrors({
+                testFail: true,
+            });
+            return;
         }
+
+        this.keyConnectorUrl.setErrors({
+            testFail: false,
+        });
+    }
+
+    get enableTestKeyConnector() {
+        return this.data.get('keyConnectorEnabled').value &&
+            this.keyConnectorUrl != null &&
+            this.keyConnectorUrl.value !== '';
+    }
+
+    get keyConnectorUrl() {
+        return this.data.get('keyConnectorUrl');
     }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -4556,5 +4556,8 @@
   },
   "migratedKeyConnector": {
     "message": "Migrated to Key Connector"
+  },
+  "cannotReachKeyConnector": {
+    "message": "Unable to reach Key Connector. Check the URL and try again."
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -4557,7 +4557,13 @@
   "migratedKeyConnector": {
     "message": "Migrated to Key Connector"
   },
-  "cannotReachKeyConnector": {
-    "message": "Unable to reach Key Connector. Check the URL and try again."
+  "keyConnectorTest": {
+    "message": "Test"
+  },
+  "keyConnectorTestSuccess": {
+    "message": "Success! Key Connector reached."
+  },
+  "keyConnectorTestFail": {
+    "message": "Cannot reach Key Connector. Check URL."
   }
 }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Before saving Key Connector config, ping the Key Connector URL to make sure it's alive.

## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **bitwarden_license/src/app/organizations/manage/sso.component.ts** - ping the Key Connector URL on save, return an error toast if it can't be reached.

Depends on https://github.com/bitwarden/jslib/pull/543.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Try saving the Key Connector config with valid and invalid Key Connector URLs. If the URL is invalid (i.e. Key Connector cannot be reached), you should get an error toast.

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
