### PR TITLE
[fix] Add max width to vault filter buttons to keep content unified

### DIFF
--- a/src/scss/vault-filters.scss
+++ b/src/scss/vault-filters.scss
@@ -116,6 +116,7 @@
       }
       text-decoration: none;
     }
+    max-width: 90%;
   }
 
   .edit-button {


### PR DESCRIPTION
https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-274

This will be cherry-picked to rc

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Truncated org names are causing a misalignment of the org menu buttons

## Code changes
Keep button alignment in check with a max-width style

## Screenshots
<img width="257" alt="Screen Shot 2022-05-13 at 1 18 56 PM" src="https://user-images.githubusercontent.com/15897251/168335264-3df663ac-6ae8-4c64-a643-a1f44012f3cf.png">

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
