### PR TITLE
Check for null cipher in edit

### DIFF
--- a/src/app/modules/vault/modules/organization-vault/organization-vault.component.ts
+++ b/src/app/modules/vault/modules/organization-vault/organization-vault.component.ts
@@ -262,7 +262,7 @@ export class OrganizationVaultComponent implements OnInit, OnDestroy {
 
   async editCipherId(cipherId: string) {
     const cipher = await this.cipherService.get(cipherId);
-    if (cipher.reprompt != 0) {
+    if (cipher != null && cipher.reprompt != 0) {
       if (!(await this.passwordRepromptService.showPasswordPrompt())) {
         this.go({ cipherId: null });
         return;


### PR DESCRIPTION
Null ciphers signify a _new_ cipher, so no password repromt is required

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fix inability to add ciphers to org vaults.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
