### PR TITLE
Add importing of 1passwords 1pux files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "date-input-polyfill": "^2.14.0",
         "font-awesome": "4.7.0",
         "jquery": "3.6.0",
+        "jszip": "^3.7.1",
         "ngx-infinite-scroll": "^10.0.1",
         "ngx-toastr": "14.1.4",
         "popper.js": "1.16.1",
@@ -3845,6 +3846,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+    },
     "node_modules/immutable": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
@@ -4431,6 +4437,17 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
+      }
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -4447,6 +4464,14 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -5332,6 +5357,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/papaparse": {
       "version": "5.3.1",
@@ -6306,6 +6336,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/setprototypeof": {
@@ -10689,6 +10727,11 @@
       "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
       "dev": true
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+    },
     "immutable": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
@@ -11099,6 +11142,17 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jszip": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
+      }
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -11110,6 +11164,14 @@
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
       "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
       "dev": true
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "requires": {
+        "immediate": "~3.0.5"
+      }
     },
     "lilconfig": {
       "version": "2.0.4",
@@ -11761,6 +11823,11 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
+    },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "papaparse": {
       "version": "5.3.1",
@@ -12499,6 +12566,11 @@
         "parseurl": "~1.3.3",
         "send": "0.17.1"
       }
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "setprototypeof": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "date-input-polyfill": "^2.14.0",
     "font-awesome": "4.7.0",
     "jquery": "3.6.0",
+    "jszip": "^3.7.1",
     "ngx-infinite-scroll": "^10.0.1",
     "ngx-toastr": "14.1.4",
     "popper.js": "1.16.1",

--- a/src/app/tools/import.component.html
+++ b/src/app/tools/import.component.html
@@ -120,7 +120,10 @@
     </ng-container>
     <ng-container
       *ngIf="
-        format === '1password1pif' || format === '1passwordwincsv' || format === '1passwordmaccsv'
+        format === '1password1pux' ||
+        format === '1password1pif' ||
+        format === '1passwordwincsv' ||
+        format === '1passwordmaccsv'
       "
     >
       See detailed instructions on our help site at

--- a/src/app/tools/import.component.ts
+++ b/src/app/tools/import.component.ts
@@ -9,6 +9,8 @@ import { PolicyService } from "jslib-common/abstractions/policy.service";
 
 import { PolicyType } from "jslib-common/enums/policyType";
 
+import * as JSZip from "jszip";
+
 import Swal, { SweetAlertIcon } from "sweetalert2";
 
 @Component({
@@ -183,6 +185,10 @@ export class ImportComponent implements OnInit {
   }
 
   private getFileContents(file: File): Promise<string> {
+    if (this.format === "1password1pux") {
+      return this.extract1PuxContent(file);
+    }
+
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.readAsText(file, "utf-8");
@@ -205,5 +211,21 @@ export class ImportComponent implements OnInit {
         reject();
       };
     });
+  }
+
+  private extract1PuxContent(file: File): Promise<string> {
+    return new JSZip()
+      .loadAsync(file)
+      .then((zip) => {
+        return zip.file("export.data").async("string");
+      })
+      .then(
+        function success(content) {
+          return content;
+        },
+        function error(e) {
+          return "";
+        }
+      );
   }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With 1Password changing their export format from `.1pif` to `.1pux` in recent versions, this adds an importer to import 1pux into Bitwarden.

The 1pux format is essentially a zip archive including multiple files. The initial one of interest is the export.data file which contains the vault data.

Further information about the new 1pux format can be found here: https://support.1password.com/1pux-format/

Depends on https://github.com/bitwarden/jslib/pull/594

Asana task: https://app.asana.com/0/1153292148278596/1201437354678085/f

## Code changes
- **jslib:** Pull in changes made in https://github.com/bitwarden/jslib/pull/594
- **package.json:** Installed `jszip`
- **package-lock.json:** Changes after executing `npm i`
- **src/app/tools/import.component.html:** Display additional instructions and link to help site when selecting 1pux importer
- **src/app/tools/import.component.ts:** Unzip `.1pux` file and pass content of `export.data` to 1pux importer

## Testing requirements
Testing should include importing several `.1pux` exports and should handle all mappings detailed in https://github.com/bitwarden/jslib/pull/594

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
