### PR TITLE
[fix] Remove an extra sync call

### DIFF
--- a/src/app/modules/vault-filter/components/organization-options.component.ts
+++ b/src/app/modules/vault-filter/components/organization-options.component.ts
@@ -35,7 +35,6 @@ export class OrganizationOptionsComponent {
   ) {}
 
   async ngOnInit() {
-    await this.syncService.fullSync(true);
     await this.load();
   }
 


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-255

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When clicking on an organization filter a ton of sync requests are sent until requests start being rejected by the server. This is because there is a sync call in organization options, and syncComplete handler in the vault component that triggers it, resulting in a loop of sync -> syncComplete -> sync.

## Code changes
- Remove the sync call from the `OrganizationOptionsComponent`. It is believed this was added in error, and does not appear to be needed here.

## Screenshots
Observe that there is no network activity when toggling organization filters: 

https://user-images.githubusercontent.com/15897251/167666815-e28cc643-89a8-4e9a-889d-0326dbdf89b3.mov

## Before you submit

- [] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
