### PR TITLE
[PS-532] Text is presented as a heading but isn't marked up as a heading semantically

### DIFF
--- a/src/app/accounts/register.component.html
+++ b/src/app/accounts/register.component.html
@@ -101,7 +101,7 @@
       <div [ngClass]="{ 'col-5': layout, 'col-12': !layout }">
         <div class="row justify-content-md-center mt-5">
           <div [ngClass]="{ 'col-5': !layout, 'col-12': layout }">
-            <p class="lead text-center mb-4" *ngIf="!layout">{{ "createAccount" | i18n }}</p>
+            <h1 class="lead text-center mb-4" *ngIf="!layout">{{ "createAccount" | i18n }}</h1>
             <div class="card d-block">
               <div class="card-body">
                 <app-callout

--- a/src/app/send/access.component.html
+++ b/src/app/send/access.component.html
@@ -1,7 +1,7 @@
 <form #form (ngSubmit)="load()" [appApiAction]="formPromise" class="container" ngNativeValidate>
   <div class="row justify-content-center mt-5">
     <div class="col-12">
-      <p class="lead text-center mb-4">Bitwarden Send</p>
+      <h1 class="lead text-center mb-4">Bitwarden Send</h1>
     </div>
     <div class="col-12 text-center" *ngIf="creatorIdentifier != null">
       <p>{{ "sendCreatorIdentifier" | i18n: creatorIdentifier }}</p>


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Properly mark up page titles with the appropriate HTML heading tags. 

## Code changes
/src/app/accounts/register.component.html 
Swapped from `<p>` to `<h1>` HTML tag for the page title.

/src/app/send/access.component.html
Swapped from `<p>` to `<h1>` HTML tag for the page title.

## Screenshots
![image](https://user-images.githubusercontent.com/43214426/170353713-1e38b4bb-5bfc-4b84-a8a9-41589283ee04.png)

![image](https://user-images.githubusercontent.com/43214426/170354300-360c12e6-b48b-4f1b-8a46-858b7dba22a4.png)


## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
