### PR TITLE
[EC-115] Restore order of ngModule imports

### DIFF
--- a/bitwarden_license/src/app/app.module.ts
+++ b/bitwarden_license/src/app/app.module.ts
@@ -19,17 +19,17 @@ import { MaximumVaultTimeoutPolicyComponent } from "./policies/maximum-vault-tim
 
 @NgModule({
   imports: [
-    AppRoutingModule,
-    BrowserAnimationsModule,
-    DragDropModule,
-    FormsModule,
-    InfiniteScrollModule,
     JslibModule,
-    OrganizationsModule,
-    OssRoutingModule,
+    BrowserAnimationsModule,
+    FormsModule,
     ReactiveFormsModule,
-    RouterModule,
     ServicesModule,
+    InfiniteScrollModule,
+    DragDropModule,
+    AppRoutingModule,
+    OssRoutingModule,
+    OrganizationsModule, // Must be after OssRoutingModule for competing routes to resolve properly
+    RouterModule,
     WildcardRoutingModule, // Needs to be last to catch all non-existing routes
   ],
   declarations: [


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
In https://github.com/bitwarden/web/pull/1556, I ordered the `ngModules` imports array alphabetically, because that seemed like a nice thing to do.

As it turns out, this matters for route definitions. The effect was that the `bitwarden_license` organization routes were promoted above the `oss-routing.module` routes, and it broke navigation in the org component.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

**bitwarden_license/src/app/app.module.ts** - put the `OrganizationsModule` import after `OssRoutingModule`. For good measure, return the order of these imports to their previous ordering as much as possible. Add comment.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
Make sure that navigation through organization pages works as expected, also navigation through the app generally.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
