### PR TITLE
Fix mobile `+` url encoding issue

### DIFF
--- a/src/connectors/captcha.ts
+++ b/src/connectors/captcha.ts
@@ -45,7 +45,7 @@ async function start() {
 
   let decodedData: any;
   try {
-    decodedData = JSON.parse(b64Decode(data));
+    decodedData = JSON.parse(b64Decode(data, true));
   } catch (e) {
     error("Cannot parse data.");
     return;

--- a/src/connectors/common.ts
+++ b/src/connectors/common.ts
@@ -15,7 +15,11 @@ export function getQsParam(name: string) {
   return decodeURIComponent(results[2].replace(/\+/g, " "));
 }
 
-export function b64Decode(str: string) {
+export function b64Decode(str: string, spaceAsPlus = false) {
+  if (spaceAsPlus) {
+    str = str.replace(/ /g, "+");
+  }
+
   return decodeURIComponent(
     Array.prototype.map
       .call(atob(str), (c: string) => {


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
This is a fix to correct for broken mobile encoding of captcha data strings with `+`s in url base64.

It will be used to hotfix our handling of captcha for mobile clients.

## Code changes
* **captcha.ts**: use new option to replace ` ` with `+`
* **common.ts**: optionally replace ` ` with `+` for connectors. This should be safe, as proper b64 will never have a space in it, these are only the result of url paramter parsing returning spaces.

## Testing requirements

captcha testing on current mobile release. hint: czech currently produces a b64 string with a `+` and can be used to test this specific bug.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [x] This change has particular **deployment requirements** (notify the DevOps team)
