### PR TITLE
Fix webpack assets using wrong name

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,7 @@ const moduleRules = [
     test: /.(ttf|otf|eot|svg|woff(2)?)(\?[a-z0-9]+)?$/,
     exclude: /loading(|-white).svg/,
     generator: {
-      filename: "fonts/[name].[ext]",
+      filename: "fonts/[name][ext]",
     },
     type: "asset/resource",
   },
@@ -39,7 +39,7 @@ const moduleRules = [
     test: /\.(jpe?g|png|gif|svg|webp|avif)$/i,
     exclude: /.*(fontawesome-webfont)\.svg/,
     generator: {
-      filename: "images/[name].[ext]",
+      filename: "images/[name][ext]",
     },
     type: "asset/resource",
   },


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

In Webpack 5, `[ext]` contains the `.` character, and should therefore be omitted.

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
