### PR TITLE
Fix missing translation for unlinking SSO dialog

### DIFF
--- a/src/app/settings/organizations.component.ts
+++ b/src/app/settings/organizations.component.ts
@@ -77,7 +77,7 @@ export class OrganizationsComponent implements OnInit {
 
   async unlinkSso(org: Organization) {
     const confirmed = await this.platformUtilsService.showDialog(
-      "Are you sure you want to unlink SSO for this organization?",
+      this.i18nService.t("unlinkSsoConfirmation"),
       org.name,
       this.i18nService.t("yes"),
       this.i18nService.t("no"),

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -3444,6 +3444,9 @@
   "unlinkSso": {
     "message": "Unlink SSO"
   },
+  "unlinkSsoConfirmation": {
+    "message": "Are you sure you want to unlink SSO for this organization?"
+  },
   "linkSso": {
     "message": "Link SSO"
   },


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fix a string that was not translated in the unlink SSO dialog

## Code changes
- **src/app/settings/organizations.component.ts:** Use i18n to translate missing string
- **src/locales/en/messages.json:** Add missing string

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
