### PR TITLE
[SG-345] Switch in-line "+"  add org button to more explicit version

### DIFF
--- a/src/app/modules/vault-filter/components/organization-filter.component.html
+++ b/src/app/modules/vault-filter/components/organization-filter.component.html
@@ -45,14 +45,6 @@
         >
           &nbsp;{{ organizationGrouping.name | i18n }}
         </button>
-        <a
-          href="#"
-          routerLink="/create-organization"
-          class="text-muted ml-auto create-organization-link"
-          appA11yTitle="{{ 'newOrganization' | i18n }}"
-        >
-          <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
-        </a>
       </div>
       <ul id="organization-filters" *ngIf="!isCollapsed" class="filter-options">
         <li
@@ -73,6 +65,14 @@
                 <app-organization-options [organization]="organization"></app-organization-options>
               </bit-menu>
             </ng-container>
+          </span>
+        </li>
+        <li class="filter-option">
+          <span class="filter-buttons">
+            <a href="#" routerLink="/create-organization" class="filter-button">
+              <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
+              {{ "newOrganization" | i18n }}
+            </a>
           </span>
         </li>
       </ul>
@@ -110,15 +110,6 @@
         >
           &nbsp;{{ organizationGrouping.name | i18n }}
         </button>
-        <a
-          href="#"
-          routerLink="/create-organization"
-          class="text-muted ml-auto create-organization-link"
-          appA11yTitle="{{ 'newOrganization' | i18n }}"
-          *ngIf="!(displayMode === 'singleOrganizationPolicy')"
-        >
-          <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
-        </a>
       </div>
       <ul id="organization-filters" *ngIf="!isCollapsed" class="filter-options">
         <li class="filter-option" [ngClass]="{ active: activeFilter.myVaultOnly }">
@@ -147,6 +138,14 @@
                 <app-organization-options [organization]="organization"></app-organization-options>
               </bit-menu>
             </ng-container>
+          </span>
+        </li>
+        <li class="filter-option" *ngIf="!(displayMode === 'singleOrganizationPolicy')">
+          <span class="filter-buttons">
+            <a href="#" routerLink="/create-organization" class="filter-button">
+              <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
+              {{ "newOrganization" | i18n }}
+            </a>
           </span>
         </li>
       </ul>

--- a/src/app/modules/vault-filter/components/organization-filter.component.html
+++ b/src/app/modules/vault-filter/components/organization-filter.component.html
@@ -14,7 +14,7 @@
           <span class="filter-buttons">
             <a href="#" routerLink="/create-organization" class="filter-button">
               <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
-              {{ "newOrganization" | i18n }}
+              &nbsp;{{ "newOrganization" | i18n }}
             </a>
           </span>
         </li>
@@ -71,7 +71,7 @@
           <span class="filter-buttons">
             <a href="#" routerLink="/create-organization" class="filter-button">
               <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
-              {{ "newOrganization" | i18n }}
+              &nbsp;{{ "newOrganization" | i18n }}
             </a>
           </span>
         </li>
@@ -144,7 +144,7 @@
           <span class="filter-buttons">
             <a href="#" routerLink="/create-organization" class="filter-button">
               <i class="bwi bwi-plus bwi-fw" aria-hidden="true"></i>
-              {{ "newOrganization" | i18n }}
+              &nbsp;{{ "newOrganization" | i18n }}
             </a>
           </span>
         </li>

--- a/src/scss/vault-filters.scss
+++ b/src/scss/vault-filters.scss
@@ -14,14 +14,6 @@
     font-size: $font-size-base;
   }
 
-  a.create-organization-link {
-    &:hover {
-      @include themify($themes) {
-        color: themed("iconHover") !important;
-      }
-    }
-  }
-
   button {
     @extend .no-btn;
   }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

There are concerns that the in-line “+” button in the organization filter is not clear enough to understand that means adding an organization, so we are swapping it for the more explicit “+ New Organization“ button that is used for users that do not belong to an org.

**This will be cherry-picked to rc**

## Code changes

- **src/app/modules/vault-filter/components/organization-filter.component.html:** Change in-line plus buttons to "+ New Organization" rows in the organization filter
- **src/scss/vault-filters.scss:** Remove css that is no longer needed

## Screenshots
| Case      | Before | After | 
| ----------- | ----------- | ------------|
| New User (same)     |   ![Screen Shot 2022-05-17 at 1 23 17 PM](https://user-images.githubusercontent.com/8926729/170108901-60106281-95c3-4b2c-b382-cc86bbde27b6.png)  | ![Screen Shot 2022-05-24 at 3 19 33 PM](https://user-images.githubusercontent.com/8926729/170115395-df4a40c9-17fe-4017-b9ed-016c1471c35f.png) |
| Org Member **UPDATED**  |  ![Screen Shot 2022-05-24 at 3 04 04 PM](https://user-images.githubusercontent.com/8926729/170113010-07adaa6b-1cde-4be5-a6e2-d561b1604998.png) |  ![Screen Shot 2022-05-24 at 3 17 51 PM](https://user-images.githubusercontent.com/8926729/170115469-4522d39d-9898-4b2b-96ea-7061b780fa45.png) |
| Single Org Policy (same)   |  ![Screen Shot 2022-05-17 at 1 25 07 PM](https://user-images.githubusercontent.com/8926729/170109722-a79a15b7-992c-453c-b758-25dc9f85942f.png) | ![Screen Shot 2022-05-24 at 1 51 29 PM](https://user-images.githubusercontent.com/8926729/170109800-bedf9ca8-c6e8-4957-a84b-4b5ebd32a02a.png) |
| Personal Own. Policy  **UPDATED** | ![Screen Shot 2022-05-17 at 1 25 38 PM](https://user-images.githubusercontent.com/8926729/170109979-65ef2946-db8e-44af-a16a-29e81c6743f6.png) |  ![Screen Shot 2022-05-24 at 3 18 25 PM](https://user-images.githubusercontent.com/8926729/170115529-5de38096-21fc-46d3-ab98-ee021765b71e.png) |
| Single org && Personal Own. Policy (same)   |  ![Screen Shot 2022-05-17 at 1 26 00 PM](https://user-images.githubusercontent.com/8926729/170110307-911c9d29-5ef6-4353-9ec1-23b3be17cd98.png) |  ![Screen Shot 2022-05-24 at 1 52 14 PM](https://user-images.githubusercontent.com/8926729/170110326-4d621dfa-2011-491d-a178-249ebaad0969.png) |


## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
