### PR TITLE
[Icons Bug] fa-remove -> bwi-close

### DIFF
--- a/bitwarden_license/src/app/providers/manage/people.component.html
+++ b/bitwarden_license/src/app/providers/manage/people.component.html
@@ -214,7 +214,7 @@
                   {{ "eventLogs" | i18n }}
                 </a>
                 <a class="dropdown-item text-danger" href="#" appStopClick (click)="remove(u)">
-                  <i class="bwi bwi-fw bwi-remove" aria-hidden="true"></i>
+                  <i class="bwi bwi-fw bwi-close" aria-hidden="true"></i>
                   {{ "remove" | i18n }}
                 </a>
               </div>

--- a/src/app/settings/emergency-access.component.html
+++ b/src/app/settings/emergency-access.component.html
@@ -138,7 +138,7 @@
               {{ "reject" | i18n }}
             </a>
             <a class="dropdown-item text-danger" href="#" appStopClick (click)="remove(c)">
-              <i class="bwi bwi-fw bwi-remove" aria-hidden="true"></i>
+              <i class="bwi bwi-fw bwi-close" aria-hidden="true"></i>
               {{ "remove" | i18n }}
             </a>
           </div>


### PR DESCRIPTION
## Type of change
- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Fix issue with missing icon due to incorrect reference in the `html` files

## Code changes
- **providers/people.component.html**: `fa-remove` -> `bwi-close` updated to correct reference
- **emergency-access.component.html**: `fa-remove` -> `bwi-close` updated to correct reference

## Screenshots
![Screen Shot 2022-02-18 at 5 09 54 PM](https://user-images.githubusercontent.com/26154748/154773393-79c0180d-3c87-41b1-8996-dde27db63963.png)

## Testing requirements
- Make sure the following dropdown menus are correctly showing the `bwi-close` icon

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
