### PR TITLE
Store last sync in memory

### DIFF
--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -92,4 +92,14 @@ export class StateService
     options = this.reconcileOptions(options, this.defaultInMemoryOptions);
     return await super.setEncryptedSends(value, options);
   }
+
+  override async getLastSync(options?: StorageOptions): Promise<string> {
+    options = this.reconcileOptions(options, this.defaultInMemoryOptions);
+    return await super.getLastSync(options);
+  }
+
+  override async setLastSync(value: string, options?: StorageOptions): Promise<void> {
+    options = this.reconcileOptions(options, this.defaultInMemoryOptions);
+    return await super.setLastSync(value, options);
+  }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Follow up to https://github.com/bitwarden/web/pull/1470

Storing data in memory causes it to be lost on refresh. We were getting it back before by [also saving lastSync to memory,](https://github.com/bitwarden/web/blob/23b30422d886bd395259cb864a7d83caffe1d099/src/services/htmlStorage.service.ts#L12) forcing a sync on refresh, and doing that again fixes the issue.

## Code changes
Store lastSync in memory for the web vault

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
