### PR TITLE
[End User Vault Refresh] Security sub-page

### DIFF
--- a/src/app/oss-routing.module.ts
+++ b/src/app/oss-routing.module.ts
@@ -51,6 +51,7 @@ import { SendComponent } from "./send/send.component";
 import { OrganizationGuardService } from "./services/organization-guard.service";
 import { OrganizationTypeGuardService } from "./services/organization-type-guard.service";
 import { AccountComponent } from "./settings/account.component";
+import { ChangePasswordComponent } from "./settings/change-password.component";
 import { CreateOrganizationComponent } from "./settings/create-organization.component";
 import { DomainRulesComponent } from "./settings/domain-rules.component";
 import { EmergencyAccessViewComponent } from "./settings/emergency-access-view.component";
@@ -58,6 +59,8 @@ import { EmergencyAccessComponent } from "./settings/emergency-access.component"
 import { OrganizationsComponent } from "./settings/organizations.component";
 import { PreferencesComponent } from "./settings/preferences.component";
 import { PremiumComponent } from "./settings/premium.component";
+import { SecurityKeysComponent } from "./settings/security-keys.component";
+import { SecurityComponent } from "./settings/security.component";
 import { SettingsComponent } from "./settings/settings.component";
 import { SponsoredFamiliesComponent } from "./settings/sponsored-families.component";
 import { TwoFactorSetupComponent } from "./settings/two-factor-setup.component";
@@ -184,14 +187,32 @@ const routes: Routes = [
             data: { titleId: "preferences" },
           },
           {
+            path: "security",
+            component: SecurityComponent,
+            data: { titleId: "security" },
+            children: [
+              { path: "", pathMatch: "full", redirectTo: "change-password" },
+              {
+                path: "change-password",
+                component: ChangePasswordComponent,
+                data: { titleId: "masterPassword" },
+              },
+              {
+                path: "two-factor",
+                component: TwoFactorSetupComponent,
+                data: { titleId: "twoStepLogin" },
+              },
+              {
+                path: "security-keys",
+                component: SecurityKeysComponent,
+                data: { titleId: "keys" },
+              },
+            ],
+          },
+          {
             path: "domain-rules",
             component: DomainRulesComponent,
             data: { titleId: "domainRules" },
-          },
-          {
-            path: "two-factor",
-            component: TwoFactorSetupComponent,
-            data: { titleId: "twoStepLogin" },
           },
           { path: "premium", component: PremiumComponent, data: { titleId: "goPremium" } },
           { path: "billing", component: UserBillingComponent, data: { titleId: "billing" } },

--- a/src/app/oss-routing.module.ts
+++ b/src/app/oss-routing.module.ts
@@ -51,7 +51,6 @@ import { SendComponent } from "./send/send.component";
 import { OrganizationGuardService } from "./services/organization-guard.service";
 import { OrganizationTypeGuardService } from "./services/organization-type-guard.service";
 import { AccountComponent } from "./settings/account.component";
-import { ChangePasswordComponent } from "./settings/change-password.component";
 import { CreateOrganizationComponent } from "./settings/create-organization.component";
 import { DomainRulesComponent } from "./settings/domain-rules.component";
 import { EmergencyAccessViewComponent } from "./settings/emergency-access-view.component";
@@ -59,11 +58,9 @@ import { EmergencyAccessComponent } from "./settings/emergency-access.component"
 import { OrganizationsComponent } from "./settings/organizations.component";
 import { PreferencesComponent } from "./settings/preferences.component";
 import { PremiumComponent } from "./settings/premium.component";
-import { SecurityKeysComponent } from "./settings/security-keys.component";
 import { SecurityComponent } from "./settings/security.component";
 import { SettingsComponent } from "./settings/settings.component";
 import { SponsoredFamiliesComponent } from "./settings/sponsored-families.component";
-import { TwoFactorSetupComponent } from "./settings/two-factor-setup.component";
 import { UserBillingComponent } from "./settings/user-billing.component";
 import { UserSubscriptionComponent } from "./settings/user-subscription.component";
 import { BreachReportComponent } from "./tools/breach-report.component";
@@ -188,26 +185,7 @@ const routes: Routes = [
           },
           {
             path: "security",
-            component: SecurityComponent,
-            data: { titleId: "security" },
-            children: [
-              { path: "", pathMatch: "full", redirectTo: "change-password" },
-              {
-                path: "change-password",
-                component: ChangePasswordComponent,
-                data: { titleId: "masterPassword" },
-              },
-              {
-                path: "two-factor",
-                component: TwoFactorSetupComponent,
-                data: { titleId: "twoStepLogin" },
-              },
-              {
-                path: "security-keys",
-                component: SecurityKeysComponent,
-                data: { titleId: "keys" },
-              },
-            ],
+            loadChildren: async () => (await import("./settings/security.module")).SecurityModule,
           },
           {
             path: "domain-rules",

--- a/src/app/oss.module.ts
+++ b/src/app/oss.module.ts
@@ -191,6 +191,8 @@ import { PreferencesComponent } from "./settings/preferences.component";
 import { PremiumComponent } from "./settings/premium.component";
 import { ProfileComponent } from "./settings/profile.component";
 import { PurgeVaultComponent } from "./settings/purge-vault.component";
+import { SecurityKeysComponent } from "./settings/security-keys.component";
+import { SecurityComponent } from "./settings/security.component";
 import { SettingsComponent } from "./settings/settings.component";
 import { SponsoredFamiliesComponent } from "./settings/sponsored-families.component";
 import { SponsoringOrgRowComponent } from "./settings/sponsoring-org-row.component";
@@ -431,6 +433,8 @@ registerLocaleData(localeZhTw, "zh-TW");
     ReusedPasswordsReportComponent,
     SearchCiphersPipe,
     SearchPipe,
+    SecurityComponent,
+    SecurityKeysComponent,
     SelectCopyDirective,
     SendAddEditComponent,
     SendComponent,

--- a/src/app/oss.module.ts
+++ b/src/app/oss.module.ts
@@ -53,7 +53,7 @@ import localeZhTw from "@angular/common/locales/zh-Hant";
 import { NgModule } from "@angular/core";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { RouterModule } from "@angular/router";
-import { BadgeModule } from "@bitwarden/components";
+import { BadgeModule, ButtonModule } from "@bitwarden/components";
 import { InfiniteScrollModule } from "ngx-infinite-scroll";
 import { ToastrModule } from "ngx-toastr";
 
@@ -298,6 +298,7 @@ registerLocaleData(localeZhTw, "zh-TW");
     ReactiveFormsModule,
     RouterModule,
     BadgeModule,
+    ButtonModule,
   ],
   declarations: [
     A11yInvalidDirective,

--- a/src/app/oss.module.ts
+++ b/src/app/oss.module.ts
@@ -53,7 +53,7 @@ import localeZhTw from "@angular/common/locales/zh-Hant";
 import { NgModule } from "@angular/core";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { RouterModule } from "@angular/router";
-import { BadgeModule, ButtonModule } from "@bitwarden/components";
+import { BadgeModule, ButtonModule, CalloutModule } from "@bitwarden/components";
 import { InfiniteScrollModule } from "ngx-infinite-scroll";
 import { ToastrModule } from "ngx-toastr";
 
@@ -299,6 +299,7 @@ registerLocaleData(localeZhTw, "zh-TW");
     RouterModule,
     BadgeModule,
     ButtonModule,
+    CalloutModule,
   ],
   declarations: [
     A11yInvalidDirective,

--- a/src/app/settings/account.component.html
+++ b/src/app/settings/account.component.html
@@ -14,13 +14,13 @@
 <div class="card border-danger">
   <div class="card-body">
     <p>{{ "dangerZoneDesc" | i18n }}</p>
-    <button type="button" class="btn btn-outline-danger" (click)="deauthorizeSessions()">
+    <button bit-button buttonType="danger" (click)="deauthorizeSessions()">
       {{ "deauthorizeSessions" | i18n }}
     </button>
-    <button type="button" class="btn btn-outline-danger" (click)="purgeVault()">
+    <button bit-button buttonType="danger" (click)="purgeVault()">
       {{ "purgeVault" | i18n }}
     </button>
-    <button type="button" class="btn btn-outline-danger" (click)="deleteAccount()">
+    <button bit-button buttonType="danger" (click)="deleteAccount()">
       {{ "deleteAccount" | i18n }}
     </button>
   </div>

--- a/src/app/settings/account.component.html
+++ b/src/app/settings/account.component.html
@@ -8,30 +8,6 @@
   </div>
   <app-change-email></app-change-email>
 </ng-container>
-<ng-container *ngIf="showChangePassword">
-  <div class="secondary-header">
-    <h1>{{ "changeMasterPassword" | i18n }}</h1>
-  </div>
-  <app-change-password></app-change-password>
-</ng-container>
-<ng-container *ngIf="showChangeKdf">
-  <div class="secondary-header">
-    <h1>{{ "encKeySettings" | i18n }}</h1>
-  </div>
-  <app-change-kdf></app-change-kdf>
-</ng-container>
-<div class="secondary-header border-0 mb-0">
-  <h1>{{ "apiKey" | i18n }}</h1>
-</div>
-<p>
-  {{ "userApiKeyDesc" | i18n }}
-</p>
-<button type="button" class="btn btn-outline-secondary" (click)="viewUserApiKey()">
-  {{ "viewApiKey" | i18n }}
-</button>
-<button type="button" class="btn btn-outline-secondary" (click)="rotateUserApiKey()">
-  {{ "rotateApiKey" | i18n }}
-</button>
 <div class="secondary-header text-danger border-0 mb-0">
   <h1>{{ "dangerZone" | i18n }}</h1>
 </div>

--- a/src/app/settings/account.component.ts
+++ b/src/app/settings/account.component.ts
@@ -5,7 +5,6 @@ import { ApiService } from "jslib-common/abstractions/api.service";
 import { KeyConnectorService } from "jslib-common/abstractions/keyConnector.service";
 import { StateService } from "jslib-common/abstractions/state.service";
 
-import { ApiKeyComponent } from "./api-key.component";
 import { DeauthorizeSessionsComponent } from "./deauthorize-sessions.component";
 import { DeleteAccountComponent } from "./delete-account.component";
 import { PurgeVaultComponent } from "./purge-vault.component";
@@ -21,13 +20,7 @@ export class AccountComponent {
   purgeModalRef: ViewContainerRef;
   @ViewChild("deleteAccountTemplate", { read: ViewContainerRef, static: true })
   deleteModalRef: ViewContainerRef;
-  @ViewChild("viewUserApiKeyTemplate", { read: ViewContainerRef, static: true })
-  viewUserApiKeyModalRef: ViewContainerRef;
-  @ViewChild("rotateUserApiKeyTemplate", { read: ViewContainerRef, static: true })
-  rotateUserApiKeyModalRef: ViewContainerRef;
 
-  showChangePassword = true;
-  showChangeKdf = true;
   showChangeEmail = true;
 
   constructor(
@@ -38,10 +31,7 @@ export class AccountComponent {
   ) {}
 
   async ngOnInit() {
-    this.showChangeEmail =
-      this.showChangeKdf =
-      this.showChangePassword =
-        !(await this.keyConnectorService.getUsesKeyConnector());
+    this.showChangeEmail = !(await this.keyConnectorService.getUsesKeyConnector());
   }
 
   async deauthorizeSessions() {
@@ -54,34 +44,5 @@ export class AccountComponent {
 
   async deleteAccount() {
     await this.modalService.openViewRef(DeleteAccountComponent, this.deleteModalRef);
-  }
-
-  async viewUserApiKey() {
-    const entityId = await this.stateService.getUserId();
-    await this.modalService.openViewRef(ApiKeyComponent, this.viewUserApiKeyModalRef, (comp) => {
-      comp.keyType = "user";
-      comp.entityId = entityId;
-      comp.postKey = this.apiService.postUserApiKey.bind(this.apiService);
-      comp.scope = "api";
-      comp.grantType = "client_credentials";
-      comp.apiKeyTitle = "apiKey";
-      comp.apiKeyWarning = "userApiKeyWarning";
-      comp.apiKeyDescription = "userApiKeyDesc";
-    });
-  }
-
-  async rotateUserApiKey() {
-    const entityId = await this.stateService.getUserId();
-    await this.modalService.openViewRef(ApiKeyComponent, this.rotateUserApiKeyModalRef, (comp) => {
-      comp.keyType = "user";
-      comp.isRotation = true;
-      comp.entityId = entityId;
-      comp.postKey = this.apiService.postUserRotateApiKey.bind(this.apiService);
-      comp.scope = "api";
-      comp.grantType = "client_credentials";
-      comp.apiKeyTitle = "apiKey";
-      comp.apiKeyWarning = "userApiKeyWarning";
-      comp.apiKeyDescription = "apiKeyRotateDesc";
-    });
   }
 }

--- a/src/app/settings/change-kdf.component.html
+++ b/src/app/settings/change-kdf.component.html
@@ -1,3 +1,6 @@
+<div class="tabbed-header">
+  <h1>{{ "encKeySettings" | i18n }}</h1>
+</div>
 <app-callout type="warning">{{ "loggedOutWarning" | i18n }}</app-callout>
 <form #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate autocomplete="off">
   <div class="row">

--- a/src/app/settings/change-kdf.component.html
+++ b/src/app/settings/change-kdf.component.html
@@ -71,7 +71,7 @@
       </div>
     </div>
   </div>
-  <button type="submit" class="btn btn-primary btn-submit" [disabled]="form.loading">
+  <button bit-button buttonType="primary" class="btn-submit" [disabled]="form.loading">
     <i class="bwi bwi-spinner bwi-spin" title="{{ 'loading' | i18n }}" aria-hidden="true"></i>
     <span>{{ "changeKdf" | i18n }}</span>
   </button>

--- a/src/app/settings/change-kdf.component.html
+++ b/src/app/settings/change-kdf.component.html
@@ -1,7 +1,7 @@
 <div class="tabbed-header">
   <h1>{{ "encKeySettings" | i18n }}</h1>
 </div>
-<app-callout type="warning">{{ "loggedOutWarning" | i18n }}</app-callout>
+<bit-callout type="warning">{{ "loggedOutWarning" | i18n }}</bit-callout>
 <form #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate autocomplete="off">
   <div class="row">
     <div class="col-6">

--- a/src/app/settings/change-password.component.html
+++ b/src/app/settings/change-password.component.html
@@ -1,3 +1,7 @@
+<div class="tabbed-header">
+  <h1>{{ "changeMasterPassword" | i18n }}</h1>
+</div>
+
 <app-callout type="warning">{{ "loggedOutWarning" | i18n }}</app-callout>
 <app-callout
   type="info"

--- a/src/app/settings/change-password.component.html
+++ b/src/app/settings/change-password.component.html
@@ -87,7 +87,7 @@
       </a>
     </div>
   </div>
-  <button type="submit" class="btn btn-primary btn-submit" [disabled]="form.loading">
+  <button bit-button buttonType="primary" class="btn-submit" [disabled]="form.loading">
     <i class="bwi bwi-spinner bwi-spin" title="{{ 'loading' | i18n }}" aria-hidden="true"></i>
     <span>{{ "changeMasterPassword" | i18n }}</span>
   </button>

--- a/src/app/settings/change-password.component.html
+++ b/src/app/settings/change-password.component.html
@@ -2,7 +2,8 @@
   <h1>{{ "changeMasterPassword" | i18n }}</h1>
 </div>
 
-<app-callout type="warning">{{ "loggedOutWarning" | i18n }}</app-callout>
+<bit-callout type="warning">{{ "loggedOutWarning" | i18n }}</bit-callout>
+<!--TODO Update Component Library with enforcedPolicyOptions callout options-->
 <app-callout
   type="info"
   [enforcedPolicyOptions]="enforcedPolicyOptions"

--- a/src/app/settings/change-password.component.html
+++ b/src/app/settings/change-password.component.html
@@ -3,7 +3,6 @@
 </div>
 
 <bit-callout type="warning">{{ "loggedOutWarning" | i18n }}</bit-callout>
-<!--TODO Update Component Library with enforcedPolicyOptions callout options-->
 <app-callout
   type="info"
   [enforcedPolicyOptions]="enforcedPolicyOptions"

--- a/src/app/settings/change-password.component.ts
+++ b/src/app/settings/change-password.component.ts
@@ -1,4 +1,5 @@
 import { Component } from "@angular/core";
+import { Router } from "@angular/router";
 
 import { ChangePasswordComponent as BaseChangePasswordComponent } from "jslib-angular/components/change-password.component";
 import { ApiService } from "jslib-common/abstractions/api.service";
@@ -6,6 +7,7 @@ import { CipherService } from "jslib-common/abstractions/cipher.service";
 import { CryptoService } from "jslib-common/abstractions/crypto.service";
 import { FolderService } from "jslib-common/abstractions/folder.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
+import { KeyConnectorService } from "jslib-common/abstractions/keyConnector.service";
 import { MessagingService } from "jslib-common/abstractions/messaging.service";
 import { OrganizationService } from "jslib-common/abstractions/organization.service";
 import { PasswordGenerationService } from "jslib-common/abstractions/passwordGeneration.service";
@@ -47,7 +49,9 @@ export class ChangePasswordComponent extends BaseChangePasswordComponent {
     private syncService: SyncService,
     private apiService: ApiService,
     private sendService: SendService,
-    private organizationService: OrganizationService
+    private organizationService: OrganizationService,
+    private keyConnectorService: KeyConnectorService,
+    private router: Router
   ) {
     super(
       i18nService,
@@ -58,6 +62,12 @@ export class ChangePasswordComponent extends BaseChangePasswordComponent {
       policyService,
       stateService
     );
+  }
+
+  async ngOnInit() {
+    if (!(await this.keyConnectorService.getUsesKeyConnector())) {
+      this.router.navigate(["/settings/security/two-factor"]);
+    }
   }
 
   async rotateEncKeyClicked() {

--- a/src/app/settings/change-password.component.ts
+++ b/src/app/settings/change-password.component.ts
@@ -65,7 +65,7 @@ export class ChangePasswordComponent extends BaseChangePasswordComponent {
   }
 
   async ngOnInit() {
-    if (!(await this.keyConnectorService.getUsesKeyConnector())) {
+    if (await this.keyConnectorService.getUsesKeyConnector()) {
       this.router.navigate(["/settings/security/two-factor"]);
     }
   }

--- a/src/app/settings/security-keys.component.html
+++ b/src/app/settings/security-keys.component.html
@@ -8,10 +8,10 @@
 <p>
   {{ "userApiKeyDesc" | i18n }}
 </p>
-<button type="button" class="btn btn-outline-secondary" (click)="viewUserApiKey()">
+<button bit-button buttonType="secondary" (click)="viewUserApiKey()">
   {{ "viewApiKey" | i18n }}
 </button>
-<button type="button" class="btn btn-outline-secondary" (click)="rotateUserApiKey()">
+<button bit-button buttonType="secondary" (click)="rotateUserApiKey()">
   {{ "rotateApiKey" | i18n }}
 </button>
 <ng-template #viewUserApiKeyTemplate></ng-template>

--- a/src/app/settings/security-keys.component.html
+++ b/src/app/settings/security-keys.component.html
@@ -1,0 +1,18 @@
+<app-change-kdf *ngIf="showChangeKdf"></app-change-kdf>
+<div
+  [ngClass]="{ 'tabbed-header': !showChangeKdf, 'secondary-header': showChangeKdf }"
+  class="border-0 mb-0"
+>
+  <h1>{{ "apiKey" | i18n }}</h1>
+</div>
+<p>
+  {{ "userApiKeyDesc" | i18n }}
+</p>
+<button type="button" class="btn btn-outline-secondary" (click)="viewUserApiKey()">
+  {{ "viewApiKey" | i18n }}
+</button>
+<button type="button" class="btn btn-outline-secondary" (click)="rotateUserApiKey()">
+  {{ "rotateApiKey" | i18n }}
+</button>
+<ng-template #viewUserApiKeyTemplate></ng-template>
+<ng-template #rotateUserApiKeyTemplate></ng-template>

--- a/src/app/settings/security-keys.component.ts
+++ b/src/app/settings/security-keys.component.ts
@@ -1,0 +1,61 @@
+import { Component, OnInit, ViewChild, ViewContainerRef } from "@angular/core";
+
+import { ModalService } from "jslib-angular/services/modal.service";
+import { ApiService } from "jslib-common/abstractions/api.service";
+import { KeyConnectorService } from "jslib-common/abstractions/keyConnector.service";
+import { StateService } from "jslib-common/abstractions/state.service";
+
+import { ApiKeyComponent } from "./api-key.component";
+
+@Component({
+  selector: "app-security-keys",
+  templateUrl: "security-keys.component.html",
+})
+export class SecurityKeysComponent implements OnInit {
+  @ViewChild("viewUserApiKeyTemplate", { read: ViewContainerRef, static: true })
+  viewUserApiKeyModalRef: ViewContainerRef;
+  @ViewChild("rotateUserApiKeyTemplate", { read: ViewContainerRef, static: true })
+  rotateUserApiKeyModalRef: ViewContainerRef;
+
+  showChangeKdf = true;
+
+  constructor(
+    private keyConnectorService: KeyConnectorService,
+    private stateService: StateService,
+    private modalService: ModalService,
+    private apiService: ApiService
+  ) {}
+
+  async ngOnInit() {
+    this.showChangeKdf = !(await this.keyConnectorService.getUsesKeyConnector());
+  }
+
+  async viewUserApiKey() {
+    const entityId = await this.stateService.getUserId();
+    await this.modalService.openViewRef(ApiKeyComponent, this.viewUserApiKeyModalRef, (comp) => {
+      comp.keyType = "user";
+      comp.entityId = entityId;
+      comp.postKey = this.apiService.postUserApiKey.bind(this.apiService);
+      comp.scope = "api";
+      comp.grantType = "client_credentials";
+      comp.apiKeyTitle = "apiKey";
+      comp.apiKeyWarning = "userApiKeyWarning";
+      comp.apiKeyDescription = "userApiKeyDesc";
+    });
+  }
+
+  async rotateUserApiKey() {
+    const entityId = await this.stateService.getUserId();
+    await this.modalService.openViewRef(ApiKeyComponent, this.rotateUserApiKeyModalRef, (comp) => {
+      comp.keyType = "user";
+      comp.isRotation = true;
+      comp.entityId = entityId;
+      comp.postKey = this.apiService.postUserRotateApiKey.bind(this.apiService);
+      comp.scope = "api";
+      comp.grantType = "client_credentials";
+      comp.apiKeyTitle = "apiKey";
+      comp.apiKeyWarning = "userApiKeyWarning";
+      comp.apiKeyDescription = "apiKeyRotateDesc";
+    });
+  }
+}

--- a/src/app/settings/security.component.html
+++ b/src/app/settings/security.component.html
@@ -1,0 +1,22 @@
+<div class="tabbed-nav d-flex flex-column">
+  <ul class="nav nav-tabs">
+    <ng-container *ngIf="showChangePassword">
+      <li class="nav-item">
+        <a class="nav-link" routerLink="change-password" routerLinkActive="active">
+          {{ "masterPassword" | i18n }}
+        </a>
+      </li>
+    </ng-container>
+    <li class="nav-item">
+      <a class="nav-link" routerLink="two-factor" routerLinkActive="active">
+        {{ "twoStepLogin" | i18n }}
+      </a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" routerLink="security-keys" routerLinkActive="active">
+        {{ "keys" | i18n }}
+      </a>
+    </li>
+  </ul>
+</div>
+<router-outlet></router-outlet>

--- a/src/app/settings/security.component.ts
+++ b/src/app/settings/security.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+
+import { KeyConnectorService } from "jslib-common/abstractions/keyConnector.service";
+
+@Component({
+  selector: "app-security",
+  templateUrl: "security.component.html",
+})
+export class SecurityComponent implements OnInit {
+  showChangePassword = true;
+
+  constructor(
+    private keyConnectorService: KeyConnectorService,
+    private router: Router,
+    private route: ActivatedRoute
+  ) {}
+
+  async ngOnInit() {
+    this.showChangePassword = !(await this.keyConnectorService.getUsesKeyConnector());
+    if (!this.showChangePassword) {
+      this.router.navigate(["/settings/security/two-factor"]);
+    }
+  }
+}

--- a/src/app/settings/security.component.ts
+++ b/src/app/settings/security.component.ts
@@ -12,6 +12,6 @@ export class SecurityComponent {
   constructor(private keyConnectorService: KeyConnectorService) {}
 
   async ngOnInit() {
-    this.showChangePassword = await this.keyConnectorService.getUsesKeyConnector();
+    this.showChangePassword = !(await this.keyConnectorService.getUsesKeyConnector());
   }
 }

--- a/src/app/settings/security.component.ts
+++ b/src/app/settings/security.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnInit } from "@angular/core";
-import { ActivatedRoute, Router } from "@angular/router";
+import { Component } from "@angular/core";
 
 import { KeyConnectorService } from "jslib-common/abstractions/keyConnector.service";
 
@@ -7,19 +6,12 @@ import { KeyConnectorService } from "jslib-common/abstractions/keyConnector.serv
   selector: "app-security",
   templateUrl: "security.component.html",
 })
-export class SecurityComponent implements OnInit {
+export class SecurityComponent {
   showChangePassword = true;
 
-  constructor(
-    private keyConnectorService: KeyConnectorService,
-    private router: Router,
-    private route: ActivatedRoute
-  ) {}
+  constructor(private keyConnectorService: KeyConnectorService) {}
 
   async ngOnInit() {
-    this.showChangePassword = !(await this.keyConnectorService.getUsesKeyConnector());
-    if (!this.showChangePassword) {
-      this.router.navigate(["/settings/security/two-factor"]);
-    }
+    this.showChangePassword = await this.keyConnectorService.getUsesKeyConnector();
   }
 }

--- a/src/app/settings/security.module.ts
+++ b/src/app/settings/security.module.ts
@@ -1,0 +1,39 @@
+import { NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+
+import { ChangePasswordComponent } from "./change-password.component";
+import { SecurityKeysComponent } from "./security-keys.component";
+import { SecurityComponent } from "./security.component";
+import { TwoFactorSetupComponent } from "./two-factor-setup.component";
+
+const routes: Routes = [
+  {
+    path: "",
+    component: SecurityComponent,
+    data: { titleId: "security" },
+    children: [
+      { path: "", pathMatch: "full", redirectTo: "change-password" },
+      {
+        path: "change-password",
+        component: ChangePasswordComponent,
+        data: { titleId: "masterPassword" },
+      },
+      {
+        path: "two-factor",
+        component: TwoFactorSetupComponent,
+        data: { titleId: "twoStepLogin" },
+      },
+      {
+        path: "security-keys",
+        component: SecurityKeysComponent,
+        data: { titleId: "keys" },
+      },
+    ],
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class SecurityModule {}

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -7,6 +7,9 @@
           <a routerLink="account" class="list-group-item" routerLinkActive="active">
             {{ "myAccount" | i18n }}
           </a>
+          <a routerLink="security" class="list-group-item" routerLinkActive="active">
+            {{ "security" | i18n }}
+          </a>
           <a routerLink="preferences" class="list-group-item" routerLinkActive="active">
             {{ "preferences" | i18n }}
           </a>
@@ -36,9 +39,6 @@
             *ngIf="!selfHosted"
           >
             {{ "billing" | i18n }}
-          </a>
-          <a routerLink="two-factor" class="list-group-item" routerLinkActive="active">
-            {{ "twoStepLogin" | i18n }}
           </a>
           <a routerLink="domain-rules" class="list-group-item" routerLinkActive="active">
             {{ "domainRules" | i18n }}

--- a/src/app/settings/two-factor-setup.component.html
+++ b/src/app/settings/two-factor-setup.component.html
@@ -45,8 +45,8 @@
     </div>
     <div class="ml-auto">
       <button
-        type="button"
-        class="btn btn-outline-secondary btn-sm"
+        bit-button
+        buttonType="secondary"
         [disabled]="!canAccessPremium && p.premium"
         (click)="manage(p.type)"
       >

--- a/src/app/settings/two-factor-setup.component.html
+++ b/src/app/settings/two-factor-setup.component.html
@@ -1,4 +1,4 @@
-<div class="page-header">
+<div class="tabbed-header">
   <h1>{{ "twoStepLogin" | i18n }}</h1>
 </div>
 <p *ngIf="!organizationId">{{ "twoStepLoginDesc" | i18n }}</p>

--- a/src/app/settings/two-factor-setup.component.html
+++ b/src/app/settings/two-factor-setup.component.html
@@ -5,7 +5,7 @@
 <p *ngIf="organizationId">{{ "twoStepLoginOrganizationDesc" | i18n }}</p>
 <app-callout type="warning" *ngIf="!organizationId">
   <p>{{ "twoStepLoginRecoveryWarning" | i18n }}</p>
-  <button type="button" class="btn btn-outline-secondary" (click)="recoveryCode()">
+  <button bit-button buttonType="secondary" (click)="recoveryCode()">
     {{ "viewRecoveryCode" | i18n }}
   </button>
 </app-callout>
@@ -44,6 +44,7 @@
       {{ p.description }}
     </div>
     <div class="ml-auto">
+      <!--TODO Update Component Library with size element-->
       <button
         type="button"
         class="btn btn-outline-secondary btn-sm"

--- a/src/app/settings/two-factor-setup.component.html
+++ b/src/app/settings/two-factor-setup.component.html
@@ -3,12 +3,12 @@
 </div>
 <p *ngIf="!organizationId">{{ "twoStepLoginDesc" | i18n }}</p>
 <p *ngIf="organizationId">{{ "twoStepLoginOrganizationDesc" | i18n }}</p>
-<app-callout type="warning" *ngIf="!organizationId">
+<bit-callout type="warning" *ngIf="!organizationId">
   <p>{{ "twoStepLoginRecoveryWarning" | i18n }}</p>
   <button bit-button buttonType="secondary" (click)="recoveryCode()">
     {{ "viewRecoveryCode" | i18n }}
   </button>
-</app-callout>
+</bit-callout>
 <h2 [ngClass]="{ 'mt-5': !organizationId }">
   {{ "providers" | i18n }}
   <small *ngIf="loading">
@@ -20,9 +20,9 @@
     <span class="sr-only">{{ "loading" | i18n }}</span>
   </small>
 </h2>
-<app-callout type="warning" *ngIf="showPolicyWarning">
+<bit-callout type="warning" *ngIf="showPolicyWarning">
   {{ "twoStepLoginPolicyUserWarning" | i18n }}
-</app-callout>
+</bit-callout>
 <ul class="list-group list-group-2fa">
   <li *ngFor="let p of providers" class="list-group-item d-flex align-items-center">
     <div class="logo-2fa d-flex justify-content-center">

--- a/src/app/settings/two-factor-setup.component.html
+++ b/src/app/settings/two-factor-setup.component.html
@@ -44,7 +44,6 @@
       {{ p.description }}
     </div>
     <div class="ml-auto">
-      <!--TODO Update Component Library with size element-->
       <button
         type="button"
         class="btn btn-outline-secondary btn-sm"

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -4829,5 +4829,14 @@
         "example": "My Org Name"
       }
     }
+  },
+  "masterPassword": {
+    "message": "Master Password"
+  },
+  "security": {
+    "message": "Security"
+  },
+  "keys": {
+    "message": "Keys"
   }
 }

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -39,7 +39,8 @@ body {
 }
 
 .page-header,
-.secondary-header {
+.secondary-header,
+.tabbed-header {
   margin-bottom: 0.5rem;
   padding-bottom: 0.6rem;
   @include themify($themes) {
@@ -62,6 +63,11 @@ body {
 .secondary-header,
 .spaced-header {
   margin-top: 4rem;
+}
+
+.tabbed-header {
+  margin-top: 2rem;
+  margin-bottom: 1rem;
 }
 
 img.logo {

--- a/src/scss/navigation.scss
+++ b/src/scss/navigation.scss
@@ -74,6 +74,27 @@
     height: 100%;
   }
 
+  .org-name {
+    line-height: 1;
+    span {
+      display: block;
+      font-size: $font-size-lg;
+      @include themify($themes) {
+        color: themed("textHeadingColor");
+      }
+    }
+  }
+}
+
+.tabbed-nav {
+  @include themify($themes) {
+    border-bottom: 1px solid themed("borderColor");
+    color: themed("textColor");
+  }
+}
+
+.org-nav,
+.tabbed-nav {
   .nav-tabs {
     border-bottom: none;
 
@@ -90,6 +111,7 @@
         padding-top: calc(#{$nav-link-padding-y} - 2px);
         @include themify($themes) {
           border-top: 3px solid themed("primary");
+          border-bottom: 1px solid themed("backgroundColor");
           color: themed("linkColor");
         }
       }
@@ -98,17 +120,6 @@
         @include themify($themes) {
           color: themed("inputDisabledColor");
         }
-      }
-    }
-  }
-
-  .org-name {
-    line-height: 1;
-    span {
-      display: block;
-      font-size: $font-size-lg;
-      @include themify($themes) {
-        color: themed("textHeadingColor");
       }
     }
   }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Remove `Change Password` `KDF Encryption` and `API Key` out of the `Account` sub-page
> Remove `Two-Factor Login` sub-page
> Create `Security` sub-page with tabbed header for each of the remove components
> SG-40

## Code changes
- **oss-routing.module.ts**: Added new `Security` sub-page and all child routes
- **oss.module.ts**: Added new `SecurityComponent` and `SecurityKeysComponent`
- **account.component.html**: Removed all components that were migrated to new sub-page
- **account.component.ts**: Removed all pieces of code that were migrated to new sub-page
- **change-kdf.component.html**: Added header to the base component - this is only used in one place
- **change-password.component.html**: Added header to the base component - this is only used in one place
- **security-keys.component.html**: Migrated UI components for `KDF` and `API keys`
- **security-keys.component.ts**: Migrated variables/logic for `KDF` and `API Keys`
- **security.component.html**: Created tabs and router outlet for active components
- **security.component.ts**: Migrated variables/logic for `change-password` tab. Added fallback route if the tab is unavailable
- **settings.component.html**: Added `Security` list option. Removed `Two-Factor Login` list option.
- **two-factor-setup.component.html**: Updated header margin with `tabbed-header` class
- **messages.json**: Added new strings
- **base.scss**: Added header related classes
- **navigation.scss**: Added `tabbed-header` class which resembles the existing `org-nav`. Separated header styles and reused `nav-tab` override to match desired style.

## Screenshots
<img width="1032" alt="2-security-mp" src="https://user-images.githubusercontent.com/26154748/157810659-8b933d1b-0025-4239-a8f3-4f9cbdee0f51.png">
<img width="1032" alt="3-security-2fa" src="https://user-images.githubusercontent.com/26154748/157810662-a2149fb3-2016-44c5-afb3-17ff80463d8e.png">
<img width="1032" alt="4-security-keys" src="https://user-images.githubusercontent.com/26154748/157810664-2b3e1031-727d-48f5-8ff1-c132b49c832c.png">

## Testing requirements
- Changes match the provided Figma wireframes

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
