### PR TITLE
[SG-265] Revert accidental nesting of organization routes

### DIFF
--- a/src/app/organizations/layouts/organization-layout.component.html
+++ b/src/app/organizations/layouts/organization-layout.component.html
@@ -1,3 +1,4 @@
+<app-navbar></app-navbar>
 <div class="org-nav" *ngIf="organization">
   <div class="container d-flex">
     <div class="d-flex flex-column">
@@ -35,3 +36,4 @@
   </div>
 </div>
 <router-outlet></router-outlet>
+<app-footer></app-footer>

--- a/src/app/oss-routing.module.ts
+++ b/src/app/oss-routing.module.ts
@@ -229,14 +229,14 @@ const routes: Routes = [
           (await import("./reports/reports-routing.module")).ReportsRoutingModule,
       },
       { path: "setup/families-for-enterprise", component: FamiliesForEnterpriseSetupComponent },
-      {
-        path: "organizations",
-        loadChildren: () =>
-          import("./organizations/organization-routing.module").then(
-            (m) => m.OrganizationsRoutingModule
-          ),
-      },
     ],
+  },
+  {
+    path: "organizations",
+    loadChildren: () =>
+      import("./organizations/organization-routing.module").then(
+        (m) => m.OrganizationsRoutingModule
+      ),
   },
 ];
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix:
> Manage SSO page is missing the navbar and footer

In my organization route changes, I accidentally moved the `OrganizationLayoutComponent` route under the `UserLayoutComponent` route. Then I noticed that I had double navbars and footers, so I removed them from `OrganizationLayoutComponent`. This was all unnecessary, and also broke the routing in the `bitwarden_license` project, which needs to shadow the same routing structure.


Will be picked to `rc`.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Revert these changes by:
* un-nesting the org routes
* re-adding the navbar and footer components

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
