### PR TITLE
Revert "[ps-136] Igonre accented characters in vault search"

### DIFF
--- a/src/app/modules/vault-filter/vault-filter.component.ts
+++ b/src/app/modules/vault-filter/vault-filter.component.ts
@@ -25,7 +25,7 @@ export class VaultFilterComponent extends BaseVaultFilterComponent {
   }
 
   searchTextChanged() {
-    this.onSearchTextChanged.emit(this.searchText.normalize("NFD").replace(/[\u0300-\u036f]/g, ""));
+    this.onSearchTextChanged.emit(this.searchText);
   }
 
   async initCollections() {

--- a/src/app/settings/billing-sync-key.component.ts
+++ b/src/app/settings/billing-sync-key.component.ts
@@ -3,6 +3,7 @@ import { Component } from "@angular/core";
 import { ApiService } from "jslib-common/abstractions/api.service";
 import { LogService } from "jslib-common/abstractions/log.service";
 import { OrganizationConnectionType } from "jslib-common/enums/organizationConnectionType";
+import { Utils } from "jslib-common/misc/utils";
 import { BillingSyncConfigApi } from "jslib-common/models/api/billingSyncConfigApi";
 import { BillingSyncConfigRequest } from "jslib-common/models/request/billingSyncConfigRequest";
 import { OrganizationConnectionRequest } from "jslib-common/models/request/organizationConnectionRequest";


### PR DESCRIPTION
Reverts bitwarden/web#1690. 

The logic to remove accents from `searchText` has been moved to the `search service` in https://github.com/bitwarden/jslib/pull/812. This PR is no longer needed. 