### PR TITLE
Add Inputmode for tel and email (identities)

### DIFF
--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -587,6 +587,7 @@
                 id="idEmail"
                 class="form-control"
                 type="text"
+                inputmode="email"
                 name="Identity.Email"
                 [(ngModel)]="cipher.identity.email"
                 appInputVerbatim
@@ -599,6 +600,7 @@
                 id="idPhone"
                 class="form-control"
                 type="text"
+                inputmode="tel"
                 name="Identity.Phone"
                 [(ngModel)]="cipher.identity.phone"
                 [disabled]="cipher.isDeleted || viewOnly"


### PR DESCRIPTION
helps improve the UX for users with virtual keyboards (mobile devices and tablets

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Helps improve the UX for users with virtual keyboards (mobile devices and tablets).

## Code changes

This PR supercedes: bitwarden#661

I wrote about inputmode for CSS Tricks:
https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode/#aa-tel
https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode/#aa-email

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
