### PR TITLE
[Bug] Fix select options background color (#1338)

### DIFF
--- a/src/scss/forms.scss
+++ b/src/scss/forms.scss
@@ -74,7 +74,11 @@ label.form-check-label, .form-control-file {
     @include themify($themes) {
         background-color: themed('inputBackgroundColor');
         border-color: themed('inputBorderColor');
-        color: themed('inputTextColor');
+        color: themed('inputTextColor');  
+        
+        option {
+            background-color: themed('backgroundColor');
+        }
     }
 
     &:disabled, &[readonly] {
@@ -82,7 +86,7 @@ label.form-check-label, .form-control-file {
             background-color: themed('inputDisabledBackground');
             color: themed('inputDisabledColor');
         }
-    }
+    }  
 }
 
 input[type="radio"], input[type="checkbox"] {


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fix for bug #1338 

## Code changes
- forms.scss
Added background color from theme, to <option> tag in a form-control class

## Screenshots
![Screenshot](https://user-images.githubusercontent.com/34923063/146600523-1cb2e880-a8d7-455a-bed5-9c8c90391a81.png)

## Testing requirements

Check if in dark mode the select options input have dark background

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
