### PR TITLE
Adding missing code for Serbian Latin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -15,3 +15,4 @@ files:
         en-GB: en_GB
         en-IN: en_IN
         sr-CY: sr_CY
+        sr-CS: sr_CS


### PR DESCRIPTION
Crowdin was throwing an error because sr_CS was missing. Now Crowdin should pull Serbian (Cyrillic) and Serbian (Latin)

## Type of change

- [ X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other