### PR TITLE
Use Mql.addListener for backwards compat (Safari < v14)

### DIFF
--- a/src/services/webPlatformUtils.service.ts
+++ b/src/services/webPlatformUtils.service.ts
@@ -156,7 +156,7 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
     }
 
     supportsWebAuthn(win: Window): boolean {
-        return (typeof(PublicKeyCredential) !== 'undefined');
+        return (typeof (PublicKeyCredential) !== 'undefined');
     }
 
     supportsDuo(): boolean {
@@ -304,8 +304,15 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
     }
 
     onDefaultSystemThemeChange(callback: ((theme: ThemeType.Light | ThemeType.Dark) => unknown)) {
-        this.prefersColorSchemeDark.addEventListener('change', ({ matches }) => {
-            callback(matches ? ThemeType.Dark : ThemeType.Light);
-        });
+        try {
+            this.prefersColorSchemeDark.addEventListener('change', ({ matches }) => {
+                callback(matches ? ThemeType.Dark : ThemeType.Light);
+            });
+        } catch (e) {
+            // Safari older than v14
+            this.prefersColorSchemeDark.addListener(ev => {
+                callback(ev.matches ? ThemeType.Dark : ThemeType.Light);
+            });
+        }
     }
 }


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Asana ticket: https://app.asana.com/0/1169444489336079/1201388075241995/f

When opening the web-vault on Safari older than v14 the login form would not come up and only display and endless spinner.

This is due to an issue with backwards compatability of `MediaQueryList.addEventListener` which is only supported as of Safari > v14. To fix this I've added a fallback to `MediaQueryList.addListener` which is supported on lower version.

I unfortunately don't own a Mac and I'm unable to test this locally.

## Code changes
* **services\webPlatformUtils.service.ts:** Added a try catch and on exception try using addListener instead.

## Testing requirements
Possible to see the vault login form on a Mac using Safari v13.x

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
