### PR TITLE
[bug:euvr] Self-hosted instance hiding subscription nav item

### DIFF
--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -54,7 +54,11 @@ export class SettingsComponent implements OnInit, OnDestroy {
     this.premium = await this.tokenService.getPremium();
     this.hasFamilySponsorshipAvailable = await this.organizationService.canManageSponsorships();
     const hasPremiumFromOrg = await this.stateService.getCanAccessPremium();
-    const billing = await this.apiService.getUserBillingHistory();
-    this.hideSubscription = !this.premium && hasPremiumFromOrg && billing.hasNoHistory;
+    let billing = null;
+    if (!this.selfHosted) {
+      billing = await this.apiService.getUserBillingHistory();
+    }
+    this.hideSubscription =
+      !this.premium && hasPremiumFromOrg && (this.selfHosted || billing?.hasNoHistory);
   }
 }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Fix issue where a self-hosted instance was **not** hiding the subscription menu item when the proper conditions were met.
> SG-281
> Will 🍒 ⛏️  to `rc`

## Code changes
- **settings.component.ts**: Self-hosted instances cannot call the new APIs for billing history. This matches the previous pattern established and adds a bypass to the API if the application is self-hosted.

## Screenshots
<img width="1101" alt="12-self-host-from-org" src="https://user-images.githubusercontent.com/26154748/167953869-fddbb688-37fe-4298-adab-5f0c159efdbf.png">

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
