### PR TITLE
[PS-779] Fix expanding/collapsing of nested collections

### DIFF
--- a/src/app/modules/vault-filter/components/collection-filter.component.html
+++ b/src/app/modules/vault-filter/components/collection-filter.component.html
@@ -31,7 +31,7 @@
           <button
             class="toggle-button"
             *ngIf="c.children.length"
-            (click)="collapse(c.node)"
+            (click)="toggleCollapse(c.node)"
             title="{{ 'toggleCollapse' | i18n }}"
             [attr.aria-expanded]="!isCollapsed(c.node)"
             [attr.aria-controls]="c.node.name + '_children'"


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Nested collections could not be expanded/collapsed in the left nav bar.

Closes #1721 

## Code changes
- **src/app/modules/vault-filter/components/collection-filter.component.html:** Replaced non-existant `collapse` method with `toggleCollapse()`

## Screenshots

![image](https://user-images.githubusercontent.com/2670567/171406061-a49741e4-7e94-4645-922c-5facccf6de8d.png)

![image](https://user-images.githubusercontent.com/2670567/171406128-ca441041-af6f-40aa-aa18-29e4197f0f10.png)


## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
  - This will be included in a hotfix for cloud
