### PR TITLE
[EC-189] Resolve password reprompt not appearing on linkable cipher

### DIFF
--- a/src/app/organizations/vault/vault.component.ts
+++ b/src/app/organizations/vault/vault.component.ts
@@ -16,6 +16,7 @@ import { CipherService } from "jslib-common/abstractions/cipher.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { MessagingService } from "jslib-common/abstractions/messaging.service";
 import { OrganizationService } from "jslib-common/abstractions/organization.service";
+import { PasswordRepromptService } from "jslib-common/abstractions/passwordReprompt.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
 import { SyncService } from "jslib-common/abstractions/sync.service";
 import { CipherType } from "jslib-common/enums/cipherType";
@@ -66,7 +67,8 @@ export class VaultComponent implements OnInit, OnDestroy {
     private broadcasterService: BroadcasterService,
     private ngZone: NgZone,
     private platformUtilsService: PlatformUtilsService,
-    private cipherService: CipherService
+    private cipherService: CipherService,
+    private passwordRepromptService: PasswordRepromptService
   ) {}
 
   ngOnInit() {
@@ -281,6 +283,14 @@ export class VaultComponent implements OnInit, OnDestroy {
   }
 
   async editCipherId(cipherId: string) {
+    const cipher = await this.cipherService.get(cipherId);
+    if (cipher.reprompt != 0) {
+      if (!(await this.passwordRepromptService.showPasswordPrompt())) {
+        this.go({ cipherId: null });
+        return;
+      }
+    }
+
     const [modal, childComponent] = await this.modalService.openViewRef(
       AddEditComponent,
       this.cipherAddEditModalRef,

--- a/src/app/organizations/vault/vault.component.ts
+++ b/src/app/organizations/vault/vault.component.ts
@@ -313,8 +313,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     );
 
     modal.onClosedPromise().then(() => {
-      this.route.params;
-      this.router.navigate([], { queryParams: { cipherId: null }, queryParamsHandling: "merge" });
+      this.go({ cipherId: null });
     });
 
     return childComponent;

--- a/src/app/vault/vault.component.ts
+++ b/src/app/vault/vault.component.ts
@@ -389,7 +389,6 @@ export class VaultComponent implements OnInit, OnDestroy {
     );
 
     modal.onClosedPromise().then(() => {
-      this.route.params;
       this.go({ cipherId: null });
     });
 

--- a/src/app/vault/vault.component.ts
+++ b/src/app/vault/vault.component.ts
@@ -17,6 +17,7 @@ import { CryptoService } from "jslib-common/abstractions/crypto.service";
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { MessagingService } from "jslib-common/abstractions/messaging.service";
 import { OrganizationService } from "jslib-common/abstractions/organization.service";
+import { PasswordRepromptService } from "jslib-common/abstractions/passwordReprompt.service";
 import { PlatformUtilsService } from "jslib-common/abstractions/platformUtils.service";
 import { ProviderService } from "jslib-common/abstractions/provider.service";
 import { StateService } from "jslib-common/abstractions/state.service";
@@ -87,7 +88,8 @@ export class VaultComponent implements OnInit, OnDestroy {
     private stateService: StateService,
     private organizationService: OrganizationService,
     private providerService: ProviderService,
-    private cipherService: CipherService
+    private cipherService: CipherService,
+    private passwordRepromptService: PasswordRepromptService
   ) {}
 
   async ngOnInit() {
@@ -358,6 +360,14 @@ export class VaultComponent implements OnInit, OnDestroy {
   }
 
   async editCipherId(id: string) {
+    const cipher = await this.cipherService.get(id);
+    if (cipher.reprompt != 0) {
+      if (!(await this.passwordRepromptService.showPasswordPrompt())) {
+        this.go({ cipherId: null });
+        return;
+      }
+    }
+
     const [modal, childComponent] = await this.modalService.openViewRef(
       AddEditComponent,
       this.cipherAddEditModalRef,
@@ -380,7 +390,7 @@ export class VaultComponent implements OnInit, OnDestroy {
 
     modal.onClosedPromise().then(() => {
       this.route.params;
-      this.router.navigate([], { queryParams: { cipherId: null }, queryParamsHandling: "merge" });
+      this.go({ cipherId: null });
     });
 
     return childComponent;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The logic for opening ciphers got moved with the #1087. Unfortunately this also meant that the password reprompt logic no longer got triggered. Solved by adding this logic to the new location.

I also noticed that the routing logic for the onClose could be cleaned up slightly.

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Verify the reprompt is shown when attempting to view ciphers.

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
