### PR TITLE
Allow firefox relay service in generator

### DIFF
--- a/src/app/tools/generator.component.ts
+++ b/src/app/tools/generator.component.ts
@@ -40,11 +40,6 @@ export class GeneratorComponent extends BaseGeneratorComponent {
       route,
       window
     );
-    // Cannot use Firefox Relay on the web vault yet due to CORS issues with Firefox Relay API
-    this.forwardOptions.splice(
-      this.forwardOptions.findIndex((o) => o.value === "firefoxrelay"),
-      1
-    );
   }
 
   async history() {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective

Firefox Relay has whitelisted our web vault origin (vault.bitwarden.com) so we are adding back support for FF relay in the web vault.

## Code changes

- **generator component:** No longer remove firefox relay from forwarding service options.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [x] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
