### PR TITLE
Bump node to v16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,10 +56,6 @@ jobs:
         with:
           node-version: '16'
 
-      - name: Update NPM
-        run: |
-          npm install -g npm@8
-
       - name: Cache npm
         id: npm-cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353  # v2.1.6
@@ -108,10 +104,6 @@ jobs:
         with:
           node-version: '16'
 
-      - name: Update NPM
-        run: |
-          npm install -g npm@8
-
       - name: Cache npm
         id: npm-cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353  # v2.1.6
@@ -159,10 +151,6 @@ jobs:
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
           node-version: '16'
-
-      - name: Update NPM
-        run: |
-          npm install -g npm@8
 
       - name: Cache npm
         id: npm-cache
@@ -270,10 +258,6 @@ jobs:
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
           node-version: '16'
-
-      - name: Update NPM
-        run: |
-          npm install -g npm@8
 
       - name: Cache npm
         id: npm-cache
@@ -385,10 +369,6 @@ jobs:
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
           node-version: '16'
-
-      - name: Update NPM
-        run: |
-          npm install -g npm@8
 
       - name: Print environment
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,11 +54,11 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Update NPM
         run: |
-          npm install -g npm@7
+          npm install -g npm@8
 
       - name: Cache npm
         id: npm-cache
@@ -106,11 +106,11 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Update NPM
         run: |
-          npm install -g npm@7
+          npm install -g npm@8
 
       - name: Cache npm
         id: npm-cache
@@ -158,11 +158,11 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Update NPM
         run: |
-          npm install -g npm@7
+          npm install -g npm@8
 
       - name: Cache npm
         id: npm-cache
@@ -269,11 +269,11 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Update NPM
         run: |
-          npm install -g npm@7
+          npm install -g npm@8
 
       - name: Cache npm
         id: npm-cache
@@ -384,11 +384,11 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Update NPM
         run: |
-          npm install -g npm@7
+          npm install -g npm@8
 
       - name: Print environment
         run: |

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 
 ### Requirements
 
-- [Node.js](https://nodejs.org) v14.17 or greater
-- NPM v7
+- [Node.js](https://nodejs.org) v16.13.1 or greater
+- NPM v8
 
 ### Run the app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,8 +69,8 @@
         "webpack-dev-server": "^4.6.0"
       },
       "engines": {
-        "node": "~14",
-        "npm": "~7"
+        "node": "~16",
+        "npm": "~8"
       }
     },
     "jslib/angular": {
@@ -117,7 +117,7 @@
       },
       "devDependencies": {
         "@types/lunr": "^2.3.3",
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "@types/node-forge": "^0.9.7",
         "@types/papaparse": "^5.2.5",
         "@types/tldjs": "^2.3.0",
@@ -125,6 +125,12 @@
         "rimraf": "^3.0.2",
         "typescript": "4.3.5"
       }
+    },
+    "jslib/common/node_modules/@types/node": {
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
+      "dev": true
     },
     "node_modules/@angular/animations": {
       "version": "12.2.14",
@@ -7701,7 +7707,7 @@
         "@microsoft/signalr": "5.0.10",
         "@microsoft/signalr-protocol-msgpack": "5.0.10",
         "@types/lunr": "^2.3.3",
-        "@types/node": "^14.17.1",
+        "@types/node": "^16.11.12",
         "@types/node-forge": "^0.9.7",
         "@types/papaparse": "^5.2.5",
         "@types/tldjs": "^2.3.0",
@@ -7716,6 +7722,14 @@
         "tldjs": "^2.3.1",
         "typescript": "4.3.5",
         "zxcvbn": "^4.4.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "16.11.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+          "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
+          "dev": true
+        }
       }
     },
     "@braintree/asset-loader": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@angular/compiler-cli": "^12.2.13",
         "@ngtools/webpack": "^12.2.13",
         "@types/jquery": "^3.5.5",
-        "@types/node": "^14.17.2",
+        "@types/node": "^16.11.12",
         "@types/webcrypto": "^0.0.28",
         "@types/webpack": "^5.28.0",
         "buffer": "^6.0.3",
@@ -125,12 +125,6 @@
         "rimraf": "^3.0.2",
         "typescript": "4.3.5"
       }
-    },
-    "jslib/common/node_modules/@types/node": {
-      "version": "16.11.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
-      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
-      "dev": true
     },
     "node_modules/@angular/animations": {
       "version": "12.2.14",
@@ -902,9 +896,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
-      "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==",
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
       "dev": true
     },
     "node_modules/@types/node-forge": {
@@ -7722,14 +7716,6 @@
         "tldjs": "^2.3.1",
         "typescript": "4.3.5",
         "zxcvbn": "^4.4.2"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "16.11.12",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
-          "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
-          "dev": true
-        }
       }
     },
     "@braintree/asset-loader": {
@@ -7940,9 +7926,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
-      "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==",
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
       "dev": true
     },
     "@types/node-forge": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "whatwg-fetch": "3.6.2"
   },
   "engines": {
-    "node": "~14",
-    "npm": "~7"
+    "node": "~16",
+    "npm": "~8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@angular/compiler-cli": "^12.2.13",
     "@ngtools/webpack": "^12.2.13",
     "@types/jquery": "^3.5.5",
-    "@types/node": "^14.17.2",
+    "@types/node": "^16.11.12",
     "@types/webcrypto": "^0.0.28",
     "@types/webpack": "^5.28.0",
     "buffer": "^6.0.3",


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With our plan to bump electron soon, we need to upgrade Node to v16 (LTS) as newer version of electron require it.

Depends on https://github.com/bitwarden/jslib/pull/575
Asana task: https://app.asana.com/0/0/1201498644188835/f

## Code changes
* **jslib:** Bump jslib from https://github.com/bitwarden/jslib/pull/575
* **package.json:** Updated engine requirements and bumped @types/node to 16.11.12
* **package-lock.json:** Updates after running `npm i`
* **build.yml:** Setting the build to require node v16 and npm v8
* **README.md:** Updated requirements

## Testing requirements
Will require running regression testing.

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
