### PR TITLE
More explicit warning about "Don't ask again" for fingerprint

### DIFF
--- a/src/locales/nn/messages.json
+++ b/src/locales/nn/messages.json
@@ -3164,7 +3164,7 @@
     "description": "A 'fingerprint phrase' is a unique word phrase (similar to a passphrase) that a user can use to authenticate their public key with another user, for the purposes of sharing."
   },
   "dontAskFingerprintAgain": {
-    "message": "Don't ask to verify fingerprint phrase again",
+    "message": "Don't reveal fingerprints for any users and don't ask to verify fingerprint phrase",
     "description": "A 'fingerprint phrase' is a unique word phrase (similar to a passphrase) that a user can use to authenticate their public key with another user, for the purposes of sharing."
   },
   "free": {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other [Improve UX and security]

## Objective

Warn users that they won't be able to undo this checkbox that creates a significant security vulnerability: https://community.bitwarden.com/t/let-admins-disable-the-dont-ask-to-verify-fingerprint-phrases-again-option/11731

## Code changes

Only change is to one string in the nn lang. Happy to change additional strings if this wording is acceptable to the BitWarden team. 

- **src/locales/nn/messages.json:** Expanded this text "Don't ask to verify fingerprint phrase again" to explicitly warn the user that this applies to all users in the organization and cannot be undone.

## Testing requirements

Invite user to join an organization.
User creates account
Admin clicks "confirm" on that user
Verify that text displayed is appropriate for the checkbox "Don't ask me again"

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
