### PR TITLE
Patch CI to allow for redeployments. Add Github actions to prettier .ignore as well.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,15 @@ name: Release
 
 on:
   workflow_dispatch:
-    release_type:
-      description: 'Release Options'
-      required: true
-      default: 'Initial Release'
-      type: choice
-      options:
-        - Initial Release
-        - Rerun
+    inputs:
+      release_type:
+        description: 'Release Options'
+        required: true
+        default: 'Initial Release'
+        type: choice
+        options:
+          - Initial Release
+          - Rerun
 
 jobs:
   setup:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-20.04
+    if: ${{ github.event.inputs.release_type != 'Rerun' }}
     outputs:
       release_version: ${{ steps.version.outputs.package }}
       tag_version: ${{ steps.version.outputs.tag }}
@@ -168,6 +169,7 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-20.04
+    if: ${{ github.event.inputs.release_type == 'Initial Release' }}
     needs:
       - setup
       - self-host

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,14 @@ name: Release
 
 on:
   workflow_dispatch:
-    inputs: {}
+    release_type:
+      description: 'Release Options'
+      required: true
+      default: 'Initial Release'
+      type: choice
+      options:
+        - Initial Release
+        - Rerun
 
 jobs:
   setup:
@@ -24,7 +31,7 @@ jobs:
           fi
 
       - name: Checkout repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # 2.3.4
 
       - name: Check Release Version
         id: version
@@ -106,7 +113,7 @@ jobs:
       _TAG_VERSION: ${{ needs.setup.outputs.tag_version }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
         with:
           ref: gh-pages
 
@@ -116,7 +123,7 @@ jobs:
           git push -u origin deploy-$_TAG_VERSION
 
       - name: Checkout Repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
 
       - name: Setup git config
         run: |
@@ -138,7 +145,7 @@ jobs:
         run: unzip web-*-cloud-COMMERCIAL.zip
 
       - name: Deploy GitHub Pages
-        uses: crazy-max/ghaction-github-pages@db4476a01402e1a7ce05f41832040eef16d14925 # v2.5.0
+        uses: crazy-max/ghaction-github-pages@db4476a01402e1a7ce05f41832040eef16d14925  # v2.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-20.04
-    if: ${{ github.event.inputs.release_type != 'Redeploy' }}
     outputs:
       release_version: ${{ steps.version.outputs.package }}
       tag_version: ${{ steps.version.outputs.tag }}
@@ -43,7 +42,8 @@ jobs:
             curl -sL https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest | jq -r ".tag_name"
           )
 
-          if [ "v$version" == "$previous_release_tag_version" ]; then
+          if [ "v$version" == "$previous_release_tag_version" ] && \
+          [ "${{ github.event.inputs.release_type }}" == "Initial Release" ]; then
             echo "[!] Already released v$version. Please bump version to continue"
             exit 1
           fi
@@ -169,7 +169,6 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-20.04
-    if: ${{ github.event.inputs.release_type == 'Initial Release' }}
     needs:
       - setup
       - self-host

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,13 @@ on:
         type: choice
         options:
           - Initial Release
-          - Rerun
+          - Redeploy
 
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-20.04
-    if: ${{ github.event.inputs.release_type != 'Rerun' }}
+    if: ${{ github.event.inputs.release_type != 'Redeploy' }}
     outputs:
       release_version: ${{ steps.version.outputs.package }}
       tag_version: ${{ steps.version.outputs.tag }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,6 @@ jslib
 src/locales
 src/404/*.min.css
 src/scripts/u2f.js
+
+# Github Workflows
+.github/workflows


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

This adds an input into the release pipeline to define the release.
For an initial release, we need to validate that the version has been bumped.
For a redeploy, we need to skip the version check and the Github release.
This will allow us the ability of redeploying a release by defining logic around the input's value.

I also added the Github actions folder to the `.prettierignore` file as it interferes with the current workflow linter that @bitwarden/dept-devops uses.
## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **release.yml:** Added logic based on the input values of either "Initial Release" or "Redeploy"
- **.prettierignore** Added Github workflows to .ignore for Prettier. 

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
