### PR TITLE
[fix] Remove function implementation that was moved to jslib

### DIFF
--- a/src/app/modules/vault-filter/vault-filter.component.ts
+++ b/src/app/modules/vault-filter/vault-filter.component.ts
@@ -28,16 +28,6 @@ export class VaultFilterComponent extends BaseVaultFilterComponent {
     this.onSearchTextChanged.emit(this.searchText);
   }
 
-  // This method exists because the vault component gets its data mixed up during the initial sync on first login. It looks for data before the sync is complete.
-  // It should be removed as soon as doing so makes sense.
-  async reloadOrganizations() {
-    this.organizations = await this.vaultFilterService.buildOrganizations();
-    this.activePersonalOwnershipPolicy =
-      await this.vaultFilterService.checkForPersonalOwnershipPolicy();
-    this.activeSingleOrganizationPolicy =
-      await this.vaultFilterService.checkForSingleOrganizationPolicy();
-  }
-
   async initCollections() {
     return await this.vaultFilterService.buildCollections(this.organization?.id);
   }


### PR DESCRIPTION
**https://bitwarden.atlassian.net/jira/software/projects/SG/boards/34?selectedIssue=SG-333**
Depends on https://github.com/bitwarden/jslib/pull/807

## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Remove the function implementation of `VaultFiltersComponent.reloadOrganizations()` that was moved to the base class in jslib.