### PR TITLE
Add sponsorship pre validate to families redeem page

### DIFF
--- a/src/app/organizations/sponsorships/families-for-enterprise-setup.component.html
+++ b/src/app/organizations/sponsorships/families-for-enterprise-setup.component.html
@@ -6,7 +6,10 @@
                 <i class="fa fa-spinner fa-spin fa-2x text-muted" title="{{'loading' | i18n}}" aria-hidden="true"></i>
                 <span class="sr-only">{{'loading' | i18n}}</span>
     </div>
-    <form #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate *ngIf="!loading">
+    <div *ngIf="!loading && badToken" class="mt-5 d-flex justify-content-center">
+        <span>{{'badToken' | i18n}}</span>
+    </div>
+    <form #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate *ngIf="!loading && !badToken">
         <p>
             <span>{{'acceptBitwardenFamiliesHelp' | i18n}}</span>
         </p>

--- a/src/app/organizations/sponsorships/families-for-enterprise-setup.component.ts
+++ b/src/app/organizations/sponsorships/families-for-enterprise-setup.component.ts
@@ -55,6 +55,7 @@ export class FamiliesForEnterpriseSetupComponent implements OnInit {
     @ViewChild('deleteOrganizationTemplate', { read: ViewContainerRef, static: true }) deleteModalRef: ViewContainerRef;
 
     loading = true;
+    badToken = false;
     formPromise: Promise<any>;
 
     token: string;
@@ -89,6 +90,7 @@ export class FamiliesForEnterpriseSetupComponent implements OnInit {
             this.token = qParams.token;
 
             await this.syncService.fullSync(true);
+            this.badToken = !await this.apiService.postPreValidateSponsorshipToken(this.token);
             this.loading = false;
 
             this.existingFamilyOrganizations = (await this.userService.getAllOrganizations())

--- a/src/app/settings/organization-plans.component.ts
+++ b/src/app/settings/organization-plans.component.ts
@@ -282,8 +282,8 @@ export class OrganizationPlansComponent implements OnInit {
             };
 
             this.formPromise = doSubmit();
-            const orgId = await this.formPromise;
-            this.onSuccess.emit({ organizationId: orgId });
+            const organizationId = await this.formPromise;
+            this.onSuccess.emit({ organizationId: organizationId });
         } catch (e) {
             this.logService.error(e);
         }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -4506,6 +4506,9 @@
   "sponsoredFamiliesSharedCollections": {
     "message": "Shared collections for Family secrets"
   },
+  "badToken": {
+    "message": "The link is no longer valid. Please have the sponsor resend the redemption offer."
+  },
   "reclaimedFreePlan": {
     "message": "Reclaimed free plan"
   },
@@ -4702,7 +4705,7 @@
     "message": "Please provide a payment method to associate with the organization. Don't worry, we won't charge you anything unless you select additional features or your sponsorship expires. "
   },
   "orgCreatedSponsorshipInvalid": {
-    "message": "The sponsorship offer has expired you may delete the organization you created to avoid a charge at the end of your 7 day trial. Otherwise you may close this prompt to keep the organization and assume billing responsibility."
+    "message": "The sponsorship offer has expired. You may delete the organization you created to avoid a charge at the end of your 7 day trial. Otherwise you may close this prompt to keep the organization and assume billing responsibility."
   },
   "newFamiliesOrganization": {
     "message": "New Families Organization"

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -4507,7 +4507,7 @@
     "message": "Shared collections for Family secrets"
   },
   "badToken": {
-    "message": "The link is no longer valid. Please have the sponsor resend the redemption offer."
+    "message": "The link is no longer valid. Please have the sponsor resend the offer."
   },
   "reclaimedFreePlan": {
     "message": "Reclaimed free plan"
@@ -4543,7 +4543,7 @@
     }
   },
   "sponsoredFamiliesOffer": {
-    "message": "Redeem Free Bitwarden Families Organization Offer"
+    "message": "Accept Free Bitwarden Families"
   },
   "sponsoredFamiliesOfferRedeemed": {
     "message": "Free Bitwarden Families offer successfully redeemed"


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Show error page on sponsorship redeem if the token is not going to work. This involved pre-validating the token with new api endpoints.


## Code changes
Messages and view changes related to bad tokens. 

* **families-for-enterprise-setup.component**: Pre validate the sponsorship token to increase likelihood subsequent requests will succeed.
* **organization-plans.component**: linter fix of shadowed variable.
* **messages.json**: new messages

## Screenshots
![image](https://user-images.githubusercontent.com/18214891/143262930-8cafeb17-0ec8-4da8-857e-7b7652e0bab0.png)




## Testing requirements
Attempt to bypass the block by re-using a sponsorship link, using a link that have been revoked, the wrong user, etc. In all cases, the page should block use unless the sponsorship will work.

It is still possible to get an error state from the redeem endpoint that isn't caught by the pre-validate token, but it will require usage of the endpoint by a user not entitled to sponsor a particular organization rather than an issue with the token itself.



## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)


# Draft Reason
 - [x] depends on bitwarden/jslib#564