### PR TITLE
inactive-2fa: search subdomains

### DIFF
--- a/src/app/tools/inactive-two-factor-report.component.ts
+++ b/src/app/tools/inactive-two-factor-report.component.ts
@@ -63,11 +63,17 @@ export class InactiveTwoFactorReportComponent extends CipherReportComponent impl
           if (u.uri != null && u.uri !== "") {
             const uri = u.uri.replace("www.", "");
             const domain = Utils.getDomain(uri);
-            if (domain != null && this.services.has(domain)) {
-              if (this.services.get(domain) != null) {
-                docs.set(c.id, this.services.get(domain));
+            const labels = domain.split(".");
+            for (let j = labels.length; j > 1; j--) {
+              const d = labels.join(".");
+              if (d != "" && this.services.has(d)) {
+                if (this.services.get(d) != null) {
+                  docs.set(c.id, this.services.get(d));
+                }
+                inactive2faCiphers.push(c);
+                break;
               }
-              inactive2faCiphers.push(c);
+              labels.shift();
             }
           }
         }


### PR DESCRIPTION
## Type of change

[X ] Other (general improvement)

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

This improves Inactive 2FA reporting by checking subdomains of cipher URIs.

The 2fa.directory package uses simple string comparisons, and it is not obvious to users that this can create false negatives.

Currently the platform removes `www.` from hosts, but this is not sufficient. Many sites use `login`, `auth`, `id`, etc for subdomains handling authentication. These URIs are imported from browsers.

These URIs will never match. 

I submitted a [feature request](https://community.bitwarden.com/t/inactive-2fa-report-and-subdomains/39459/2) on this topic earlier this week.

## Code changes

After potentially removing `www.` from the uri, split into labels.

Join labels and search for 2fa match.

If nothing matches, shift labels and loop.

When a single label is left, e.g. `com`, exit loop.

Also, I added a break if the cipher has a match. No need to keep searching.

## Testing requirements

Run reports against ciphers with subdomains lacking 2fa. For example, the URI `https://app.hubspot.com` will be a false negative. With this change the report will match.

## Before you submit

- [x ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
