### PR TITLE
Use accept flow for families for enterprise

### DIFF
--- a/src/app/organizations/sponsorships/accept-family-sponsorship.component.html
+++ b/src/app/organizations/sponsorships/accept-family-sponsorship.component.html
@@ -1,0 +1,13 @@
+<div class="mt-5 d-flex justify-content-center" *ngIf="loading">
+  <div>
+    <img class="mb-4 logo logo-themed" alt="Bitwarden" />
+    <p class="text-center">
+      <i
+        class="bwi bwi-spinner bwi-spin bwi-2x text-muted"
+        title="{{ 'loading' | i18n }}"
+        aria-hidden="true"
+      ></i>
+      <span class="sr-only">{{ "loading" | i18n }}</span>
+    </p>
+  </div>
+</div>

--- a/src/app/organizations/sponsorships/accept-family-sponsorship.component.ts
+++ b/src/app/organizations/sponsorships/accept-family-sponsorship.component.ts
@@ -1,0 +1,26 @@
+import { Component } from "@angular/core";
+
+import { BaseAcceptComponent } from "src/app/common/base.accept.component";
+
+@Component({
+  selector: "app-accept-family-sponsorship",
+  templateUrl: "accept-family-sponsorship.component.html",
+})
+export class AcceptFamilySponsorshipComponent extends BaseAcceptComponent {
+  failedShortMessage = "inviteAcceptFailedShort";
+  failedMessage = "inviteAcceptFailed";
+
+  requiredParameters = ["email", "token"];
+
+  async authedHandler(qParams: any) {
+    this.router.navigate(["/setup/families-for-enterprise"], { queryParams: qParams });
+  }
+
+  async unauthedHandler(qParams: any) {
+    if (!qParams.register) {
+      this.router.navigate(["/"], { queryParams: { email: qParams.email } });
+    } else {
+      this.router.navigate(["/register"], { queryParams: { email: qParams.email } });
+    }
+  }
+}

--- a/src/app/oss-routing.module.ts
+++ b/src/app/oss-routing.module.ts
@@ -37,6 +37,7 @@ import { OrganizationBillingComponent } from "./organizations/settings/organizat
 import { OrganizationSubscriptionComponent } from "./organizations/settings/organization-subscription.component";
 import { SettingsComponent as OrgSettingsComponent } from "./organizations/settings/settings.component";
 import { TwoFactorSetupComponent as OrgTwoFactorSetupComponent } from "./organizations/settings/two-factor-setup.component";
+import { AcceptFamilySponsorshipComponent } from "./organizations/sponsorships/accept-family-sponsorship.component";
 import { FamiliesForEnterpriseSetupComponent } from "./organizations/sponsorships/families-for-enterprise-setup.component";
 import { ExportComponent as OrgExportComponent } from "./organizations/tools/export.component";
 import { ExposedPasswordsReportComponent as OrgExposedPasswordsReportComponent } from "./organizations/tools/exposed-passwords-report.component";
@@ -122,6 +123,11 @@ const routes: Routes = [
         path: "accept-emergency",
         component: AcceptEmergencyComponent,
         data: { titleId: "acceptEmergency", doNotSaveUrl: false },
+      },
+      {
+        path: "accept-families-for-enterprise",
+        component: AcceptFamilySponsorshipComponent,
+        data: { titleId: "acceptFamilySponsorship", doNotSaveUrl: false },
       },
       { path: "recover", pathMatch: "full", redirectTo: "recover-2fa" },
       {

--- a/src/app/oss.module.ts
+++ b/src/app/oss.module.ts
@@ -122,6 +122,7 @@ import { OrganizationBillingComponent } from "./organizations/settings/organizat
 import { OrganizationSubscriptionComponent } from "./organizations/settings/organization-subscription.component";
 import { SettingsComponent as OrgSettingComponent } from "./organizations/settings/settings.component";
 import { TwoFactorSetupComponent as OrgTwoFactorSetupComponent } from "./organizations/settings/two-factor-setup.component";
+import { AcceptFamilySponsorshipComponent } from "./organizations/sponsorships/accept-family-sponsorship.component";
 import { FamiliesForEnterpriseSetupComponent } from "./organizations/sponsorships/families-for-enterprise-setup.component";
 import { ExportComponent as OrgExportComponent } from "./organizations/tools/export.component";
 import { ExposedPasswordsReportComponent as OrgExposedPasswordsReportComponent } from "./organizations/tools/exposed-passwords-report.component";
@@ -283,6 +284,7 @@ registerLocaleData(localeZhTw, "zh-TW");
   declarations: [
     PremiumBadgeComponent,
     AcceptEmergencyComponent,
+    AcceptFamilySponsorshipComponent,
     AcceptOrganizationComponent,
     AccessComponent,
     AccountComponent,


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Add in an accept-style flow for families for enterprise. This PR doesn't remove the existing param-based navigation for existing offer emails. We can update Server whenever we want to use this flow instead and then determine when we want to remove the parameter-based flow.

## Code changes
- **accept-familiy-sponsorship.component.html**: Just a spinner component. This page immediately redirects to login, so this shouldn't be visible
- **accpet-familiy-sponsorship.comonent.ts**: `BaseAcceptComponent` redirect to families for enterprise setup and login/register (for unauthed sessions)
- **oss-rounting.module**: Add in accept path to routes
- **oss.module**: Register accept family sponsorship comonent


## Testing requirements
* Validate that redemption of f4e works as expected both with existing url and by navigating to
```
{WebVaultUrl}/#/accept-family-sponsorship?token={token}&email={email}
```
* Also confirm register flow by navigating to 
```{WebVaultUrl}/#/accept-family-sponsorship?token={token}&email={email}```

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
