### PR TITLE
Add DatePipe to providers in routing module

### DIFF
--- a/src/app/oss-routing.module.ts
+++ b/src/app/oss-routing.module.ts
@@ -1,3 +1,4 @@
+import { DatePipe } from "@angular/common";
 import { NgModule } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router";
 
@@ -473,5 +474,6 @@ const routes: Routes = [
     }),
   ],
   exports: [RouterModule],
+  providers: [DatePipe],
 })
 export class OssRoutingModule {}


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Fixes: https://bitwarden.atlassian.net/browse/PS-141

Add DatePipe to routing module. When creating a send, it opens a popup to the SendComponent. The main app module had it as a provider, but it was not getting it as a provider when routed to. 

## Code changes

- **src/app/oss-routing.module.ts:** Add Date Pipe as provider
## Testing requirements

Make sure creating sends works

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
