### PR TITLE
[PS-381] Fix locale being empty when not configuring a language

### DIFF
--- a/src/app/settings/options.component.ts
+++ b/src/app/settings/options.component.ts
@@ -74,7 +74,7 @@ export class OptionsComponent implements OnInit {
     this.enableGravatars = await this.stateService.getEnableGravitars();
     this.enableFullWidth = await this.stateService.getEnableFullWidth();
 
-    this.locale = await this.stateService.getLocale();
+    this.locale = (await this.stateService.getLocale()) ?? null;
     this.startingLocale = this.locale;
 
     this.theme = await this.stateService.getTheme();


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Resolves an issue where the locale dropdown would default to blank.

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Verify the locale dropdown is not empty in private mode. And the content saves correctly.

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
