### PR TITLE
Display sponsored status for sponsored org subscription

### DIFF
--- a/src/app/organizations/settings/account.component.ts
+++ b/src/app/organizations/settings/account.component.ts
@@ -4,7 +4,7 @@ import {
     ViewContainerRef,
 } from '@angular/core';
 
-import { 
+import {
     ActivatedRoute,
     Router
 } from '@angular/router';

--- a/src/app/organizations/settings/delete-organization.component.ts
+++ b/src/app/organizations/settings/delete-organization.component.ts
@@ -1,4 +1,4 @@
-import { 
+import {
     Component,
     EventEmitter,
     Output,

--- a/src/app/organizations/settings/organization-subscription.component.html
+++ b/src/app/organizations/settings/organization-subscription.component.html
@@ -32,7 +32,7 @@
                     <ng-container *ngIf="subscription">
                         <dt>{{'status' | i18n}}</dt>
                         <dd>
-                            <span class="text-capitalize">{{subscription.status || '-'}}</span>
+                            <span class="text-capitalize">{{isSponsoredSubscription ? 'sponsored' : subscription.status || '-'}}</span>
                             <span class="badge badge-warning"
                                 *ngIf="subscriptionMarkedForCancel">{{'pendingCancellation' |
                                 i18n}}</span>

--- a/src/app/organizations/sponsorships/families-for-enterprise-setup.component.ts
+++ b/src/app/organizations/sponsorships/families-for-enterprise-setup.component.ts
@@ -40,7 +40,7 @@ import { OrganizationPlansComponent } from 'src/app/settings/organization-plans.
     templateUrl: 'families-for-enterprise-setup.component.html',
 })
 export class FamiliesForEnterpriseSetupComponent implements OnInit {
-    @ViewChild(OrganizationPlansComponent, { static: false }) 
+    @ViewChild(OrganizationPlansComponent, { static: false })
     set organizationPlansComponent(value: OrganizationPlansComponent) {
         if (!value) {
             return;
@@ -109,7 +109,7 @@ export class FamiliesForEnterpriseSetupComponent implements OnInit {
     get selectedFamilyOrganizationId() {
         return this._selectedFamilyOrganizationId;
     }
-    
+
     set selectedFamilyOrganizationId(value: string) {
         this._selectedFamilyOrganizationId = value;
         this.showNewOrganization = value === 'createNew';

--- a/src/app/settings/sponsoring-org-row.component.ts
+++ b/src/app/settings/sponsoring-org-row.component.ts
@@ -50,7 +50,7 @@ export class SponsoringOrgRowComponent {
 
     private async doRevokeSponsorship() {
         const isConfirmed = await this.platformUtilsService.showDialog(
-            this.i18nService.t('revokeSponsorshipConfirmation'), 
+            this.i18nService.t('revokeSponsorshipConfirmation'),
             `${this.i18nService.t('remove')} ${this.sponsoringOrg.familySponsorshipFriendlyName}?`,
             this.i18nService.t('remove'), this.i18nService.t('cancel'), 'warning');
 


### PR DESCRIPTION
Fixes https://app.asana.com/0/1169444489336079/1201418385615065/f

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Organization sponsorship pages display subscription statuses. This is confusing since Stripe doesn't know much about our sponsorship statuses. This PR detects when an organization is sponsored and updates the status to `sponsored`.

Note, this isn't translated, just like the subscription status isn't translated.

## Screenshots
![image](https://user-images.githubusercontent.com/18214891/143149722-b5caf682-7559-4645-b783-bd02d2deecda.png)



## Testing requirements
This uses the presence a sponsored subscription item to update this status. We need to be really sure that we don't get in a state where we have a sponsored plan and a non-sponsored plan, otherwise this status will be invalid.



## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
