### PR TITLE
Tech Debt: Rename fb to formBuilder

### DIFF
--- a/bitwarden_license/src/app/organizations/manage/sso.component.ts
+++ b/bitwarden_license/src/app/organizations/manage/sso.component.ts
@@ -34,8 +34,8 @@ export class SsoComponent implements OnInit {
   spMetadataUrl: string;
   spAcsUrl: string;
 
-  enabled = this.fb.control(false);
-  data = this.fb.group({
+  enabled = this.formBuilder.control(false);
+  data = this.formBuilder.group({
     configType: [],
 
     keyConnectorEnabled: [],
@@ -76,7 +76,7 @@ export class SsoComponent implements OnInit {
   });
 
   constructor(
-    private fb: FormBuilder,
+    private formBuilder: FormBuilder,
     private route: ActivatedRoute,
     private apiService: ApiService,
     private platformUtilsService: PlatformUtilsService,

--- a/bitwarden_license/src/app/policies/maximum-vault-timeout.component.ts
+++ b/bitwarden_license/src/app/policies/maximum-vault-timeout.component.ts
@@ -24,12 +24,12 @@ export class MaximumVaultTimeoutPolicy extends BasePolicy {
   templateUrl: "maximum-vault-timeout.component.html",
 })
 export class MaximumVaultTimeoutPolicyComponent extends BasePolicyComponent {
-  data = this.fb.group({
+  data = this.formBuilder.group({
     hours: [null],
     minutes: [null],
   });
 
-  constructor(private fb: FormBuilder, private i18nService: I18nService) {
+  constructor(private formBuilder: FormBuilder, private i18nService: I18nService) {
     super();
   }
 

--- a/src/app/organizations/policies/master-password.component.ts
+++ b/src/app/organizations/policies/master-password.component.ts
@@ -20,7 +20,7 @@ export class MasterPasswordPolicy extends BasePolicy {
   templateUrl: "master-password.component.html",
 })
 export class MasterPasswordPolicyComponent extends BasePolicyComponent {
-  data = this.fb.group({
+  data = this.formBuilder.group({
     minComplexity: [null],
     minLength: [null],
     requireUpper: [null],
@@ -33,7 +33,7 @@ export class MasterPasswordPolicyComponent extends BasePolicyComponent {
   showKeyConnectorInfo: boolean = false;
 
   constructor(
-    private fb: FormBuilder,
+    private formBuilder: FormBuilder,
     i18nService: I18nService,
     private organizationService: OrganizationService
   ) {

--- a/src/app/organizations/policies/password-generator.component.ts
+++ b/src/app/organizations/policies/password-generator.component.ts
@@ -19,7 +19,7 @@ export class PasswordGeneratorPolicy extends BasePolicy {
   templateUrl: "password-generator.component.html",
 })
 export class PasswordGeneratorPolicyComponent extends BasePolicyComponent {
-  data = this.fb.group({
+  data = this.formBuilder.group({
     defaultType: [null],
     minLength: [null],
     useUpper: [null],
@@ -35,7 +35,7 @@ export class PasswordGeneratorPolicyComponent extends BasePolicyComponent {
 
   defaultTypes: { name: string; value: string }[];
 
-  constructor(private fb: FormBuilder, i18nService: I18nService) {
+  constructor(private formBuilder: FormBuilder, i18nService: I18nService) {
     super();
 
     this.defaultTypes = [

--- a/src/app/organizations/policies/reset-password.component.ts
+++ b/src/app/organizations/policies/reset-password.component.ts
@@ -24,14 +24,14 @@ export class ResetPasswordPolicy extends BasePolicy {
   templateUrl: "reset-password.component.html",
 })
 export class ResetPasswordPolicyComponent extends BasePolicyComponent {
-  data = this.fb.group({
+  data = this.formBuilder.group({
     autoEnrollEnabled: false,
   });
 
   defaultTypes: { name: string; value: string }[];
   showKeyConnectorInfo: boolean = false;
 
-  constructor(private fb: FormBuilder, private organizationService: OrganizationService) {
+  constructor(private formBuilder: FormBuilder, private organizationService: OrganizationService) {
     super();
   }
 

--- a/src/app/organizations/policies/send-options.component.ts
+++ b/src/app/organizations/policies/send-options.component.ts
@@ -17,11 +17,11 @@ export class SendOptionsPolicy extends BasePolicy {
   templateUrl: "send-options.component.html",
 })
 export class SendOptionsPolicyComponent extends BasePolicyComponent {
-  data = this.fb.group({
+  data = this.formBuilder.group({
     disableHideEmail: false,
   });
 
-  constructor(private fb: FormBuilder) {
+  constructor(private formBuilder: FormBuilder) {
     super();
   }
 }

--- a/src/app/organizations/tools/export.component.ts
+++ b/src/app/organizations/tools/export.component.ts
@@ -28,7 +28,7 @@ export class ExportComponent extends BaseExportComponent {
     policyService: PolicyService,
     logService: LogService,
     userVerificationService: UserVerificationService,
-    fb: FormBuilder
+    formBuilder: FormBuilder
   ) {
     super(
       cryptoService,
@@ -39,7 +39,7 @@ export class ExportComponent extends BaseExportComponent {
       policyService,
       logService,
       userVerificationService,
-      fb
+      formBuilder
     );
   }
 

--- a/src/app/tools/export.component.ts
+++ b/src/app/tools/export.component.ts
@@ -28,7 +28,7 @@ export class ExportComponent extends BaseExportComponent {
     policyService: PolicyService,
     logService: LogService,
     userVerificationService: UserVerificationService,
-    fb: FormBuilder
+    formBuilder: FormBuilder
   ) {
     super(
       cryptoService,
@@ -40,7 +40,7 @@ export class ExportComponent extends BaseExportComponent {
       window,
       logService,
       userVerificationService,
-      fb
+      formBuilder
     );
   }
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Rename all occurrences of fb to formBuilder as it can be confusing.

## Code changes

These were the files that needed to be updated:
- **bitwarden_license/src/app/organizations/manage/sso.component.ts**
- **bitwarden_license/src/app/policies/maximum-vault-timeout.component.ts**
- **src/app/organizations/policies/master-password.component.ts**
- **src/app/organizations/policies/password-generator.component.ts**
- **src/app/organizations/policies/reset-password.component.ts**
- **src/app/organizations/policies/send-options.component.ts**
- **src/app/organizations/tools/export.component.ts**
- **src/app/tools/export.component.ts**


## Testing requirements

No functionality changes, just make sure the forms in organizations -> policies, the organizations export, and vault export forms work as expected.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
