### PR TITLE
Fix formatting and title of sponsoring org drop down

### DIFF
--- a/src/app/settings/sponsored-families.component.html
+++ b/src/app/settings/sponsored-families.component.html
@@ -17,8 +17,8 @@
         </ul>
     </div>
     <form #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate *ngIf="anyOrgsAvailable">
-        <div *ngIf="moreThanOneOrgAvailable" class="form-group col-6">
-            <label for="availableSponsorshipOrg">{{ 'sponsoredFamiliesSelectOffer' | i18n}}</label>
+        <div *ngIf="moreThanOneOrgAvailable" class="form-group col-7">
+            <label for="availableSponsorshipOrg">{{ 'familiesSponsoringOrgSelect' | i18n}}</label>
             <select id="availableSponsorshipOrg" name="Available Sponsorship Organization"
                 [(ngModel)]="selectedSponsorshipOrgId" class="form-control" required>
                 <option value="">-- {{'select' | i18n}} --</option>
@@ -26,7 +26,7 @@
             </select>
             <small>{{'sponsoredFamiliesLeaveCopy' | i18n}}</small>
         </div>
-        <div class="form-group col-6">
+        <div class="form-group col-7">
             <label for="accountEmail">{{'sponsoredFamiliesEmail' | i18n}}:</label>
             <input id="accountEmail" class="form-control" inputmode="email" [(ngModel)]="sponsorshipEmail"
                 name="sponsorshipEmail" required>

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -4515,6 +4515,9 @@
   "sponsoredFamiliesSelectOffer": {
     "message": "Select the organization you would like sponsored"
   },
+  "familiesSponsoringOrgSelect": {
+    "message": "Which Free Families offer would you like to redeem?"
+  },
   "sponsoredFamiliesEmail": {
     "message": "Enter your personal email to redeem Bitwarden Families"
   },


### PR DESCRIPTION
Fixes https://app.asana.com/0/1169444489336079/1201418252130711/f

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Correct language around the sponsoring org drop down on families offer page. Previously it was tied to the setup page, which was incorrect. I also made the inputs larger to better match our figma design.
## Screenshots
![image](https://user-images.githubusercontent.com/18214891/143308460-666a9102-0970-4551-8477-9b2d0a81e3f2.png)



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->



## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
