### PR TITLE
[EC-241] Fix Manage SSO permissions

### DIFF
--- a/bitwarden_license/src/app/organizations/organizations-routing.module.ts
+++ b/bitwarden_license/src/app/organizations/organizations-routing.module.ts
@@ -22,14 +22,16 @@ const routes: Routes = [
         component: ManageComponent,
         canActivate: [PermissionsGuard],
         data: {
-          permissions: NavigationPermissionsService.getPermissions("manage").concat(
-            Permissions.ManageSso
-          ),
+          permissions: NavigationPermissionsService.getPermissions("manage"),
         },
         children: [
           {
             path: "sso",
             component: SsoComponent,
+            canActivate: [PermissionsGuard],
+            data: {
+              permissions: [Permissions.ManageSso],
+            },
           },
         ],
       },


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
The permissions for the Manage SSO page are too wide - any manager can access the vault URL (even though the page itself never loads because it’s blocked at the server side). This page should be limited to those where `organization.manageSso` is true, i.e. admins, owners, Manage SSO custom permission.

Note: you have to navigate directly to the URL to find this bug, the button is hidden correctly in the UI.

(This will not be picked to rc. Master only)

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Update permissions in the routing guards. The `Permissions` array only requires that 1 of those permissions is met for navigation to be permitted. So:
* keep the "manage" permissions on the parent `ManageComponent` (for consistency with `OssRoutingModule`)
* move `ManageSso` permission down to the `SsoComponent` itself, so that it's always required

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
