### PR TITLE
CSA-6 Remove artifact binding from SSO config UI

### DIFF
--- a/bitwarden_license/src/app/organizations/manage/sso.component.html
+++ b/bitwarden_license/src/app/organizations/manage/sso.component.html
@@ -395,7 +395,6 @@
         <select class="form-control" formControlName="idpBindingType" id="idpBindingType">
           <option [ngValue]="1">Redirect</option>
           <option [ngValue]="2">HTTP POST</option>
-          <option [ngValue]="4">Artifact</option>
         </select>
       </div>
       <div class="form-group">
@@ -412,16 +411,6 @@
           class="form-control"
           formControlName="idpSingleLogoutServiceUrl"
           id="idpSingleLogoutServiceUrl"
-        />
-      </div>
-      <div class="form-group">
-        <label for="idpArtifactResolutionServiceUrl">{{
-          "idpArtifactResolutionServiceUrl" | i18n
-        }}</label>
-        <input
-          class="form-control"
-          formControlName="idpArtifactResolutionServiceUrl"
-          id="idpArtifactResolutionServiceUrl"
         />
       </div>
       <div class="form-group">

--- a/bitwarden_license/src/app/organizations/manage/sso.component.ts
+++ b/bitwarden_license/src/app/organizations/manage/sso.component.ts
@@ -65,7 +65,6 @@ export class SsoComponent implements OnInit {
     idpBindingType: [],
     idpSingleSignOnServiceUrl: [],
     idpSingleLogoutServiceUrl: [],
-    idpArtifactResolutionServiceUrl: [],
     idpX509PublicCert: [],
     idpOutboundSigningAlgorithm: [],
     idpAllowUnsolicitedAuthnResponse: [],


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Remove Artifact binding capabilities from Bitwarden's SSO service for now; they _may_ be added back in the future.
see: https://app.asana.com/0/1169444489336079/1201340159635915/f
see: CSA-6

## Code changes
* **sso.component.html:** 
* **sso.component.ts:** 

## Screenshots

![image](https://user-images.githubusercontent.com/3904944/155811628-a40a7b5a-fbed-4f97-b84f-ad2a000e153b.png)

## Testing requirements
* Ensure you can still configure SAML SSO via the web vault and the configuration saves and loads as expected
* Ensure you can still configure OpenID Connect SSO via the web vault and the configuration saves and loads as expected
* See: https://github.com/bitwarden/server/pull/1885

## Documentation updates
cc: @fschillingeriv 
Because this removes the underlying functionality for the Artifact binding and associated Artifact Endpoint URL configuration in the UI when configuring SAML, this update will need to be made to the documentation when this goes live (likely in March release). See: https://github.com/bitwarden/server/pull/1885.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [x] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
