### PR TITLE
[bug] Extend GlobalState to supply correct default theme

### DIFF
--- a/src/app/services/services.module.ts
+++ b/src/app/services/services.module.ts
@@ -24,6 +24,7 @@ import { ContainerService } from "jslib-common/services/container.service";
 import { CryptoService } from "jslib-common/services/crypto.service";
 import { EventService as EventLoggingService } from "jslib-common/services/event.service";
 import { ImportService } from "jslib-common/services/import.service";
+import { StateMigrationService } from "jslib-common/services/stateMigration.service";
 import { VaultTimeoutService } from "jslib-common/services/vaultTimeout.service";
 
 import { ApiService as ApiServiceAbstraction } from "jslib-common/abstractions/api.service";
@@ -52,13 +53,14 @@ import { VaultTimeoutService as VaultTimeoutServiceAbstraction } from "jslib-com
 
 import { ThemeType } from "jslib-common/enums/themeType";
 
-import { AccountFactory } from "jslib-common/models/domain/account";
-
 import { Account } from "../../models/account";
+import { GlobalState } from "../../models/globalState";
+
+import { GlobalStateFactory } from "jslib-common/factories/globalStateFactory";
+import { StateFactory } from "jslib-common/factories/stateFactory";
 
 export function initFactory(
   window: Window,
-  storageService: StorageServiceAbstraction,
   environmentService: EnvironmentServiceAbstraction,
   notificationsService: NotificationsServiceAbstraction,
   vaultTimeoutService: VaultTimeoutService,
@@ -70,7 +72,6 @@ export function initFactory(
   cryptoService: CryptoServiceAbstraction
 ): Function {
   return async () => {
-    await (storageService as HtmlStorageService).init();
     await stateService.init();
 
     const urls = process.env.URLS as Urls;
@@ -110,7 +111,6 @@ export function initFactory(
       useFactory: initFactory,
       deps: [
         "WINDOW",
-        StorageServiceAbstraction,
         EnvironmentServiceAbstraction,
         NotificationsServiceAbstraction,
         VaultTimeoutServiceAbstraction,
@@ -181,6 +181,19 @@ export function initFactory(
       ],
     },
     {
+      provide: StateMigrationServiceAbstraction,
+      useFactory: (
+        storageService: StorageServiceAbstraction,
+        secureStorageService: StorageServiceAbstraction
+      ) =>
+        new StateMigrationService(
+          storageService,
+          secureStorageService,
+          new GlobalStateFactory(GlobalState)
+        ),
+      deps: [StorageServiceAbstraction, "SECURE_STORAGE"],
+    },
+    {
       provide: StateServiceAbstraction,
       useFactory: (
         storageService: StorageServiceAbstraction,
@@ -193,7 +206,7 @@ export function initFactory(
           secureStorageService,
           logService,
           stateMigrationService,
-          new AccountFactory(Account)
+          new StateFactory(GlobalState, Account)
         ),
       deps: [
         StorageServiceAbstraction,

--- a/src/models/globalState.ts
+++ b/src/models/globalState.ts
@@ -1,0 +1,7 @@
+import { ThemeType } from "jslib-common/enums/themeType";
+
+import { GlobalState as BaseGlobalState } from "jslib-common/models/domain/globalState";
+
+export class GlobalState extends BaseGlobalState {
+  theme?: ThemeType = ThemeType.Light;
+}

--- a/src/services/htmlStorage.service.ts
+++ b/src/services/htmlStorage.service.ts
@@ -4,24 +4,12 @@ import { StorageService } from "jslib-common/abstractions/storage.service";
 
 import { HtmlStorageLocation } from "jslib-common/enums/htmlStorageLocation";
 
-import { GlobalState } from "jslib-common/models/domain/globalState";
-import { State } from "jslib-common/models/domain/state";
 import { StorageOptions } from "jslib-common/models/domain/storageOptions";
 
 @Injectable()
 export class HtmlStorageService implements StorageService {
   get defaultOptions(): StorageOptions {
     return { htmlStorageLocation: HtmlStorageLocation.Session };
-  }
-
-  async init() {
-    const state =
-      (await this.get<State>("state", { htmlStorageLocation: HtmlStorageLocation.Local })) ??
-      new State();
-    state.globals = state.globals ?? new GlobalState();
-    state.globals.vaultTimeout = state.globals.vaultTimeout ?? 15;
-    state.globals.vaultTimeoutAction = state.globals.vaultTimeoutAction ?? "lock";
-    await this.save("state", state, { htmlStorageLocation: HtmlStorageLocation.Local });
   }
 
   get<T>(key: string, options: StorageOptions = this.defaultOptions): Promise<T> {


### PR DESCRIPTION
https://app.asana.com/0/1201648796371593/1201735234799074

Depends on https://github.com/bitwarden/jslib/pull/646

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The default theme for most clients is System, but web uses Light.
We need to extend GlobalState in web to reflect this.

## Code changes
* Extend the GlobalState object and correct services.modules to use the right one for StateService
* Remove the init function from htmlStorageService, it isn't even using the correct data structure and hasn't been doing anything. I think this was dead code even when it was converted to use StateService.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
