### PR TITLE
[Icons] Fix button icon/text margins

### DIFF
--- a/src/app/organizations/vault/vault.component.html
+++ b/src/app/organizations/vault/vault.component.html
@@ -37,7 +37,7 @@
           </app-vault-bulk-actions>
           <button
             type="button"
-            class="btn btn-outline-primary btn-sm ml-3"
+            class="btn btn-outline-primary btn-sm ml-auto"
             (click)="addCipher()"
             *ngIf="!deleted"
           >

--- a/src/app/send/send.component.html
+++ b/src/app/send/send.component.html
@@ -60,7 +60,7 @@
         <div class="ml-auto d-flex">
           <button
             type="button"
-            class="btn btn-outline-primary btn-sm ml-3"
+            class="btn btn-outline-primary btn-sm"
             (click)="addSend()"
             [disabled]="disableSend"
           >
@@ -177,7 +177,7 @@
         </ng-container>
         <ng-container *ngIf="loaded">
           <p>{{ "noSendsInList" | i18n }}</p>
-          <button (click)="addSend()" class="btn btn-outline-primary ml-3" [disabled]="disableSend">
+          <button (click)="addSend()" class="btn btn-outline-primary" [disabled]="disableSend">
             <i class="bwi bwi-plus bwi-fw"></i>{{ "createSend" | i18n }}
           </button>
         </ng-container>

--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -184,7 +184,7 @@
     </ng-container>
     <ng-container *ngIf="loaded">
       <p>{{ "noItemsInList" | i18n }}</p>
-      <button (click)="addCipher()" class="btn btn-outline-primary ml-3" *ngIf="showAddNew">
+      <button (click)="addCipher()" class="btn btn-outline-primary" *ngIf="showAddNew">
         <i class="bwi bwi-plus bwi-fw"></i>{{ "addItem" | i18n }}
       </button>
     </ng-container>

--- a/src/app/vault/vault.component.html
+++ b/src/app/vault/vault.component.html
@@ -34,7 +34,7 @@
           </app-vault-bulk-actions>
           <button
             type="button"
-            class="btn btn-outline-primary btn-sm ml-3"
+            class="btn btn-outline-primary btn-sm"
             (click)="addCipher()"
             *ngIf="!deleted"
           >

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -292,3 +292,7 @@ code {
     color: themed("textMuted") !important;
   }
 }
+
+button i.bwi {
+  margin-right: 0.25rem;
+}


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Revert previous margin updates for the buttons within the components below. Add base style class to add margin between icon and text on the button. Merge to `master` and `rc` branches.

## Code changes
- **organizations/vault.component.html**: Reverted exterior margin change
- **send.component.html**: Reverted exterior margin change
- **ciphers.component.html**: Reverted exterior margin change
- **vault.component.html**: Reverted exterior margin change
- **base.scss**: Add rule for buttons with an icon to add a little right margin to properly space the icon/text

## Screenshots
![Screen Shot 2022-02-04 at 11 12 47 AM](https://user-images.githubusercontent.com/26154748/152578974-32701c6a-72e1-4ccb-a55c-f0cd5c3f02b9.png)
![Screen Shot 2022-02-04 at 11 12 59 AM](https://user-images.githubusercontent.com/26154748/152578977-8981daec-50b6-4a45-87f1-70b5fa44e9f7.png)

## Testing requirements

- Ensure button spacing looks better than it did before

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
