### PR TITLE
[euvr] Adjust vault width based on card visibility

### DIFF
--- a/src/app/vault/vault.component.html
+++ b/src/app/vault/vault.component.html
@@ -14,7 +14,7 @@
       >
       </app-vault-groupings>
     </div>
-    <div class="col-6">
+    <div [ngClass]="{ 'col-6': isShowingCards, 'col-9': !isShowingCards }">
       <div class="page-header d-flex">
         <h1>
           {{ "vaultItems" | i18n }}

--- a/src/app/vault/vault.component.ts
+++ b/src/app/vault/vault.component.ts
@@ -146,6 +146,15 @@ export class VaultComponent implements OnInit, OnDestroy {
     });
   }
 
+  get isShowingCards() {
+    return (
+      this.showBrowserOutdated ||
+      this.showPremiumCallout ||
+      this.showUpdateKey ||
+      this.showVerifyEmail
+    );
+  }
+
   ngOnDestroy() {
     this.broadcasterService.unsubscribe(BroadcasterSubscriptionId);
   }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Allow vault width to expand to fill card area if no cards are visible (.col-9). If cards are visible, set vault width to current width (.col-6)
> SG-30

## Code changes
- **vault.component.html**: Updated div to conditionally change classes based on card visibility
- **vault.component.ts**: Added helper method `isShowingCards` which will enable the vault width to adjust based on the result

## Screenshots
![0-with-cards](https://user-images.githubusercontent.com/26154748/162226436-dea3723a-69c6-4bcd-9113-cc38eb93fe30.png)
![1-without-cards](https://user-images.githubusercontent.com/26154748/162226440-90126881-f995-4e58-8af9-d6459955f7f4.png)

## Testing requirements
- Maintains current width when cards visible
- Expands vault width when no cards visible

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
