### PR TITLE
[SG-224] [EUVR] Fix organization options menu loading crash

### DIFF
--- a/src/app/modules/vault-filter/components/organization-options.component.html
+++ b/src/app/modules/vault-filter/components/organization-options.component.html
@@ -1,4 +1,12 @@
-<div class="tw-max-w-[300px] tw-min-w-[200px] tw-flex tw-flex-col">
+<ng-container *ngIf="!loaded">
+  <i
+    class="bwi bwi-spinner bwi-spin text-muted tw-m-2"
+    title="{{ 'loading' | i18n }}"
+    aria-hidden="true"
+  ></i>
+  <span class="sr-only">{{ "loading" | i18n }}</span>
+</ng-container>
+<div *ngIf="loaded" class="tw-max-w-[300px] tw-min-w-[200px] tw-flex tw-flex-col">
   <button
     *ngIf="allowEnrollmentChanges(organization) && !organization.resetPasswordEnrolled"
     class="dropdown-item"


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Using the org filters currently crashes the browser through infinite error messages:

https://user-images.githubusercontent.com/31796059/166624738-388283e4-11eb-4519-943c-c6da6b695f6c.mov

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

This is caused by `organization-options.component` rendering content before finishing its `load` method. Add an `*ngIf` to delay rendering, plus a spinner so we show something in the meantime.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
Here's how it behaves with a simulated 2000ms loading time:

https://user-images.githubusercontent.com/31796059/166624929-0a6708c6-26b6-440d-93ae-609af889cb2c.mov

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
