### PR TITLE
[fix] Check policies when reloading organizations for filters

### DIFF
--- a/src/app/modules/vault-filter/vault-filter.component.ts
+++ b/src/app/modules/vault-filter/vault-filter.component.ts
@@ -32,6 +32,10 @@ export class VaultFilterComponent extends BaseVaultFilterComponent {
   // It should be removed as soon as doing so makes sense.
   async reloadOrganizations() {
     this.organizations = await this.vaultFilterService.buildOrganizations();
+    this.activePersonalOwnershipPolicy =
+      await this.vaultFilterService.checkForPersonalOwnershipPolicy();
+    this.activeSingleOrganizationPolicy =
+      await this.vaultFilterService.checkForSingleOrganizationPolicy();
   }
 
   async initCollections() {


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-272
This will be cherry picked to rc

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Continuing to mitigate the issues between the EUVR filters work and our sync behavior, the personalOwnershipPolicy only _sometimes_ hides the "My Vault" filter, when it should hide all the time.

## Code changes
This is because we are rechecking orgs after sync but not checking the policies again. I just added some refresh logic for rechecking policies to the same place we recheck orgs.

## Screenshots
https://user-images.githubusercontent.com/15897251/168332296-500e0a89-1878-4149-9b95-2d9227483cd2.mov

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
