### PR TITLE
Fix various bugs in Options page

### DIFF
--- a/src/app/settings/options.component.ts
+++ b/src/app/settings/options.component.ts
@@ -74,8 +74,12 @@ export class OptionsComponent implements OnInit {
     this.disableIcons = await this.stateService.getDisableFavicon();
     this.enableGravatars = await this.stateService.getEnableGravitars();
     this.enableFullWidth = await this.stateService.getEnableFullWidth();
-    this.locale = (await this.stateService.getLocale()) ?? this.startingLocale;
-    this.theme = (await this.stateService.getTheme()) ?? this.startingTheme;
+
+    this.locale = await this.stateService.getLocale();
+    this.startingLocale = this.locale;
+
+    this.theme = await this.stateService.getTheme();
+    this.startingTheme = this.theme;
   }
 
   async submit() {

--- a/src/app/settings/options.component.ts
+++ b/src/app/settings/options.component.ts
@@ -104,10 +104,7 @@ export class OptionsComponent implements OnInit {
     if (this.locale !== this.startingLocale) {
       window.location.reload();
     } else {
-      this.platformUtilsService.showToast("success", null, [
-        this.i18nService.t("optionsUpdated"),
-        this.i18nService.t("optionsUpdated"),
-      ]);
+      this.platformUtilsService.showToast("success", null, this.i18nService.t("optionsUpdated"));
     }
   }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

1. When saving on the options page, the confirmation toast has duplicate text in it. It says 'Options updated.' twice within the same toast.
2. In Firefox, the locale dropdown would not have a default setting. In Chrome, the page would always refresh (and then lock the vault) when saving.


## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **src/app/settings/options.component.ts** 
  -  remove duplicate text
  - set the `startingLocale` and `startingTheme` properties properly. These should be set to the same value as `locale` and `theme`, but [this change](https://github.com/bitwarden/web/commit/17ae5ee57c4ecd1ae59b9519b5727bb2546061cb#diff-4c73005a246b799eef390729c9ec4364f3e45723c1bc351a511235caae689ee3R80) replaced the multiple left-hand assignment with null coalescing, which changed the behaviour. However, I think this illustrates that multiple left-hand assignment can be confusing and is best avoided.


## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
