### PR TITLE
Make spacing match other rows in vault filter

### DIFF
--- a/src/app/modules/vault-filter/components/collection-filter.component.html
+++ b/src/app/modules/vault-filter/components/collection-filter.component.html
@@ -16,7 +16,7 @@
         aria-hidden="true"
       ></i>
     </button>
-    <h3 class="filter-title">{{ collectionsGrouping.name | i18n }}</h3>
+    <h3 class="filter-title">&nbsp;{{ collectionsGrouping.name | i18n }}</h3>
   </div>
   <ul id="collection-filters" *ngIf="!isCollapsed(collectionsGrouping)" class="filter-options">
     <ng-template #recursiveCollections let-collections>

--- a/src/app/modules/vault-filter/components/collection-filter.component.html
+++ b/src/app/modules/vault-filter/components/collection-filter.component.html
@@ -51,7 +51,7 @@
               class="bwi bwi-collection bwi-fw"
               aria-hidden="true"
             ></i
-            >{{ c.node.name }}
+            >&nbsp;{{ c.node.name }}
           </button>
         </span>
         <ul

--- a/src/app/modules/vault-filter/components/folder-filter.component.html
+++ b/src/app/modules/vault-filter/components/folder-filter.component.html
@@ -56,7 +56,7 @@
           </button>
           <button class="filter-button" (click)="applyFilter(f.node)">
             <i *ngIf="f.children.length === 0" class="bwi bwi-fw bwi-folder" aria-hidden="true"></i
-            >{{ f.node.name }}
+            >&nbsp;{{ f.node.name }}
           </button>
           <button
             class="edit-button"

--- a/src/app/modules/vault-filter/components/folder-filter.component.html
+++ b/src/app/modules/vault-filter/components/folder-filter.component.html
@@ -16,9 +16,7 @@
         }"
       ></i>
     </button>
-    <h3 class="filter-title">
-      {{ "folders" | i18n }}
-    </h3>
+    <h3 class="filter-title">&nbsp;{{ "folders" | i18n }}</h3>
     <button
       class="text-muted ml-auto add-button"
       (click)="addFolder()"

--- a/src/app/modules/vault-filter/components/type-filter.component.html
+++ b/src/app/modules/vault-filter/components/type-filter.component.html
@@ -15,9 +15,7 @@
       }"
     ></i>
   </button>
-  <h3>
-    {{ "types" | i18n }}
-  </h3>
+  <h3>&nbsp;{{ "types" | i18n }}</h3>
 </div>
 <ul id="type-filters" *ngIf="!isCollapsed" class="filter-options">
   <li

--- a/src/app/modules/vault-filter/components/type-filter.component.html
+++ b/src/app/modules/vault-filter/components/type-filter.component.html
@@ -26,14 +26,14 @@
   >
     <span class="filter-buttons">
       <button class="filter-button" (click)="applyFilter(cipherTypeEnum.Login)">
-        <i class="bwi bwi-fw bwi-globe" aria-hidden="true"></i>{{ "typeLogin" | i18n }}
+        <i class="bwi bwi-fw bwi-globe" aria-hidden="true"></i>&nbsp;{{ "typeLogin" | i18n }}
       </button>
     </span>
   </li>
   <li class="filter-option" [ngClass]="{ active: activeFilter.cipherType === cipherTypeEnum.Card }">
     <span class="filter-buttons">
       <button class="filter-button" (click)="applyFilter(cipherTypeEnum.Card)">
-        <i class="bwi bwi-fw bwi-credit-card" aria-hidden="true"></i>{{ "typeCard" | i18n }}
+        <i class="bwi bwi-fw bwi-credit-card" aria-hidden="true"></i>&nbsp;{{ "typeCard" | i18n }}
       </button>
     </span>
   </li>
@@ -43,7 +43,7 @@
   >
     <span class="filter-buttons">
       <button class="filter-button" (click)="applyFilter(cipherTypeEnum.Identity)">
-        <i class="bwi bwi-fw bwi-id-card" aria-hidden="true"></i>{{ "typeIdentity" | i18n }}
+        <i class="bwi bwi-fw bwi-id-card" aria-hidden="true"></i>&nbsp;{{ "typeIdentity" | i18n }}
       </button>
     </span>
   </li>
@@ -53,7 +53,9 @@
   >
     <span class="filter-buttons">
       <button class="filter-button" (click)="applyFilter(cipherTypeEnum.SecureNote)">
-        <i class="bwi bwi-fw bwi-sticky-note" aria-hidden="true"></i>{{ "typeSecureNote" | i18n }}
+        <i class="bwi bwi-fw bwi-sticky-note" aria-hidden="true"></i>&nbsp;{{
+          "typeSecureNote" | i18n
+        }}
       </button>
     </span>
   </li>


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fix spacing mismatch on vault filters

## Code changes

Add `&nbsp;` before text in types, folders, and collections

## Screenshots
| Before     | After |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/8926729/169056916-f2651196-f4a3-44bb-8ce5-298e0b1c2e26.png) | ![Screen Shot 2022-05-18 at 10 01 27 AM](https://user-images.githubusercontent.com/8926729/169060090-caf18c59-8845-41b9-b621-43a78a886780.png)

 |



## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
