### PR TITLE
[PS-502] Remove extraneous comma from web vault footer

### DIFF
--- a/src/app/layouts/footer.component.html
+++ b/src/app/layouts/footer.component.html
@@ -1,6 +1,6 @@
 <div class="container footer text-muted">
   <div class="row">
-    <div class="col">&copy; {{ year }}, Bitwarden Inc.</div>
+    <div class="col">&copy; {{ year }} Bitwarden Inc.</div>
     <div class="col text-center"></div>
     <div class="col text-right">
       {{ "versionNumber" | i18n: version }}

--- a/src/app/layouts/frontend-layout.component.html
+++ b/src/app/layouts/frontend-layout.component.html
@@ -1,5 +1,5 @@
 <router-outlet></router-outlet>
 <div class="container my-5 text-muted text-center">
-  &copy; {{ year }}, Bitwarden Inc. <br />
+  &copy; {{ year }} Bitwarden Inc. <br />
   {{ "versionNumber" | i18n: version }}
 </div>


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
In the Bitwarden Web Vault, the footer seems to contain an extraneous comma after the year.

## Code changes
removed comma in both footer files

## Screenshots
**before**:
<img width="410" alt="image" src="https://user-images.githubusercontent.com/4648522/169337140-efc81176-4298-4a13-b7a2-96553568aede.png">
**after**:
<img width="290" alt="image" src="https://user-images.githubusercontent.com/4648522/169337192-8eab8e63-23ef-4da3-b385-57251ba3be76.png">


## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
