### PR TITLE
[Hotfix] Uri url updates

### DIFF
--- a/bitwarden_license/src/app/organizations/manage/sso.component.html
+++ b/bitwarden_license/src/app/organizations/manage/sso.component.html
@@ -67,7 +67,7 @@
           target="_blank"
           rel="noopener"
           appA11yTitle="{{ 'learnMore' | i18n }}"
-          href="https://bitwarden.com/help/article/about-key-connector/"
+          href="https://bitwarden.com/help/about-key-connector/"
         >
           <i class="fa fa-question-circle-o" aria-hidden="true"></i>
         </a>

--- a/bitwarden_license/src/app/providers/manage/user-add-edit.component.html
+++ b/bitwarden_license/src/app/providers/manage/user-add-edit.component.html
@@ -52,7 +52,7 @@
             target="_blank"
             rel="noopener"
             appA11yTitle="{{ 'learnMore' | i18n }}"
-            href="https://bitwarden.com/help/article/user-types-access-control/#user-types"
+            href="https://bitwarden.com/help/user-types-access-control/#user-types"
           >
             <i class="fa fa-question-circle-o" aria-hidden="true"></i>
           </a>

--- a/src/app/accounts/recover-two-factor.component.html
+++ b/src/app/accounts/recover-two-factor.component.html
@@ -7,7 +7,7 @@
           <p>
             {{ "recoverAccountTwoStepDesc" | i18n }}
             <a
-              href="https://help.bitwarden.com/article/lost-two-step-device/"
+              href="https://bitwarden.com/help/lost-two-step-device/"
               target="_blank"
               rel="noopener"
               >{{ "learnMore" | i18n }}</a

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -153,7 +153,7 @@ export class AppComponent implements OnDestroy, OnInit {
             );
             if (emailVerificationConfirmed) {
               this.platformUtilsService.launchUri(
-                "https://bitwarden.com/help/article/create-bitwarden-account/"
+                "https://bitwarden.com/help/create-bitwarden-account/"
               );
             }
             break;

--- a/src/app/organizations/manage/bulk/bulk-confirm.component.html
+++ b/src/app/organizations/manage/bulk/bulk-confirm.component.html
@@ -29,7 +29,7 @@
           <p>
             {{ "fingerprintEnsureIntegrityVerify" | i18n }}
             <a
-              href="https://help.bitwarden.com/article/fingerprint-phrase/"
+              href="https://bitwarden.com/help/fingerprint-phrase/"
               target="_blank"
               rel="noopener"
             >

--- a/src/app/organizations/manage/group-add-edit.component.html
+++ b/src/app/organizations/manage/group-add-edit.component.html
@@ -56,7 +56,7 @@
               target="_blank"
               rel="noopener"
               appA11yTitle="{{ 'learnMore' | i18n }}"
-              href="https://bitwarden.com/help/article/user-types-access-control/#access-control"
+              href="https://bitwarden.com/help/user-types-access-control/#access-control"
             >
               <i class="fa fa-question-circle-o" aria-hidden="true"></i>
             </a>

--- a/src/app/organizations/manage/user-add-edit.component.html
+++ b/src/app/organizations/manage/user-add-edit.component.html
@@ -52,7 +52,7 @@
             target="_blank"
             rel="noopener"
             appA11yTitle="{{ 'learnMore' | i18n }}"
-            href="https://bitwarden.com/help/article/user-types-access-control/#user-types"
+            href="https://bitwarden.com/help/user-types-access-control/#user-types"
           >
             <i class="fa fa-question-circle-o" aria-hidden="true"></i>
           </a>
@@ -277,7 +277,7 @@
               target="_blank"
               rel="noopener"
               appA11yTitle="{{ 'learnMore' | i18n }}"
-              href="https://bitwarden.com/help/article/user-types-access-control/#access-control"
+              href="https://bitwarden.com/help/user-types-access-control/#access-control"
             >
               <i class="fa fa-question-circle-o" aria-hidden="true"></i>
             </a>

--- a/src/app/organizations/manage/user-confirm.component.html
+++ b/src/app/organizations/manage/user-confirm.component.html
@@ -19,7 +19,7 @@
         <p>
           {{ "fingerprintEnsureIntegrityVerify" | i18n }}
           <a
-            href="https://help.bitwarden.com/article/fingerprint-phrase/"
+            href="https://bitwarden.com/help/fingerprint-phrase/"
             target="_blank"
             rel="noopener"
           >

--- a/src/app/organizations/settings/download-license.component.html
+++ b/src/app/organizations/settings/download-license.component.html
@@ -13,7 +13,7 @@
             target="_blank"
             rel="noopener"
             appA11yTitle="{{ 'learnMore' | i18n }}"
-            href="https://help.bitwarden.com/article/licensing-on-premise/#organization-account-sharing"
+            href="https://bitwarden.com/help/licensing-on-premise/#organization-account-sharing"
           >
             <i class="fa fa-question-circle-o" aria-hidden="true"></i>
           </a>

--- a/src/app/send/access.component.html
+++ b/src/app/send/access.component.html
@@ -9,7 +9,7 @@
     <div class="col-8" *ngIf="hideEmail">
       <app-callout type="warning" title="{{ 'warning' | i18n }}">
         {{ "viewSendHiddenEmailWarning" | i18n }}
-        <a href="https://bitwarden.com/help/article/receive-send/" target="_blank">{{
+        <a href="https://bitwarden.com/help/receive-send/" target="_blank">{{
           "learnMore" | i18n
         }}</a
         >.

--- a/src/app/settings/change-kdf.component.html
+++ b/src/app/settings/change-kdf.component.html
@@ -39,7 +39,7 @@
         <label for="kdfIterations">{{ "kdfIterations" | i18n }}</label>
         <a
           class="ml-auto"
-          href="https://bitwarden.com/help/article/what-encryption-is-used/#pbkdf2"
+          href="https://bitwarden.com/help/what-encryption-is-used/#pbkdf2"
           target="_blank"
           rel="noopener"
           appA11yTitle="{{ 'learnMore' | i18n }}"

--- a/src/app/settings/change-password.component.html
+++ b/src/app/settings/change-password.component.html
@@ -74,7 +74,7 @@
         {{ "rotateAccountEncKey" | i18n }}
       </label>
       <a
-        href="https://bitwarden.com/help/article/account-encryption-key/#rotate-your-encryption-key"
+        href="https://bitwarden.com/help/account-encryption-key/#rotate-your-encryption-key"
         target="_blank"
         rel="noopener"
         appA11yTitle="{{ 'learnMore' | i18n }}"

--- a/src/app/settings/change-password.component.ts
+++ b/src/app/settings/change-password.component.ts
@@ -87,7 +87,7 @@ export class ChangePasswordComponent extends BaseChangePasswordComponent {
         );
         if (learnMore) {
           this.platformUtilsService.launchUri(
-            "https://help.bitwarden.com/article/attachments/#fixing-old-attachments"
+            "https://bitwarden.com/help/attachments/#fixing-old-attachments"
           );
         }
         this.rotateEncKey = false;

--- a/src/app/settings/emergency-access-add-edit.component.html
+++ b/src/app/settings/emergency-access-add-edit.component.html
@@ -51,7 +51,7 @@
             target="_blank"
             rel="noopener"
             appA11yTitle="{{ 'learnMore' | i18n }}"
-            href="https://bitwarden.com/help/article/emergency-access/#user-access"
+            href="https://bitwarden.com/help/emergency-access/#user-access"
           >
             <i class="fa fa-question-circle-o" aria-hidden="true"></i>
           </a>

--- a/src/app/settings/emergency-access-confirm.component.html
+++ b/src/app/settings/emergency-access-confirm.component.html
@@ -19,7 +19,7 @@
         <p>
           {{ "fingerprintEnsureIntegrityVerify" | i18n }}
           <a
-            href="https://help.bitwarden.com/article/fingerprint-phrase/"
+            href="https://bitwarden.com/help/fingerprint-phrase/"
             target="_blank"
             rel="noopener"
           >

--- a/src/app/settings/emergency-access.component.html
+++ b/src/app/settings/emergency-access.component.html
@@ -3,7 +3,7 @@
 </div>
 <p>
   {{ "emergencyAccessDesc" | i18n }}
-  <a href="https://bitwarden.com/help/article/emergency-access/" target="_blank" rel="noopener">
+  <a href="https://bitwarden.com/help/emergency-access/" target="_blank" rel="noopener">
     {{ "learnMore" | i18n }}.
   </a>
 </p>

--- a/src/app/settings/options.component.html
+++ b/src/app/settings/options.component.html
@@ -52,7 +52,7 @@
           <label for="locale">{{ "language" | i18n }}</label>
           <a
             class="ml-auto"
-            href="https://help.bitwarden.com/article/localization/"
+            href="https://bitwarden.com/help/localization/"
             target="_blank"
             rel="noopener"
             appA11yTitle="{{ 'learnMore' | i18n }}"
@@ -80,7 +80,7 @@
         {{ "disableIcons" | i18n }}
       </label>
       <a
-        href="https://help.bitwarden.com/article/website-icons/"
+        href="https://bitwarden.com/help/website-icons/"
         target="_blank"
         rel="noopener"
         appA11yTitle="{{ 'learnMore' | i18n }}"

--- a/src/app/settings/profile.component.html
+++ b/src/app/settings/profile.component.html
@@ -51,7 +51,7 @@
       <p *ngIf="fingerprint">
         {{ "yourAccountsFingerprint" | i18n }}:
         <a
-          href="https://help.bitwarden.com/article/fingerprint-phrase/"
+          href="https://bitwarden.com/help/fingerprint-phrase/"
           target="_blank"
           rel="noopener"
           appA11yTitle="{{ 'learnMore' | i18n }}"

--- a/src/app/settings/update-key.component.html
+++ b/src/app/settings/update-key.component.html
@@ -22,7 +22,7 @@
         <p>
           {{ "updateEncryptionKeyShortDesc" | i18n }} {{ "updateEncryptionKeyDesc" | i18n }}
           <a
-            href="https://help.bitwarden.com/article/update-encryption-key/"
+            href="https://bitwarden.com/help/account-encryption-key/#rotate-your-encryption-key"
             target="_blank"
             rel="noopener"
             >{{ "learnMore" | i18n }}</a

--- a/src/app/tools/import.component.html
+++ b/src/app/tools/import.component.html
@@ -103,9 +103,9 @@
       <a
         target="_blank"
         rel="noopener"
-        href="https://bitwarden.com/help/article/import-from-firefox/"
+        href="https://bitwarden.com/help/import-from-firefox/"
       >
-        https://bitwarden.com/help/article/import-from-firefox/</a
+        https://bitwarden.com/help/import-from-firefox/</a
       >.
     </ng-container>
     <ng-container *ngIf="format === 'safaricsv'">
@@ -113,9 +113,9 @@
       <a
         target="_blank"
         rel="noopener"
-        href="https://bitwarden.com/help/article/import-from-safari/"
+        href="https://bitwarden.com/help/import-from-safari/"
       >
-        https://bitwarden.com/help/article/import-from-safari/</a
+        https://bitwarden.com/help/import-from-safari/</a
       >.
     </ng-container>
     <ng-container

--- a/src/app/tools/import.component.html
+++ b/src/app/tools/import.component.html
@@ -29,8 +29,8 @@
   <app-callout type="info" title="{{ getFormatInstructionTitle() }}" *ngIf="format">
     <ng-container *ngIf="format === 'bitwardencsv' || format === 'bitwardenjson'">
       See detailed instructions on our help site at
-      <a target="_blank" rel="noopener" href="https://help.bitwarden.com/article/export-your-data/">
-        https://help.bitwarden.com/article/export-your-data/</a
+      <a target="_blank" rel="noopener" href="https://bitwarden.com/help/export-your-data/">
+        https://bitwarden.com/help/export-your-data/</a
       >
     </ng-container>
     <ng-container *ngIf="format === 'lastpasscsv'">
@@ -38,9 +38,9 @@
       <a
         target="_blank"
         rel="noopener"
-        href="https://help.bitwarden.com/article/import-from-lastpass/"
+        href="https://bitwarden.com/help/import-from-lastpass/"
       >
-        https://help.bitwarden.com/article/import-from-lastpass/</a
+        https://bitwarden.com/help/import-from-lastpass/</a
       >
     </ng-container>
     <ng-container *ngIf="format === 'keepassxcsv'">
@@ -93,9 +93,9 @@
       <a
         target="_blank"
         rel="noopener"
-        href="https://help.bitwarden.com/article/import-from-chrome/"
+        href="https://bitwarden.com/help/import-from-chrome/"
       >
-        https://help.bitwarden.com/article/import-from-chrome/</a
+        https://bitwarden.com/help/import-from-chrome/</a
       >
     </ng-container>
     <ng-container *ngIf="format === 'firefoxcsv'">
@@ -127,9 +127,9 @@
       <a
         target="_blank"
         rel="noopener"
-        href="https://help.bitwarden.com/article/import-from-1password/"
+        href="https://bitwarden.com/help/import-from-1password/"
       >
-        https://help.bitwarden.com/article/import-from-1password/</a
+        https://bitwarden.com/help/import-from-1password/</a
       >.
     </ng-container>
     <ng-container *ngIf="format === 'passworddragonxml'">

--- a/src/app/vault/add-edit-custom-fields.component.html
+++ b/src/app/vault/add-edit-custom-fields.component.html
@@ -11,7 +11,7 @@
           <label for="fieldName{{ i }}">{{ "name" | i18n }}</label>
           <a
             class="ml-auto"
-            href="https://help.bitwarden.com/article/custom-fields/"
+            href="https://bitwarden.com/help/custom-fields/"
             target="_blank"
             rel="noopener"
             appA11yTitle="{{ 'learnMore' | i18n }}"

--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -790,7 +790,7 @@
               target="_blank"
               rel="noopener"
               appA11yTitle="{{ 'learnMore' | i18n }}"
-              href="https://bitwarden.com/help/article/managing-items/#protect-individual-items"
+              href="https://bitwarden.com/help/managing-items/#protect-individual-items"
             >
               <i class="fa fa-question-circle-o" aria-hidden="true"></i>
             </a>

--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -288,7 +288,7 @@
                   </label>
                   <a
                     class="ml-auto"
-                    href="https://help.bitwarden.com/article/uri-match-detection/"
+                    href="https://bitwarden.com/help/uri-match-detection/"
                     target="_blank"
                     rel="noopener"
                     appA11yTitle="{{ 'learnMore' | i18n }}"

--- a/src/app/vault/attachments.component.html
+++ b/src/app/vault/attachments.component.html
@@ -38,7 +38,7 @@
                   <a href="#" appStopClick (click)="download(a)">{{ a.fileName }}</a>
                   <div *ngIf="showFixOldAttachments(a)" class="ml-2">
                     <a
-                      href="https://help.bitwarden.com/article/attachments/#fixing-old-attachments"
+                      href="https://bitwarden.com/help/attachments/#fixing-old-attachments"
                       target="_blank"
                       rel="noopener"
                     >

--- a/src/app/vault/groupings.component.html
+++ b/src/app/vault/groupings.component.html
@@ -3,7 +3,7 @@
     {{ "filters" | i18n }}
     <a
       class="ml-auto"
-      href="https://help.bitwarden.com/article/searching-vault/"
+      href="https://bitwarden.com/help/searching-vault/"
       target="_blank"
       rel="noopener"
       appA11yTitle="{{ 'learnMore' | i18n }}"

--- a/src/app/vault/vault.component.html
+++ b/src/app/vault/vault.component.html
@@ -128,7 +128,7 @@
           {{ "providers" | i18n }}
           <a
             class="ml-auto"
-            href="https://bitwarden.com/help/article/about-providers/"
+            href="https://bitwarden.com/help/providers/"
             target="_blank"
             rel="noopener"
             appA11yTitle="{{ 'learnMore' | i18n }}"

--- a/src/app/vault/vault.component.html
+++ b/src/app/vault/vault.component.html
@@ -100,7 +100,7 @@
           {{ "organizations" | i18n }}
           <a
             class="ml-auto"
-            href="https://help.bitwarden.com/article/what-is-an-organization/"
+            href="https://bitwarden.com/help/about-organizations/"
             target="_blank"
             rel="noopener"
             appA11yTitle="{{ 'learnMore' | i18n }}"


### PR DESCRIPTION
help.bitwarden.com/article/ -> bitwarden.com/help/

## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective

Fixing all old help site links.

Old structure:
help.bitwarden.com/article/article-name/

New structure:
bitwarden.com/help/article-name

## Code changes

Just link updates

## Testing requirements

Confirm links in the vault have been updated correctly

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
