### PR TITLE
[bug] Store vault data in memory

### DIFF
--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -7,6 +7,11 @@ import { StateService as StateServiceAbstraction } from "../abstractions/state.s
 
 import { StorageOptions } from "jslib-common/models/domain/storageOptions";
 
+import { CipherData } from "jslib-common/models/data/cipherData";
+import { CollectionData } from "jslib-common/models/data/collectionData";
+import { FolderData } from "jslib-common/models/data/folderData";
+import { SendData } from "jslib-common/models/data/sendData";
+
 export class StateService
   extends BaseStateService<GlobalState, Account>
   implements StateServiceAbstraction
@@ -32,5 +37,59 @@ export class StateService
       globals,
       this.reconcileOptions(options, await this.defaultOnDiskLocalOptions())
     );
+  }
+
+  async getEncryptedCiphers(options?: StorageOptions): Promise<{ [id: string]: CipherData }> {
+    options = this.reconcileOptions(options, this.defaultInMemoryOptions);
+    return await super.getEncryptedCiphers(options);
+  }
+
+  async setEncryptedCiphers(
+    value: { [id: string]: CipherData },
+    options?: StorageOptions
+  ): Promise<void> {
+    options = this.reconcileOptions(options, this.defaultInMemoryOptions);
+    return await super.setEncryptedCiphers(value, options);
+  }
+
+  async getEncryptedCollections(
+    options?: StorageOptions
+  ): Promise<{ [id: string]: CollectionData }> {
+    options = this.reconcileOptions(options, this.defaultInMemoryOptions);
+    return await super.getEncryptedCollections(options);
+  }
+
+  async setEncryptedCollections(
+    value: { [id: string]: CollectionData },
+    options?: StorageOptions
+  ): Promise<void> {
+    options = this.reconcileOptions(options, this.defaultInMemoryOptions);
+    return await super.setEncryptedCollections(value, options);
+  }
+
+  async getEncryptedFolders(options?: StorageOptions): Promise<{ [id: string]: FolderData }> {
+    options = this.reconcileOptions(options, this.defaultInMemoryOptions);
+    return await super.getEncryptedFolders(options);
+  }
+
+  async setEncryptedFolders(
+    value: { [id: string]: FolderData },
+    options?: StorageOptions
+  ): Promise<void> {
+    options = this.reconcileOptions(options, this.defaultInMemoryOptions);
+    return await super.setEncryptedFolders(value, options);
+  }
+
+  async getEncryptedSends(options?: StorageOptions): Promise<{ [id: string]: SendData }> {
+    options = this.reconcileOptions(options, this.defaultInMemoryOptions);
+    return await super.getEncryptedSends(options);
+  }
+
+  async setEncryptedSends(
+    value: { [id: string]: SendData },
+    options?: StorageOptions
+  ): Promise<void> {
+    options = this.reconcileOptions(options, this.defaultInMemoryOptions);
+    return await super.setEncryptedSends(value, options);
   }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Resolve https://app.asana.com/0/1201804463288267/1201794888247580

## Code changes
We were storing vault data in memory in the web vault to avoid key size limits for storing data in Chrome. This was broken in with the storage restructure, and is put back in this PR. Instead of saving vault data to disk we save it to in memory state.


I tested this by connecting my local web client to the qa cloud vault, and used @Larry-Sussman's test account from the ticket. Vault data loads in as expected.

## Screenshots
<img width="1792" alt="Screen Shot 2022-02-11 at 3 14 14 AM" src="https://user-images.githubusercontent.com/15897251/153557614-23c12a6a-7f2e-49a1-b0b6-eb26dfa1faf7.png">

<!--Required for any UI changes. Delete if not applicable-->

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
