### PR TITLE
[End User Vault Refresh] Vault - remove Org and Provider cards

### DIFF
--- a/src/app/providers/providers.component.html
+++ b/src/app/providers/providers.component.html
@@ -1,27 +1,4 @@
-<ng-container *ngIf="vault">
-  <p *ngIf="!loaded" class="text-muted">
-    <i class="bwi bwi-spinner bwi-spin" title="{{ 'loading' | i18n }}" aria-hidden="true"></i>
-    <span class="sr-only">{{ "loading" | i18n }}</span>
-  </p>
-  <ng-container *ngIf="loaded">
-    <ul class="bwi-ul card-ul carets" *ngIf="providers && providers.length">
-      <li *ngFor="let p of providers">
-        <a [routerLink]="['/providers', p.id]" class="text-body">
-          <i class="bwi bwi-li bwi-caret-right" aria-hidden="true"></i> {{ p.name }}
-          <ng-container *ngIf="!p.enabled">
-            <i
-              class="bwi bwi-exclamation-triangle text-danger"
-              title="{{ 'providerIsDisabled' | i18n }}"
-              aria-hidden="true"
-            ></i>
-            <span class="sr-only">{{ "providerIsDisabled" | i18n }}</span>
-          </ng-container>
-        </a>
-      </li>
-    </ul>
-  </ng-container>
-</ng-container>
-<ng-container *ngIf="!vault">
+<ng-container>
   <app-navbar></app-navbar>
   <div class="container page-content">
     <div class="page-header d-flex">

--- a/src/app/providers/providers.component.html
+++ b/src/app/providers/providers.component.html
@@ -1,35 +1,33 @@
-<ng-container>
-  <app-navbar></app-navbar>
-  <div class="container page-content">
-    <div class="page-header d-flex">
-      <h1>{{ "providers" | i18n }}</h1>
-    </div>
-    <p *ngIf="!loaded" class="text-muted">
-      <i class="bwi bwi-spinner bwi-spin" title="{{ 'loading' | i18n }}" aria-hidden="true"></i>
-      <span class="sr-only">{{ "loading" | i18n }}</span>
-    </p>
-    <ng-container *ngIf="loaded">
-      <table class="table table-hover table-list" *ngIf="providers && providers.length">
-        <tbody>
-          <tr *ngFor="let p of providers">
-            <td width="30">
-              <app-avatar [data]="p.name" size="25" [circle]="true" [fontSize]="14"></app-avatar>
-            </td>
-            <td>
-              <a href="#" [routerLink]="['/providers', p.id]">{{ p.name }}</a>
-              <ng-container *ngIf="!p.enabled">
-                <i
-                  class="bwi bwi-exclamation-triangle text-danger"
-                  title="{{ 'providerIsDisabled' | i18n }}"
-                  aria-hidden="true"
-                ></i>
-                <span class="sr-only">{{ "providerIsDisabled" | i18n }}</span>
-              </ng-container>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </ng-container>
+<app-navbar></app-navbar>
+<div class="container page-content">
+  <div class="page-header d-flex">
+    <h1>{{ "providers" | i18n }}</h1>
   </div>
-  <app-footer></app-footer>
-</ng-container>
+  <p *ngIf="!loaded" class="text-muted">
+    <i class="bwi bwi-spinner bwi-spin" title="{{ 'loading' | i18n }}" aria-hidden="true"></i>
+    <span class="sr-only">{{ "loading" | i18n }}</span>
+  </p>
+  <ng-container *ngIf="loaded">
+    <table class="table table-hover table-list" *ngIf="providers && providers.length">
+      <tbody>
+        <tr *ngFor="let p of providers">
+          <td width="30">
+            <app-avatar [data]="p.name" size="25" [circle]="true" [fontSize]="14"></app-avatar>
+          </td>
+          <td>
+            <a href="#" [routerLink]="['/providers', p.id]">{{ p.name }}</a>
+            <ng-container *ngIf="!p.enabled">
+              <i
+                class="bwi bwi-exclamation-triangle text-danger"
+                title="{{ 'providerIsDisabled' | i18n }}"
+                aria-hidden="true"
+              ></i>
+              <span class="sr-only">{{ "providerIsDisabled" | i18n }}</span>
+            </ng-container>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </ng-container>
+</div>
+<app-footer></app-footer>

--- a/src/app/providers/providers.component.ts
+++ b/src/app/providers/providers.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { ProviderService } from "jslib-common/abstractions/provider.service";

--- a/src/app/providers/providers.component.ts
+++ b/src/app/providers/providers.component.ts
@@ -10,8 +10,6 @@ import { Provider } from "jslib-common/models/domain/provider";
   templateUrl: "providers.component.html",
 })
 export class ProvidersComponent implements OnInit {
-  @Input() vault = false;
-
   providers: Provider[];
   loaded = false;
   actionPromise: Promise<any>;

--- a/src/app/settings/organizations.component.html
+++ b/src/app/settings/organizations.component.html
@@ -1,32 +1,4 @@
-<ng-container *ngIf="vault">
-  <p *ngIf="!loaded" class="text-muted">
-    <i class="bwi bwi-spinner bwi-spin" title="{{ 'loading' | i18n }}" aria-hidden="true"></i>
-    <span class="sr-only">{{ "loading" | i18n }}</span>
-  </p>
-  <ng-container *ngIf="loaded">
-    <ul class="bwi-ul card-ul carets" *ngIf="organizations && organizations.length">
-      <li *ngFor="let o of organizations">
-        <a [routerLink]="['/organizations', o.id]" class="text-body">
-          <i class="bwi bwi-li bwi-caret-right" aria-hidden="true"></i> {{ o.name }}
-          <ng-container *ngIf="!o.enabled">
-            <i
-              class="bwi bwi-exclamation-triangle text-danger"
-              title="{{ 'organizationIsDisabled' | i18n }}"
-              aria-hidden="true"
-            ></i>
-            <span class="sr-only">{{ "organizationIsDisabled" | i18n }}</span>
-          </ng-container>
-        </a>
-      </li>
-    </ul>
-    <p *ngIf="!organizations || !organizations.length">{{ "noOrganizationsList" | i18n }}</p>
-  </ng-container>
-  <a href="#" routerLink="/settings/create-organization" class="btn btn-block btn-outline-primary">
-    <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
-    {{ "newOrganization" | i18n }}
-  </a>
-</ng-container>
-<ng-container *ngIf="!vault">
+<ng-container>
   <div class="page-header d-flex">
     <h1>
       {{ "organizations" | i18n }}

--- a/src/app/settings/organizations.component.html
+++ b/src/app/settings/organizations.component.html
@@ -1,127 +1,125 @@
-<ng-container>
-  <div class="page-header d-flex">
-    <h1>
-      {{ "organizations" | i18n }}
-      <small [appApiAction]="actionPromise" #action>
-        <ng-container *ngIf="action.loading">
-          <i
-            class="bwi bwi-spinner bwi-spin text-muted"
-            title="{{ 'loading' | i18n }}"
-            aria-hidden="true"
-          ></i>
-          <span class="sr-only">{{ "loading" | i18n }}</span>
-        </ng-container>
-      </small>
-    </h1>
-    <a
-      href="#"
-      routerLink="/settings/create-organization"
-      class="btn btn-sm btn-outline-primary ml-auto"
-      *ngIf="!loaded || (organizations && organizations.length)"
-    >
+<div class="page-header d-flex">
+  <h1>
+    {{ "organizations" | i18n }}
+    <small [appApiAction]="actionPromise" #action>
+      <ng-container *ngIf="action.loading">
+        <i
+          class="bwi bwi-spinner bwi-spin text-muted"
+          title="{{ 'loading' | i18n }}"
+          aria-hidden="true"
+        ></i>
+        <span class="sr-only">{{ "loading" | i18n }}</span>
+      </ng-container>
+    </small>
+  </h1>
+  <a
+    href="#"
+    routerLink="/settings/create-organization"
+    class="btn btn-sm btn-outline-primary ml-auto"
+    *ngIf="!loaded || (organizations && organizations.length)"
+  >
+    <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
+    {{ "newOrganization" | i18n }}
+  </a>
+</div>
+<ng-container *ngIf="!loaded">
+  <i
+    class="bwi bwi-spinner bwi-spin text-muted"
+    title="{{ 'loading' | i18n }}"
+    aria-hidden="true"
+  ></i>
+  <span class="sr-only">{{ "loading" | i18n }}</span>
+</ng-container>
+<ng-container *ngIf="loaded">
+  <ng-container *ngIf="!organizations || !organizations.length">
+    <p>{{ "noOrganizationsList" | i18n }}</p>
+    <a href="#" routerLink="/settings/create-organization" class="btn btn-outline-primary">
       <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
       {{ "newOrganization" | i18n }}
     </a>
-  </div>
-  <ng-container *ngIf="!loaded">
-    <i
-      class="bwi bwi-spinner bwi-spin text-muted"
-      title="{{ 'loading' | i18n }}"
-      aria-hidden="true"
-    ></i>
-    <span class="sr-only">{{ "loading" | i18n }}</span>
   </ng-container>
-  <ng-container *ngIf="loaded">
-    <ng-container *ngIf="!organizations || !organizations.length">
-      <p>{{ "noOrganizationsList" | i18n }}</p>
-      <a href="#" routerLink="/settings/create-organization" class="btn btn-outline-primary">
-        <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
-        {{ "newOrganization" | i18n }}
-      </a>
-    </ng-container>
-    <table class="table table-hover table-list" *ngIf="organizations && organizations.length">
-      <tbody>
-        <tr *ngFor="let o of organizations">
-          <td width="30">
-            <app-avatar [data]="o.name" size="25" [circle]="true" [fontSize]="14"></app-avatar>
-          </td>
-          <td>
-            <a href="#" [routerLink]="['/organizations', o.id]">{{ o.name }}</a>
-            <ng-container *ngIf="!o.enabled">
-              <i
-                class="bwi bwi-exclamation-triangle text-danger"
-                title="{{ 'organizationIsDisabled' | i18n }}"
-                aria-hidden="true"
-              ></i>
-              <span class="sr-only">{{ "organizationIsDisabled" | i18n }}</span>
-            </ng-container>
-            <ng-container *ngIf="showEnrolledStatus(o)">
-              <i
-                class="bwi bwi-key"
-                appStopProp
-                title="{{ 'enrolledPasswordReset' | i18n }}"
-                aria-hidden="true"
-              ></i>
-              <span class="sr-only">{{ "enrolledPasswordReset" | i18n }}</span>
-            </ng-container>
-          </td>
-          <td class="table-list-options">
-            <div class="dropdown" appListDropdown>
-              <button
-                class="btn btn-outline-secondary dropdown-toggle"
-                type="button"
-                data-toggle="dropdown"
-                aria-haspopup="true"
-                aria-expanded="false"
-                appA11yTitle="{{ 'options' | i18n }}"
+  <table class="table table-hover table-list" *ngIf="organizations && organizations.length">
+    <tbody>
+      <tr *ngFor="let o of organizations">
+        <td width="30">
+          <app-avatar [data]="o.name" size="25" [circle]="true" [fontSize]="14"></app-avatar>
+        </td>
+        <td>
+          <a href="#" [routerLink]="['/organizations', o.id]">{{ o.name }}</a>
+          <ng-container *ngIf="!o.enabled">
+            <i
+              class="bwi bwi-exclamation-triangle text-danger"
+              title="{{ 'organizationIsDisabled' | i18n }}"
+              aria-hidden="true"
+            ></i>
+            <span class="sr-only">{{ "organizationIsDisabled" | i18n }}</span>
+          </ng-container>
+          <ng-container *ngIf="showEnrolledStatus(o)">
+            <i
+              class="bwi bwi-key"
+              appStopProp
+              title="{{ 'enrolledPasswordReset' | i18n }}"
+              aria-hidden="true"
+            ></i>
+            <span class="sr-only">{{ "enrolledPasswordReset" | i18n }}</span>
+          </ng-container>
+        </td>
+        <td class="table-list-options">
+          <div class="dropdown" appListDropdown>
+            <button
+              class="btn btn-outline-secondary dropdown-toggle"
+              type="button"
+              data-toggle="dropdown"
+              aria-haspopup="true"
+              aria-expanded="false"
+              appA11yTitle="{{ 'options' | i18n }}"
+            >
+              <i class="bwi bwi-cog bwi-lg" aria-hidden="true"></i>
+            </button>
+            <div class="dropdown-menu dropdown-menu-right">
+              <a
+                *ngIf="allowEnrollmentChanges(o) && !o.resetPasswordEnrolled"
+                class="dropdown-item"
+                href="#"
+                appStopClick
+                (click)="toggleResetPasswordEnrollment(o)"
               >
-                <i class="bwi bwi-cog bwi-lg" aria-hidden="true"></i>
-              </button>
-              <div class="dropdown-menu dropdown-menu-right">
+                <i class="bwi bwi-fw bwi-key" aria-hidden="true"></i>
+                {{ "enrollPasswordReset" | i18n }}
+              </a>
+              <a
+                *ngIf="allowEnrollmentChanges(o) && o.resetPasswordEnrolled"
+                class="dropdown-item"
+                href="#"
+                appStopClick
+                (click)="toggleResetPasswordEnrollment(o)"
+              >
+                <i class="bwi bwi-fw bwi-undo" aria-hidden="true"></i>
+                {{ "withdrawPasswordReset" | i18n }}
+              </a>
+              <ng-container *ngIf="o.useSso && o.identifier">
                 <a
-                  *ngIf="allowEnrollmentChanges(o) && !o.resetPasswordEnrolled"
+                  *ngIf="o.ssoBound; else linkSso"
                   class="dropdown-item"
                   href="#"
                   appStopClick
-                  (click)="toggleResetPasswordEnrollment(o)"
+                  (click)="unlinkSso(o)"
                 >
-                  <i class="bwi bwi-fw bwi-key" aria-hidden="true"></i>
-                  {{ "enrollPasswordReset" | i18n }}
+                  <i class="bwi bwi-fw bwi-chain-broken" aria-hidden="true"></i>
+                  {{ "unlinkSso" | i18n }}
                 </a>
-                <a
-                  *ngIf="allowEnrollmentChanges(o) && o.resetPasswordEnrolled"
-                  class="dropdown-item"
-                  href="#"
-                  appStopClick
-                  (click)="toggleResetPasswordEnrollment(o)"
-                >
-                  <i class="bwi bwi-fw bwi-undo" aria-hidden="true"></i>
-                  {{ "withdrawPasswordReset" | i18n }}
-                </a>
-                <ng-container *ngIf="o.useSso && o.identifier">
-                  <a
-                    *ngIf="o.ssoBound; else linkSso"
-                    class="dropdown-item"
-                    href="#"
-                    appStopClick
-                    (click)="unlinkSso(o)"
-                  >
-                    <i class="bwi bwi-fw bwi-chain-broken" aria-hidden="true"></i>
-                    {{ "unlinkSso" | i18n }}
-                  </a>
-                  <ng-template #linkSso>
-                    <app-link-sso [organization]="o"> </app-link-sso>
-                  </ng-template>
-                </ng-container>
-                <a class="dropdown-item text-danger" href="#" appStopClick (click)="leave(o)">
-                  <i class="bwi bwi-fw bwi-sign-out" aria-hidden="true"></i>
-                  {{ "leave" | i18n }}
-                </a>
-              </div>
+                <ng-template #linkSso>
+                  <app-link-sso [organization]="o"> </app-link-sso>
+                </ng-template>
+              </ng-container>
+              <a class="dropdown-item text-danger" href="#" appStopClick (click)="leave(o)">
+                <i class="bwi bwi-fw bwi-sign-out" aria-hidden="true"></i>
+                {{ "leave" | i18n }}
+              </a>
             </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </ng-container>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </ng-container>

--- a/src/app/settings/organizations.component.ts
+++ b/src/app/settings/organizations.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";

--- a/src/app/settings/organizations.component.ts
+++ b/src/app/settings/organizations.component.ts
@@ -19,8 +19,6 @@ import { OrganizationUserResetPasswordEnrollmentRequest } from "jslib-common/mod
   templateUrl: "organizations.component.html",
 })
 export class OrganizationsComponent implements OnInit {
-  @Input() vault = false;
-
   organizations: Organization[];
   policies: Policy[];
   loaded = false;
@@ -38,10 +36,8 @@ export class OrganizationsComponent implements OnInit {
   ) {}
 
   async ngOnInit() {
-    if (!this.vault) {
-      await this.syncService.fullSync(true);
-      await this.load();
-    }
+    await this.syncService.fullSync(true);
+    await this.load();
   }
 
   async load() {

--- a/src/app/vault/vault.component.html
+++ b/src/app/vault/vault.component.html
@@ -97,40 +97,6 @@
           </a>
         </div>
       </div>
-      <div class="card mb-4">
-        <div class="card-header d-flex">
-          {{ "organizations" | i18n }}
-          <a
-            class="ml-auto"
-            href="https://bitwarden.com/help/about-organizations/"
-            target="_blank"
-            rel="noopener"
-            appA11yTitle="{{ 'learnMore' | i18n }}"
-          >
-            <i class="bwi bwi-question-circle" aria-hidden="true"></i>
-          </a>
-        </div>
-        <div class="card-body">
-          <app-organizations [vault]="true"></app-organizations>
-        </div>
-      </div>
-      <div class="card mt-4" *ngIf="showProviders">
-        <div class="card-header d-flex">
-          {{ "providers" | i18n }}
-          <a
-            class="ml-auto"
-            href="https://bitwarden.com/help/providers/"
-            target="_blank"
-            rel="noopener"
-            appA11yTitle="{{ 'learnMore' | i18n }}"
-          >
-            <i class="bwi bwi-question-circle" aria-hidden="true"></i>
-          </a>
-        </div>
-        <div class="card-body">
-          <app-providers vault="true"></app-providers>
-        </div>
-      </div>
     </div>
   </div>
 </div>

--- a/src/app/vault/vault.component.ts
+++ b/src/app/vault/vault.component.ts
@@ -17,14 +17,12 @@ import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { MessagingService } from "jslib-common/abstractions/messaging.service";
 import { OrganizationService } from "jslib-common/abstractions/organization.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
-import { ProviderService } from "jslib-common/abstractions/provider.service";
 import { StateService } from "jslib-common/abstractions/state.service";
 import { SyncService } from "jslib-common/abstractions/sync.service";
 import { TokenService } from "jslib-common/abstractions/token.service";
 import { CipherType } from "jslib-common/enums/cipherType";
 import { CipherView } from "jslib-common/models/view/cipherView";
 
-import { OrganizationsComponent } from "../settings/organizations.component";
 import { UpdateKeyComponent } from "../settings/update-key.component";
 
 import { AddEditComponent } from "./add-edit.component";
@@ -44,8 +42,6 @@ const BroadcasterSubscriptionId = "VaultComponent";
 export class VaultComponent implements OnInit, OnDestroy {
   @ViewChild(GroupingsComponent, { static: true }) groupingsComponent: GroupingsComponent;
   @ViewChild(CiphersComponent, { static: true }) ciphersComponent: CiphersComponent;
-  @ViewChild(OrganizationsComponent, { static: true })
-  organizationsComponent: OrganizationsComponent;
   @ViewChild("attachments", { read: ViewContainerRef, static: true })
   attachmentsModalRef: ViewContainerRef;
   @ViewChild("folderAddEdit", { read: ViewContainerRef, static: true })
@@ -66,7 +62,6 @@ export class VaultComponent implements OnInit, OnDestroy {
   showBrowserOutdated = false;
   showUpdateKey = false;
   showPremiumCallout = false;
-  showProviders = false;
   deleted = false;
   trashCleanupWarning: string = null;
 
@@ -84,8 +79,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     private broadcasterService: BroadcasterService,
     private ngZone: NgZone,
     private stateService: StateService,
-    private organizationService: OrganizationService,
-    private providerService: ProviderService
+    private organizationService: OrganizationService
   ) {}
 
   async ngOnInit() {
@@ -104,9 +98,7 @@ export class VaultComponent implements OnInit, OnDestroy {
       this.showPremiumCallout =
         !this.showVerifyEmail && !canAccessPremium && !this.platformUtilsService.isSelfHost();
 
-      this.showProviders = (await this.providerService.getAll()).length > 0;
-
-      await Promise.all([this.groupingsComponent.load(), this.organizationsComponent.load()]);
+      await this.groupingsComponent.load();
       this.showUpdateKey = !(await this.cryptoService.hasEncKey());
 
       if (params == null) {
@@ -143,7 +135,6 @@ export class VaultComponent implements OnInit, OnDestroy {
               if (message.successfully) {
                 await Promise.all([
                   this.groupingsComponent.load(),
-                  this.organizationsComponent.load(),
                   this.ciphersComponent.load(this.ciphersComponent.filter),
                 ]);
                 this.changeDetectorRef.detectChanges();


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Remove the Organizations and Provider cards from the vault page.

SG-28 and SG-29

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

These cards reused the `organizations.component` and `providers.component`, which are also used in the settings page. Those components had alternative templates based on an `@Input() vault` property. So instead of removing completely, just delete those parts of the template, and any loading logic in the vault component.

## Screenshots
Behold, no cards (except for Verify Email which is staying there for now):

![Screen Shot 2022-03-10 at 8 24 46 am](https://user-images.githubusercontent.com/31796059/157548756-1b3f38cf-beeb-46a6-bcc9-43752f9ae1ac.png)

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
