### PR TITLE
Fix captcha and webauthn-fallback not using theme_light

### DIFF
--- a/src/connectors/captcha-mobile.html
+++ b/src/connectors/captcha-mobile.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="theme_light">
   <head>
     <meta charset="utf-8" />
     <meta

--- a/src/connectors/webauthn-fallback.html
+++ b/src/connectors/webauthn-fallback.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="theme_light">
   <head>
     <meta charset="utf-8" />
     <title>Bitwarden WebAuthn Connector</title>


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The Captcha and WebAuthn fallback connectors did not use `theme_light` which made them look off if the OS was configured to use dark mode.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

Before:
![image](https://user-images.githubusercontent.com/137855/151943546-898eac7a-bf45-4383-b0e4-eb216eab6f62.png)
![image](https://user-images.githubusercontent.com/137855/151943560-08e0945b-3d3c-4309-8937-ce201adcedb1.png)
After:
![image](https://user-images.githubusercontent.com/137855/151943621-11955dba-e300-41a5-ab25-2328886ab4af.png)
![image](https://user-images.githubusercontent.com/137855/151943604-4286ba6e-faa4-41ba-a380-a5fcd28fe67a.png)

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
