### PR TITLE
send configType and redirectBehavior as int instead of string for req…

### DIFF
--- a/bitwarden_license/src/app/organizations/manage/sso.component.html
+++ b/bitwarden_license/src/app/organizations/manage/sso.component.html
@@ -83,9 +83,9 @@
     <div class="form-group">
         <label for="type">{{'type' | i18n}}</label>
         <select class="form-control" id="type" formControlName="configType">
-            <option value="0" disabled>{{'selectType' | i18n}}</option>
-            <option value="1">OpenID Connect</option>
-            <option value="2">SAML 2.0</option>
+            <option [ngValue]="0" disabled>{{'selectType' | i18n}}</option>
+            <option [ngValue]="1">OpenID Connect</option>
+            <option [ngValue]="2">SAML 2.0</option>
         </select>
     </div>
 
@@ -138,8 +138,8 @@
             <div class="form-group">
                 <label for="redirectBehavior">{{'oidcRedirectBehavior' | i18n}}</label>
                 <select class="form-control" formControlName="redirectBehavior" id="redirectBehavior">
-                    <option value="0">Redirect GET</option>
-                    <option value="1">Form POST</option>
+                    <option [ngValue]="0">Redirect GET</option>
+                    <option [ngValue]="1">Form POST</option>
                 </select>
             </div>
             <div class="form-group">


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Our `SsoConfigApi` response object uses the enum `SsoType` for the configType of our `organizationSsoRequest`. While saving new SSO configurations, the request was failing because it couldn't convert the string to provided by angular to the int needed for the enum. 

Essentially, our configType and redirectBehavior were sending as `"1"` instead of `1`.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **file.ext:** Description of what was changed and why

## Screenshots
<!--Required for any UI changes. Delete if not applicable-->



## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->



## Before you submit
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
