### PR TITLE
[bug] Partially revert #1516

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -197,6 +197,8 @@ export class AppComponent implements OnDestroy, OnInit {
       new SendOptionsPolicy(),
       new ResetPasswordPolicy(),
     ]);
+
+    this.setFullWidth();
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
This will be cherry picked to rc
https://app.asana.com/0/1183359552741420/1201900335531015

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
On https://github.com/bitwarden/web/pull/1516 I moved the `enableFullWidth` check from application startup to on login, citing `enableFullWidth` being an account setting that needed on authenticated account to pull correctly.

This was partially correct, but we still need to also check on application startup for use cases where chrome is closed/reopened with an active session. In that case, we won't have the `enableFullWidth` class applied, because it was never checked, but we also won't ever check since there is no new authentication happening (the reopened session is on the lock screen)

## Code changes
We should check for enableFullWidth in both places, new logins and application startup. This will let each account have its own setting, but still apply the last available one when a session is restarted after a browser close.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
