### PR TITLE
Feature/do not allow f4e to offering email

### DIFF
--- a/src/app/settings/sponsored-families.component.ts
+++ b/src/app/settings/sponsored-families.component.ts
@@ -1,9 +1,11 @@
 import { Component, OnInit } from "@angular/core";
 
+import { ValidationService } from "jslib-angular/services/validation.service";
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { OrganizationService } from "jslib-common/abstractions/organization.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
+import { StateService } from "jslib-common/abstractions/state.service";
 import { SyncService } from "jslib-common/abstractions/sync.service";
 import { PlanSponsorshipType } from "jslib-common/enums/planSponsorshipType";
 import { Organization } from "jslib-common/models/domain/organization";
@@ -19,6 +21,7 @@ export class SponsoredFamiliesComponent implements OnInit {
   activeSponsorshipOrgs: Organization[] = [];
   selectedSponsorshipOrgId = "";
   sponsorshipEmail = "";
+  currentUserEmail: string;
 
   // Conditional display properties
   formPromise: Promise<any>;
@@ -28,7 +31,9 @@ export class SponsoredFamiliesComponent implements OnInit {
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,
     private syncService: SyncService,
-    private organizationService: OrganizationService
+    private organizationService: OrganizationService,
+    private validationService: ValidationService,
+    private stateService: StateService
   ) {}
 
   async ngOnInit() {
@@ -36,6 +41,11 @@ export class SponsoredFamiliesComponent implements OnInit {
   }
 
   async submit() {
+    if (this.currentUserEmail.toLowerCase() === this.sponsorshipEmail.toLowerCase()) {
+      this.validationService.showError(this.i18nService.t("cannotSponsorSelf"));
+      return;
+    }
+
     this.formPromise = this.apiService.postCreateSponsorship(this.selectedSponsorshipOrgId, {
       sponsoredEmail: this.sponsorshipEmail,
       planSponsorshipType: PlanSponsorshipType.FamiliesForEnterprise,
@@ -53,8 +63,10 @@ export class SponsoredFamiliesComponent implements OnInit {
     if (this.loading) {
       return;
     }
-
     this.loading = true;
+
+    this.currentUserEmail = await this.stateService.getEmail();
+
     if (forceReload) {
       await this.syncService.fullSync(true);
     }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -4622,6 +4622,9 @@
   "recipient": {
     "message": "Recipient"
   },
+  "cannotSponsorSelf": {
+    "message": "Cannot send a sponsorship offer to your enterprise account."
+  },
   "removeSponsorship": {
     "message": "Remove Sponsorship"
   },


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Jira ticket: https://bitwarden.atlassian.net/browse/PS-4

Block organization sponsorships from going to the enterprise account email. The idea is that enterprise accounts are owned by the enterprise and not the user. We should try and block users from tying personal information to them.


## Testing requirements
Test error shown when attempting to sponsor current account. Should not create the sponsorship.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
