### PR TITLE
[SG-330] Fix switcher not appearing for users affected by single org policy

### DIFF
--- a/src/app/modules/vault-filter/components/organization-filter.component.html
+++ b/src/app/modules/vault-filter/components/organization-filter.component.html
@@ -85,7 +85,7 @@
         </button>
       </div>
     </ng-container>
-    <ng-container *ngSwitchCase="'organizationMember'">
+    <ng-container *ngSwitchDefault>
       <div class="filter-heading">
         <button
           class="toggle-button"
@@ -115,6 +115,7 @@
           routerLink="/create-organization"
           class="text-muted ml-auto create-organization-link"
           appA11yTitle="{{ 'newOrganization' | i18n }}"
+          *ngIf="!(displayMode === 'singleOrganizationPolicy')"
         >
           <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
         </a>


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fix switcher not appearing for users affected by single org policy
This will be cherry picked to rc

## Code changes

- **src/app/modules/vault-filter/components/organization-filter.component.html:** Use same container for single org policy users, minus the New Organization button. 

## Screenshots

User effected by single org policy:

![Screen Shot 2022-05-17 at 8 45 11 AM](https://user-images.githubusercontent.com/8926729/168813889-83bc5e52-f0c7-433e-80f9-e06577d0fbfe.png)

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
