### PR TITLE
Force sponsorship friendly name to recipient address

### DIFF
--- a/src/app/settings/sponsored-families.component.html
+++ b/src/app/settings/sponsored-families.component.html
@@ -30,10 +30,6 @@
             <label for="accountEmail">{{'sponsoredFamiliesEmail' | i18n}}:</label>
             <input id="accountEmail" class="form-control" inputmode="email" [(ngModel)]="sponsorshipEmail"
                 name="sponsorshipEmail" required>
-        </div>
-        <div class="form-group col-6">
-            <label for="friendlyName">{{'friendlyName' | i18n}}:</label>
-            <input id="friendlyName" class="form-control" [(ngModel)]="friendlyName" name="friendlyName" required>
             <button class="btn btn-primary btn-submit mt-4" type="submit" [disabled]="form.loading">
                 <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
                 <span>{{'redeem' | i18n}}</span>
@@ -44,7 +40,7 @@
         <table class="table table-hover table-list">
             <thead>
                 <tr>
-                    <th>{{'friendlyName' | i18n}}</th>
+                    <th>{{'recipient' | i18n}}</th>
                     <th>{{'sponsoringOrg' | i18n}}</th>
                     <th></th>
                 </tr>

--- a/src/app/settings/sponsored-families.component.ts
+++ b/src/app/settings/sponsored-families.component.ts
@@ -21,7 +21,6 @@ export class SponsoredFamiliesComponent implements OnInit {
     activeSponsorshipOrgs: Organization[] = [];
     selectedSponsorshipOrgId: string = '';
     sponsorshipEmail: string = '';
-    friendlyName: string = '';
 
     // Conditional display properties
     formPromise: Promise<any>;
@@ -38,7 +37,7 @@ export class SponsoredFamiliesComponent implements OnInit {
         this.formPromise = this.apiService.postCreateSponsorship(this.selectedSponsorshipOrgId, {
             sponsoredEmail: this.sponsorshipEmail,
             planSponsorshipType: PlanSponsorshipType.FamiliesForEnterprise,
-            friendlyName: this.friendlyName,
+            friendlyName: this.sponsorshipEmail,
         });
 
         await this.formPromise;
@@ -72,7 +71,6 @@ export class SponsoredFamiliesComponent implements OnInit {
 
     private async resetForm() {
         this.sponsorshipEmail = '';
-        this.friendlyName = '';
         this.selectedSponsorshipOrgId = '';
     }
 

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -4575,8 +4575,8 @@
   "redeemNow": {
     "message": "Redeem Now"
   },
-  "friendlyName": {
-    "message": "Friendly Name"
+  "recipient": {
+    "message": "Recipient"
   },
   "removeSponsorship": {
     "message": "Remove Sponsorship"


### PR DESCRIPTION
https://app.asana.com/0/1169444489336079/1201418252130717/f

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Friendly name is nice to allow for great flexibility in naming your sponsorships, but it's ultimately unnecessary. The natural way to organize and label these organizations is with the email address the offer is sent to. This PR sets friendly name to the recipient email address and removes the option of changing it from this default


## Screenshots
![image](https://user-images.githubusercontent.com/18214891/143269990-f6d7843b-5ac9-4882-8c4b-b08be70e131d.png)

![image](https://user-images.githubusercontent.com/18214891/143270039-90bdeff5-46fd-4a50-bfc7-50ec51dd25c4.png)



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->



## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [x] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
