### PR TITLE
[fix] Add missing Create Org button to filters

### DIFF
--- a/src/app/modules/vault-filter/components/organization-filter.component.html
+++ b/src/app/modules/vault-filter/components/organization-filter.component.html
@@ -10,6 +10,14 @@
             </button>
           </span>
         </li>
+        <li class="filter-option">
+          <span class="filter-buttons">
+            <a href="#" routerLink="/settings/create-organization" class="filter-button">
+              <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
+              {{ "newOrganization" | i18n }}
+            </a>
+          </span>
+        </li>
       </ul>
     </ng-container>
     <ng-container *ngSwitchCase="'personalOwnershipPolicy'">

--- a/src/scss/vault-filters.scss
+++ b/src/scss/vault-filters.scss
@@ -95,7 +95,8 @@
   display: flex;
   align-items: center;
 
-  button {
+  button,
+  a {
     @extend .no-btn;
   }
 
@@ -115,6 +116,7 @@
       @include themify($themes) {
         color: themed("linkColor") !important;
       }
+      text-decoration: none;
     }
   }
 


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-231

This will be cherry-picked to `rc`

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Part of the End User Vault Refresh initiative is to add a "New Organization" link to the bottom of the organization filter options that redirects to the form for creating an organization. This was left out of the initial implementation, and is being added here.

## Code changes
Add the missing link, and use the same styles used by filter buttons.

## Screenshots
![Screen Shot 2022-05-09 at 6 36 47 PM](https://user-images.githubusercontent.com/15897251/167509795-50ef8bad-3dcf-4b7a-bba2-399d067a2c8a.png)

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
