### PR TITLE
Link to correct doc for Org User Types

### DIFF
--- a/src/app/organizations/manage/user-add-edit.component.html
+++ b/src/app/organizations/manage/user-add-edit.component.html
@@ -52,7 +52,7 @@
             target="_blank"
             rel="noopener"
             appA11yTitle="{{ 'learnMore' | i18n }}"
-            href="https://bitwarden.com/help/provider-users/"
+            href="https://bitwarden.com/help/user-types-access-control/"
           >
             <i class="bwi bwi-question-circle" aria-hidden="true"></i>
           </a>


### PR DESCRIPTION
Help center document linked is for the Provider Portal; this modal is for Organization Users. Correcting link to help docs.

## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective

The linked Help Article should be set to the article for Organization Users, not for Provider Users, to provide the correct context

## Code changes

- **user-add-edit.component.html:** Updated help center link

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
