### PR TITLE
Fixed white dropdowns in darkmode (#1338)

### DIFF
--- a/src/scss/forms.scss
+++ b/src/scss/forms.scss
@@ -77,7 +77,11 @@ label.form-check-label,
   @include themify($themes) {
     background-color: themed("inputBackgroundColor");
     border-color: themed("inputBorderColor");
-    color: themed("inputTextColor");
+    color: themed('inputTextColor');  
+    
+    option {
+        background-color: themed('backgroundColor');
+    }
   }
 
   &:disabled,


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Changed the white dropdown with white text to a dark background


## Code changes

- ``forms.scss``
     changed background color for dropdown menus


## Screenshots
![image](https://user-images.githubusercontent.com/65036298/150981924-ec1e501b-7254-4190-862d-637ee2e5a9ac.png)

## Testing requirements
Logging in to your web vault and enable dark mode.
Open a dropdown menu

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
