### PR TITLE
[bug] Add defaults for vault timeout

### DIFF
--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -5,6 +5,7 @@ import { BroadcasterMessagingService } from "../../services/broadcasterMessaging
 import { HtmlStorageService } from "../../services/htmlStorage.service";
 import { I18nService } from "../../services/i18n.service";
 import { MemoryStorageService } from "../../services/memoryStorage.service";
+import { StateService } from "../../services/state.service";
 import { WebPlatformUtilsService } from "../../services/webPlatformUtils.service";
 
 import { EventService } from "./event.service";
@@ -43,6 +44,7 @@ import { MessagingService as MessagingServiceAbstraction } from "jslib-common/ab
 import { NotificationsService as NotificationsServiceAbstraction } from "jslib-common/abstractions/notifications.service";
 import { PlatformUtilsService as PlatformUtilsServiceAbstraction } from "jslib-common/abstractions/platformUtils.service";
 import { StateService as StateServiceAbstraction } from "jslib-common/abstractions/state.service";
+import { StateMigrationService as StateMigrationServiceAbstraction } from "jslib-common/abstractions/stateMigration.service";
 import { StorageService as StorageServiceAbstraction } from "jslib-common/abstractions/storage.service";
 import { VaultTimeoutService as VaultTimeoutServiceAbstraction } from "jslib-common/abstractions/vaultTimeout.service";
 
@@ -170,6 +172,16 @@ export function initFactory(
         PlatformUtilsServiceAbstraction,
         LogService,
         StateServiceAbstraction,
+      ],
+    },
+    {
+      provide: StateServiceAbstraction,
+      useClass: StateService,
+      deps: [
+        StorageServiceAbstraction,
+        "SECURE_STORAGE",
+        LogService,
+        StateMigrationServiceAbstraction,
       ],
     },
   ],

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -1,0 +1,20 @@
+import {
+  Account as BaseAccount,
+  AccountSettings as BaseAccountSettings,
+} from "jslib-common/models/domain/account";
+
+export class AccountSettings extends BaseAccountSettings {
+  vaultTimeout: number = process.env.NODE_ENV === "development" ? null : 15;
+}
+
+export class Account extends BaseAccount {
+  settings?: AccountSettings = new AccountSettings();
+
+  constructor(init: Partial<Account>) {
+    super(init);
+    Object.assign(this.settings, {
+      ...new AccountSettings(),
+      ...this.settings,
+    });
+  }
+}

--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -1,0 +1,13 @@
+import { StateService as BaseStateService } from "jslib-common/services/state.service";
+
+import { Account } from "../models/account";
+
+import { StateService as StateServiceAbstraction } from "jslib-common/abstractions/state.service";
+
+export class StateService extends BaseStateService<Account> implements StateServiceAbstraction {
+  async addAccount(account: Account) {
+    // Apply web overides to default account values
+    account = new Account(account);
+    await super.addAccount(account);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "preserveWhitespaces": true
   },
   "files": ["src/app/polyfills.ts", "src/app/main.ts", "bitwarden_license/src/app/main.ts"],
-  "include": ["src/connectors/*.ts"]
+  "include": ["src/connectors/*.ts", "src/models/*.ts", "src/services/*.ts"]
 }


### PR DESCRIPTION
## Related Work
- [Asana Task](https://app.asana.com/0/inbox/1183359552741416/1201592404236978/1201607436480545)
- https://github.com/bitwarden/jslib/pull/593

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The storage engine refactor created a bug where dropdown setting values are not defaulting appropriately, most noticeable on web where a vault timeout of "never" should only be allowed for dev, but instead was being applied as a default for all environments. This is addressed in two parts: a jslib PR that sets defaults for locale, theme, and timeout action (as those are the same on each client) and a web PR that extends the account model and sets an appropriate default for vault timeout duration based on environment. 

## Code changes
* Extended StateService and the Account model to set a web-appropriate default for vault timeout and added references to this in services.module
* Included new folders in tsconfig

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
