### PR TITLE
Allow all hosts for dev environment

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -3,7 +3,7 @@
     "notifications": "http://localhost:61840"
   },
   "dev": {
-    "allowedHosts": "all",
+    "allowedHosts": "bitwarden.local",
     "proxyApi": "http://localhost:4000",
     "proxyIdentity": "http://localhost:33656",
     "proxyEvents": "http://localhost:46273",

--- a/config/development.json
+++ b/config/development.json
@@ -3,6 +3,7 @@
     "notifications": "http://localhost:61840"
   },
   "dev": {
+    "allowedHosts": "all",
     "proxyApi": "http://localhost:4000",
     "proxyIdentity": "http://localhost:33656",
     "proxyEvents": "http://localhost:46273",


### PR DESCRIPTION
This is needed to enable testing of hCaptcha through a host proxy.

## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective

hCaptcha does not allow execution from localhost (https://docs.hcaptcha.com/#local-development), to remediate, the suggested solution is to make up a non-localhost uri and specify it as a known host on your system. That way we get around these rules. Unfortunately, we now hit incorrect host header issues with our webpack server.

The solution to this new problem is to allow all hosts headers as done here. Given that this is for the development configuration, there should be no risk
## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)