### PR TITLE
Exclude jslib from prettier hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "npm": "~8"
   },
   "lint-staged": {
-    "*": "prettier --ignore-unknown --write",
+    "!(./jslib/**)*": "prettier --ignore-unknown --write",
     "*.png": "node scripts/optimize.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "npm": "~8"
   },
   "lint-staged": {
-    "!(./jslib/**)*": "prettier --ignore-unknown --write",
+    "!(./jslib)*": "prettier --ignore-unknown --write",
     "*.png": "node scripts/optimize.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "npm": "~8"
   },
   "lint-staged": {
-    "!(./jslib)*": "prettier --ignore-unknown --write",
+    "./!(jslib)**": "prettier --ignore-unknown --write",
     "*.png": "node scripts/optimize.js"
   }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Workaround for the following error caused by our precommit hooks (reported in https://github.com/okonet/lint-staged/issues/929). This occurs when updating jslib without making any other changes:

```terminal
git commit -m 'Update jslib'
✖ Preparing...
✔ Hiding unstaged changes to partially staged files...
↓ Skipped because of previous git error. [SKIPPED]
↓
  ✖ lint-staged failed due to a git error. [SKIPPED]
↓
  ✖ lint-staged failed due to a git error. [SKIPPED]
↓
  ✖ lint-staged failed due to a git error. [SKIPPED]

  ✖ lint-staged failed due to a git error.
  Any lost modifications can be restored from a git stash:

    > git stash list
    stash@{0}: automatic lint-staged backup
    > git stash apply --index stash@{0}

husky - pre-commit hook exited with code 1 (error)
```

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Exclude jslib from the prettier precommit hook.

Once merged, I'll submit identical PRs for the other TS clients.

Reference: https://github.com/okonet/lint-staged#filtering-files
## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
