### PR TITLE
Fix items not opening when they have a password reprompt set

### DIFF
--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -5,6 +5,7 @@ import { BroadcasterMessagingService } from "../../services/broadcasterMessaging
 import { HtmlStorageService } from "../../services/htmlStorage.service";
 import { I18nService } from "../../services/i18n.service";
 import { MemoryStorageService } from "../../services/memoryStorage.service";
+import { PasswordRepromptService } from "../../services/passwordReprompt.service";
 import { StateService } from "../../services/state.service";
 import { WebPlatformUtilsService } from "../../services/webPlatformUtils.service";
 
@@ -42,6 +43,7 @@ import { ImportService as ImportServiceAbstraction } from "jslib-common/abstract
 import { LogService } from "jslib-common/abstractions/log.service";
 import { MessagingService as MessagingServiceAbstraction } from "jslib-common/abstractions/messaging.service";
 import { NotificationsService as NotificationsServiceAbstraction } from "jslib-common/abstractions/notifications.service";
+import { PasswordRepromptService as PasswordRepromptServiceAbstraction } from "jslib-common/abstractions/passwordReprompt.service";
 import { PlatformUtilsService as PlatformUtilsServiceAbstraction } from "jslib-common/abstractions/platformUtils.service";
 import { StateService as StateServiceAbstraction } from "jslib-common/abstractions/state.service";
 import { StateMigrationService as StateMigrationServiceAbstraction } from "jslib-common/abstractions/stateMigration.service";
@@ -183,6 +185,10 @@ export function initFactory(
         LogService,
         StateMigrationServiceAbstraction,
       ],
+    },
+    {
+      provide: PasswordRepromptServiceAbstraction,
+      useClass: PasswordRepromptService,
     },
   ],
 })


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
**Only reproducable on current master**
I noticed that vault items that had a password reprompt set would not open anymore.

Checking the console also reported an error:
```
ERROR Error: ASSERTION ERROR: Type passed in is not ComponentType, it does not have 'ɵcmp' property.
    at throwError (core.umd.js:643:1)
    at assertComponentType (core.umd.js:1586:1)
    at ComponentFactoryResolver.push../node_modules/@angular/core/__ivy_ngcc__/bundles/core.umd.js.ComponentFactoryResolver.resolveComponentFactory (core.umd.js:25705:1)
    at ModalService.resolveComponentFactory (modal.service.ts:88:42)
    at DynamicModalComponent.loadChildComponent (dynamic-modal.component.ts:59:48)
    at DynamicModalComponent.ngAfterViewInit (dynamic-modal.component.ts:43:10)
    at callHook (core.umd.js:2822:1)
    at callHooks (core.umd.js:2791:1)
    at executeInitAndCheckHooks (core.umd.js:2742:1)
    at refreshView (core.umd.js:10050:1)
    at renderComponentOrTemplate (core.umd.js:10093:1)
    at tickRootContext (core.umd.js:11326:1)
    at detectChangesInRootView (core.umd.js:11351:1)
    at RootViewRef.push../node_modules/@angular/core/__ivy_ngcc__/bundles/core.umd.js.RootViewRef.detectChanges (core.umd.js:23470:1)
    at ApplicationRef.push../node_modules/@angular/core/__ivy_ngcc__/bundles/core.umd.js.ApplicationRef.tick (core.umd.js:30415:1)
    at core.umd.js:30270:1
    at ZoneDelegate.invoke (zone.js:400:1)
    at Object.onInvoke (core.umd.js:29384:1)
    at ZoneDelegate.invoke (zone.js:399:1)
    at Zone.run (zone.js:160:1)
    at NgZone.push../node_modules/@angular/core/__ivy_ngcc__/bundles/core.umd.js.NgZone.run (core.umd.js:29237:1)
    at Object.next (core.umd.js:30269:1)
    at Object.next (Subscriber.js:123:1)
    at SafeSubscriber.Subscriber._next (Subscriber.js:63:1)
    at SafeSubscriber.Subscriber.next (Subscriber.js:34:1)
    at Subject.js:38:1
    at errorContext (errorContext.js:19:1)
    at EventEmitter_.Subject.next (Subject.js:30:21)
    at EventEmitter_.push../node_modules/@angular/core/__ivy_ngcc__/bundles/core.umd.js.EventEmitter_.emit (core.umd.js:26648:1)
    at checkStable (core.umd.js:29306:1)
    at Object.onHasTask (core.umd.js:29401:1)
    at ZoneDelegate.hasTask (zone.js:454:1)
    at ZoneDelegate._updateTaskCount (zone.js:475:1)
    at Zone._updateTaskCount (zone.js:301:1)
    at Zone.runTask (zone.js:222:1)
    at drainMicroTaskQueue (zone.js:620:1)
    at ZoneTask.invokeTask [as invoke] (zone.js:520:1)
    at invokeTask (zone.js:1656:1)
    at HTMLAnchorElement.globalZoneAwareCallback (zone.js:1682:1)
```
## Code changes
- **src/app/services/services.module.ts:** Add registration of local PasswordRepromptService as it has a override for the PasswordRepromptComponent

## Testing requirements
Items with or without a password reprompt should be opened to view/edit

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
