### PR TITLE
[ps-136] Igonre accented characters in vault search

### DIFF
--- a/src/app/modules/vault-filter/vault-filter.component.ts
+++ b/src/app/modules/vault-filter/vault-filter.component.ts
@@ -25,7 +25,7 @@ export class VaultFilterComponent extends BaseVaultFilterComponent {
   }
 
   searchTextChanged() {
-    this.onSearchTextChanged.emit(this.searchText);
+    this.onSearchTextChanged.emit(this.searchText.normalize("NFD").replace(/[\u0300-\u036f]/g, ""));
   }
 
   // This method exists because the vault component gets its data mixed up during the initial sync on first login. It looks for data before the sync is complete.

--- a/src/app/settings/billing-sync-key.component.ts
+++ b/src/app/settings/billing-sync-key.component.ts
@@ -3,7 +3,6 @@ import { Component } from "@angular/core";
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { OrganizationConnectionType } from "jslib-common/enums/organizationConnectionType";
-import { Utils } from "jslib-common/misc/utils";
 import { BillingSyncConfigApi } from "jslib-common/models/api/billingSyncConfigApi";
 import { BillingSyncConfigRequest } from "jslib-common/models/request/billingSyncConfigRequest";
 import { OrganizationConnectionRequest } from "jslib-common/models/request/organizationConnectionRequest";


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Ignore accented characters in vault searches.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes
- **src/app/modules/vault-filter/vault-filter.component.ts:** stripped off accented characters from the search input field.
- **src/app/settings/billing-sync-key.component.ts:** removed unused reference

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->


## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
