### PR TITLE
[EC-165] Add aria labels to password gen options

### DIFF
--- a/src/app/tools/generator.component.html
+++ b/src/app/tools/generator.component.html
@@ -161,6 +161,7 @@
           (change)="savePasswordOptions()"
           [(ngModel)]="passwordOptions.uppercase"
           [disabled]="enforcedPasswordPolicyOptions?.useUppercase"
+          attr.aria-label="{{ 'uppercase' | i18n }}"
         />
         <label for="uppercase" class="form-check-label">A-Z</label>
       </div>
@@ -172,6 +173,7 @@
           (change)="savePasswordOptions()"
           [(ngModel)]="passwordOptions.lowercase"
           [disabled]="enforcedPasswordPolicyOptions?.useLowercase"
+          attr.aria-label="{{ 'lowercase' | i18n }}"
         />
         <label for="lowercase" class="form-check-label">a-z</label>
       </div>
@@ -183,6 +185,7 @@
           (change)="savePasswordOptions()"
           [(ngModel)]="passwordOptions.number"
           [disabled]="enforcedPasswordPolicyOptions?.useNumbers"
+          attr.aria-label="{{ 'numbers' | i18n }}"
         />
         <label for="numbers" class="form-check-label">0-9</label>
       </div>
@@ -194,6 +197,7 @@
           (change)="savePasswordOptions()"
           [(ngModel)]="passwordOptions.special"
           [disabled]="enforcedPasswordPolicyOptions?.useSpecial"
+          attr.aria-label="{{ 'specialCharacters' | i18n }}"
         />
         <label for="special" class="form-check-label">!@#$%^&amp;*</label>
       </div>

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -891,6 +891,18 @@
   "length": {
     "message": "Length"
   },
+  "uppercase": {
+    "message": "Uppercase (A-Z)"
+  },
+  "lowercase": {
+    "message": "Lowercase (a-z)"
+  },
+  "numbers": {
+    "message": "Numbers (0-9)"
+  },
+  "specialCharacters": {
+    "message": "Special Characters (!@#$%^&*)"
+  }, 
   "numWords": {
     "message": "Number of Words"
   },


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

As mentioned by @patrickhlauke on https://github.com/bitwarden/desktop/issues/1460#issuecomment-1106574103 the fixes on other clients are missing in the web vault.

Currently, the labels for the `A-Z`, `a-z`, `0-9`, `!@#$%^&*` fields in the password generator are difficult to work out/cryptic for assistive technology users: `A-Z` and `a-z` are announced by screen readers exactly the same, and the `!@#$%^&*` is announced as "at number dollar percent and star" (as screen readers will, by default, not announce some of those punctuation marks when presented like that as a nonsensical string in particular). This PR adds new `aria-label` attributes for the checkboxes to provide a more human-understandable accessible name for each of these checkboxes to make them understandable.

This is a port of https://github.com/bitwarden/desktop/pull/1461

## Code changes

- **src/app/tools/generator.component.html:** Add aria labels to announce to the password gen checkbox options
- **src/locales/en/messages.json:** Strtings used for announcing checkbox label

## Testing requirements

Test with a screen reader (e.g. NVDA). Set focus to the checkboxes and note how they are announced.

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
